### PR TITLE
chore(ci): gate main on CI and pin the on-disk object format

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,44 @@
+name: Bug report
+description: Something behaves differently from what it says it does
+labels: [bug]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened
+      description: Include the command and its output.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected instead
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: "`noidroid --version`, or the commit"
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - engine (record / replay / branch)
+        - store or object format
+        - CLI
+        - Python client
+        - browser adapter
+        - docs
+    validations:
+      required: true
+  - type: textarea
+    id: divergence
+    attributes:
+      label: If a replay or branch diverged, paste the divergence report
+      description: The `@n kind — detail` lines are usually the whole story.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security report
+    url: https://github.com/swalla02/noidroid/security/advisories/new
+    about: Report a vulnerability privately instead of opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,26 @@
+name: Proposal
+description: Something the project should be able to do
+labels: [proposal]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What can't you do today
+      description: Describe the situation, not the implementation.
+    validations:
+      required: true
+  - type: textarea
+    id: claim
+    attributes:
+      label: What claim would this let the project make
+      description: >
+        Paranoid Android's constraint is that it must not claim capabilities it does
+        not have. What would become true, and how would someone verify it?
+    validations:
+      required: true
+  - type: textarea
+    id: boundary
+    attributes:
+      label: Where would its knowledge stop
+      description: >
+        What would be real, what replayed, what simulated, and what unknown?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+## What this changes
+
+<!-- One or two sentences. The diff says what; say why. -->
+
+## How it was verified
+
+<!-- Commands you ran and what they printed. "Tests pass" is not evidence; the output
+     is. If you added an invariant, name the test that would fail without it. -->
+
+## Checklist
+
+- [ ] `cargo test --all` passes (browser tests skip cleanly without Chromium)
+- [ ] `cargo fmt --all --check` and `cargo clippy --all-targets -- -D warnings` pass
+- [ ] `CHANGELOG.md` updated under `Unreleased`, if this is user-visible
+- [ ] If the on-disk object format changed: `STEP_VERSION` decision made deliberately
+      and recorded in the changelog (see CONTRIBUTING.md → Versioning)
+- [ ] No capability is claimed that is not actually there; anything simulated says so

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      # The core has three dependencies; reviewing them one PR at a time is noise.
+      cargo:
+        patterns: ["*"]
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,12 +42,12 @@ jobs:
           python -m pip install playwright
           python -m playwright install --with-deps chromium
       - name: Run every test, including the ones that drive a real browser
-        run: cargo test --all --verbose
+        run: cargo test --all --verbose -- --nocapture 2>&1 | tee test-output.txt
       - name: Fail if the browser tests silently skipped
         # The browser tests pass when Chromium is missing, by design. On this job it
         # is present, so a skip here would mean the suite is quietly not running.
         run: |
-          if cargo test --all 2>&1 | grep -q "SKIP: browser adapter test"; then
+          if grep -q "SKIP: browser adapter test" test-output.txt; then
             echo "::error::browser tests skipped on the job that installs a browser"
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,111 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+# A newer push to the same branch makes the older run irrelevant.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -D warnings
+
+jobs:
+  lint:
+    name: fmt + clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install toolchain
+        run: rustup component add rustfmt clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo fmt --all --check
+      - run: cargo clippy --all-targets --all-features -- -D warnings
+
+  test:
+    name: tests (with browser)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install Playwright and Chromium
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install playwright
+          python -m playwright install --with-deps chromium
+      - name: Run every test, including the ones that drive a real browser
+        run: cargo test --all --verbose
+      - name: Fail if the browser tests silently skipped
+        # The browser tests pass when Chromium is missing, by design. On this job it
+        # is present, so a skip here would mean the suite is quietly not running.
+        run: |
+          if cargo test --all 2>&1 | grep -q "SKIP: browser adapter test"; then
+            echo "::error::browser tests skipped on the job that installs a browser"
+            exit 1
+          fi
+
+  test-without-browser:
+    name: tests (no browser installed)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      # No Playwright on purpose: the browser tests must skip cleanly rather than
+      # fail, so that contributors without Chromium can still run the suite.
+      - run: cargo test --all
+
+  test-macos:
+    name: tests (macOS)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      # The engine talks to clients over Unix sockets and spawns real child
+      # processes; this job is what backs the claim that it works beyond Linux.
+      - run: cargo test --all
+
+  example:
+    name: the example actually runs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: cargo build --release
+      - name: Record, replay, branch, and check the invariants from the CLI
+        run: |
+          set -euo pipefail
+          export PATH="$PWD/target/release:$PATH"
+          export PYTHONPATH="$PWD/clients/python"
+          export NO_COLOR=1
+
+          noidroid run -- python3 examples/flight_agent/agent.py
+          noidroid replay run-1 | tee replay.txt
+          grep -q "faithful:" replay.txt
+
+          before=$(python3 -c "import json;print(json.load(open('.noidroid/trajectories/run-1.json'))['head'])")
+          noidroid branch run-1@2 --decide pick_flight=FL-203 \
+            --simulate 'payments.charge={"ok":true}' | tee branch.txt
+          grep -q "shared with run-1" branch.txt
+
+          after=$(python3 -c "import json;print(json.load(open('.noidroid/trajectories/run-1.json'))['head'])")
+          test "$before" = "$after" || { echo "branching mutated its parent"; exit 1; }
+
+          noidroid verify | tee verify.txt
+          grep -q "intact:" verify.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,99 @@
+name: Release
+
+# Tags are the release trigger: nothing is published except from an annotated
+# `vX.Y.Z` tag on a commit that already passed CI on main.
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  verify:
+    name: gate the tag on the full suite
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install Playwright and Chromium
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install playwright
+          python -m playwright install --with-deps chromium
+      - run: cargo test --all
+      - name: The tag must match the version in Cargo.toml
+        run: |
+          set -euo pipefail
+          declared=$(grep -m1 '^version' Cargo.toml | cut -d'"' -f2)
+          tagged="${GITHUB_REF_NAME#v}"
+          if [ "$declared" != "$tagged" ]; then
+            echo "::error::tag $GITHUB_REF_NAME does not match Cargo.toml version $declared"
+            exit 1
+          fi
+
+  build:
+    name: ${{ matrix.target }}
+    needs: verify
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: macos-latest
+            target: aarch64-apple-darwin
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - run: rustup target add ${{ matrix.target }}
+      - run: cargo build --release --target ${{ matrix.target }} -p noidroid-cli
+      - name: Package
+        run: |
+          set -euo pipefail
+          name="noidroid-${GITHUB_REF_NAME}-${{ matrix.target }}"
+          mkdir -p "dist/$name"
+          cp "target/${{ matrix.target }}/release/noidroid" "dist/$name/"
+          cp README.md LICENSE manifesto.md "dist/$name/"
+          tar -C dist -czf "dist/$name.tar.gz" "$name"
+          shasum -a 256 "dist/$name.tar.gz" > "dist/$name.tar.gz.sha256"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.target }}
+          path: dist/*.tar.gz*
+
+  publish:
+    name: publish the release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+      - name: Extract this version's changelog section
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          awk -v v="$version" '
+            $0 ~ "^## \\[" v "\\]" { found = 1; next }
+            found && /^## \[/ { exit }
+            found { print }
+          ' CHANGELOG.md > notes.md
+          if [ ! -s notes.md ]; then
+            echo "::error::CHANGELOG.md has no section for $version"
+            exit 1
+          fi
+      - env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --title "Paranoid Android $GITHUB_REF_NAME" \
+            --notes-file notes.md \
+            dist/*.tar.gz dist/*.sha256

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,6 @@ how the package version relates to `STEP_VERSION`, the on-disk object format.
 
 ## [Unreleased]
 
-### Added
-
-- Continuous integration: fmt, clippy (`-D warnings`), the full suite on Linux with a
-  browser, the suite without a browser (the browser tests must skip cleanly), the
-  suite on macOS, and the CLI example end to end.
-- A release workflow triggered by `v*` tags, which refuses a tag that disagrees with
-  `Cargo.toml` or has no changelog section, and publishes Linux and macOS binaries.
-- `format_is_pinned`: a test asserting the exact serialised bytes and digest of a
-  known step, so a change to the on-disk format cannot pass unnoticed.
-- `CONTRIBUTING.md`, `SECURITY.md`, issue and pull-request templates, Dependabot, and
-  a pinned toolchain.
-
 ## [0.1.0] - 2026-08-18
 
 First working prototype: an execution can be recorded, returned to, and branched.
@@ -47,7 +35,18 @@ First working prototype: an execution can be recorded, returned to, and branched
   Chromium, records HTTP responses, and reconstructs a browser session by re-driving
   recorded actions — verified against a recorded page digest, and demonstrated with
   the website switched off.
-- Two worked examples and 23 tests, two of which drive real Chromium.
+- Two worked examples and 24 tests, two of which drive real Chromium.
+- **Engineering practice.** Continuous integration on every pull request: fmt, clippy
+  (`-D warnings`), the full suite on Linux with a browser, the suite *without* a
+  browser (the browser tests must skip cleanly, or contributors cannot run the suite),
+  the suite on macOS because the Unix-socket transport is a portability claim, and the
+  CLI example end to end including a check that branching did not move its parent's
+  head. Releases come from `v*` tags only, and are refused if the tag disagrees with
+  `Cargo.toml` or has no changelog section.
+- `format_is_pinned`, which asserts the exact serialised bytes and address of a known
+  step. Object names *are* the hash of their bytes, so a silent format change would
+  invalidate every recording ever made; see [CONTRIBUTING.md](CONTRIBUTING.md) for when
+  a change needs a `STEP_VERSION` bump.
 
 ### Known limitations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,60 @@
+# Changelog
+
+All notable changes to this project are documented here, following
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/). This project uses
+[semantic versioning](https://semver.org/); see [CONTRIBUTING.md](CONTRIBUTING.md) for
+how the package version relates to `STEP_VERSION`, the on-disk object format.
+
+## [Unreleased]
+
+### Added
+
+- Continuous integration: fmt, clippy (`-D warnings`), the full suite on Linux with a
+  browser, the suite without a browser (the browser tests must skip cleanly), the
+  suite on macOS, and the CLI example end to end.
+- A release workflow triggered by `v*` tags, which refuses a tag that disagrees with
+  `Cargo.toml` or has no changelog section, and publishes Linux and macOS binaries.
+- `format_is_pinned`: a test asserting the exact serialised bytes and digest of a
+  known step, so a change to the on-disk format cannot pass unnoticed.
+- `CONTRIBUTING.md`, `SECURITY.md`, issue and pull-request templates, Dependabot, and
+  a pinned toolchain.
+
+## [0.1.0] - 2026-08-18
+
+First working prototype: an execution can be recorded, returned to, and branched.
+
+### Added
+
+- **Trajectory engine.** An execution records as an immutable, content-addressed
+  Merkle DAG of steps — `(parent, action, effects, state_root, provenance)`. A branch
+  is a step whose parent belongs to another trajectory, so immutable history, prefix
+  sharing and copy-on-write follow from the data model rather than being layered on.
+- **Verified reconstruction.** `noidroid replay` re-derives a trajectory and checks it
+  addresses the same objects, reporting `key_mismatch`, `state_mismatch`,
+  `unexpected_call` or `truncated` instead of papering over a divergence.
+- **Branching with typed interventions:** `--decide` (choose differently at a declared
+  decision point), `--result` (answer differently from the world), `--fail` (inject a
+  failure), `--simulate` (supply a stated-simulated value for an irreversible effect).
+- **Provenance and delivery as separate axes.** Provenance — `real` ⊑ `live` ⊑
+  `simulated` ⊑ `unknown` — is content, is hashed, and never improves along a chain.
+  Delivery — `executed`, `replayed`, `intervened`, `denied` — is per-run and is not
+  hashed, which is what lets a branch share its parent's objects exactly.
+- **Irreversible effects fail safe.** Performed only during an original recording;
+  every replay and branch refuses them unless a simulated value is supplied.
+- **CLI:** `run`, `log`, `show`, `replay`, `branch`, `checkout`, `tree`, `diff`,
+  `verify`.
+- **Python client** (standard library only) and a **browser adapter** that drives
+  Chromium, records HTTP responses, and reconstructs a browser session by re-driving
+  recorded actions — verified against a recorded page digest, and demonstrated with
+  the website switched off.
+- Two worked examples and 23 tests, two of which drive real Chromium.
+
+### Known limitations
+
+Documented in the README, and deliberate: not zero-code, sequential programs only,
+only the sandboxed workspace is captured, the ambient environment is not captured, a
+branch is not a prediction, browser reconstruction is bounded by the recorded page
+set, and no scale work.
+
+[Unreleased]: https://github.com/swalla02/noidroid/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/swalla02/noidroid/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,117 @@
+# Contributing
+
+Paranoid Android is young enough that the interesting conventions are about *what we
+promise*, not about style. Style is enforced by CI; the rest is below.
+
+## The loop
+
+```bash
+git switch -c feat/short-description        # or fix/, chore/, docs/, refactor/
+cargo test --all                            # 23 tests; browser ones skip without Chromium
+cargo fmt --all && cargo clippy --all-targets -- -D warnings
+git commit                                  # Conventional Commits, see below
+gh pr create --fill
+```
+
+`main` is protected: it takes merges through pull requests, and CI has to be green.
+Nobody pushes to it directly, including maintainers.
+
+### Branches
+
+`<type>/<short-description>`, where type is one of `feat`, `fix`, `chore`, `docs`,
+`refactor`, `test`, `perf`. Keep a branch to one change; two changes are two PRs.
+
+### Commits
+
+[Conventional Commits](https://www.conventionalcommits.org/), with the scope naming
+the area: `feat(browser)`, `fix(engine)`, `docs(readme)`. The body should say *why*,
+because the diff already says what. Breaking changes get a `!` and a
+`BREAKING CHANGE:` footer.
+
+### Pull requests
+
+CI runs fmt, clippy (`-D warnings`), the full suite on Linux with a browser, the suite
+without a browser (the browser tests must skip cleanly, not fail), the suite on macOS,
+and the CLI example end to end. All of it has to pass.
+
+## Testing
+
+```bash
+cargo test --all                                  # everything
+cargo test --test vertical_slice                  # the core invariants
+cargo test --test browser_slice                   # real Chromium; skips if absent
+pip install playwright && playwright install chromium
+```
+
+The tests that matter drive real child processes over the real protocol, because the
+claims worth testing — *a replay cannot touch the world*, *a branch cannot mutate its
+parent* — are claims about what happens between processes. A test that mocks the
+protocol proves nothing about them.
+
+If you add an invariant, add a test that would fail without it, and name the test
+after the invariant rather than after the function.
+
+## Versioning
+
+Two version numbers matter, and they are not the same thing.
+
+### 1. The package version (semver)
+
+`Cargo.toml` and `clients/python/pyproject.toml` carry the same version. Pre-1.0, a
+minor bump may break APIs; we say so in the changelog.
+
+Releases are cut from tags:
+
+```bash
+# on main, with CI green
+$EDITOR CHANGELOG.md            # move Unreleased into a new version section
+$EDITOR Cargo.toml clients/python/pyproject.toml
+git commit -m "chore(release): 0.2.0"
+git tag -a v0.2.0 -m "Paranoid Android 0.2.0"
+git push origin main v0.2.0     # the tag triggers the release workflow
+```
+
+The release workflow refuses a tag whose version disagrees with `Cargo.toml`, or that
+has no changelog section.
+
+### 2. `STEP_VERSION` — the on-disk object format
+
+This is the one that needs care. Trajectories are content-addressed: an object's name
+*is* the hash of its bytes. So a change to how an object serialises changes every
+address derived from it, which means:
+
+> **A format change silently invalidates every recording anyone has ever made.**
+> A replay of an older trajectory would re-derive different hashes and be reported as
+> divergent, with nothing to indicate that the tool changed rather than the program.
+
+Rules:
+
+- **Byte-compatible additions do not bump the version.** A new field that is `default`
+  on read and `skip_serializing_if` on write, so that existing objects serialise to
+  exactly the bytes they already have, is safe. `Effect::outcome` was added this way.
+- **Anything else bumps `STEP_VERSION`** and needs a note in the changelog saying that
+  old trajectories cannot be replayed by this version.
+- `format_is_pinned` in `crates/noidroid-core/src/model.rs` asserts the exact
+  serialised bytes and digest of a known step. If your change fails it, that is the
+  test doing its job: decide deliberately which of the two rules above applies, then
+  update the fixture in the same commit as the version bump.
+
+Timing, host, pid and per-run delivery deliberately live *outside* hashed content. If
+you are tempted to put something run-specific into a hashed object, that is what
+`notes/` is for.
+
+## The bar for a change
+
+Two things get refused regardless of how well they are written:
+
+1. **A capability we do not have.** If something is simulated, say so in the output.
+   If something cannot be reconstructed, make the boundary explicit. Fidelity theatre
+   — a percentage that is not a real measurement, a fuzzy comparison presented as
+   verification — is the one failure mode this project cannot survive.
+2. **Speculative infrastructure.** A dashboard, a plugin system, an adapter for an
+   environment nobody has recorded yet. Build the thing that proves the next claim.
+
+## Reporting problems
+
+Bugs and design discussion go to GitHub Issues. Security reports go to
+[SECURITY.md](SECURITY.md) instead.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ promise*, not about style. Style is enforced by CI; the rest is below.
 
 ```bash
 git switch -c feat/short-description        # or fix/, chore/, docs/, refactor/
-cargo test --all                            # 23 tests; browser ones skip without Chromium
+cargo test --all                            # 24 tests; browser ones skip without Chromium
 cargo fmt --all && cargo clippy --all-targets -- -D warnings
 git commit                                  # Conventional Commits, see below
 gh pr create --fill

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ and anything resembling a universal simulator.
 ## Development
 
 ```bash
-cargo test                      # 23 tests: unit, end-to-end, and real-browser
+cargo test --all                # 24 tests: unit, end-to-end, and real-browser
 cargo clippy --all-targets
 
 # the browser tests need Chromium; they print SKIP and pass without it
@@ -323,6 +323,10 @@ pip install playwright && playwright install chromium
 The end-to-end tests drive a real Python child process through the real protocol,
 because the claims worth testing — *a replay cannot touch the world*, *a branch cannot
 mutate its parent* — are claims about what happens between processes.
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the branch and release workflow, and for the
+rules about `STEP_VERSION` — the on-disk object format is a compatibility surface,
+because an object's name *is* the hash of its bytes.
 
 ```
 crates/noidroid-core/   objects, store, workspace trees, the record/replay/branch engine

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# Security
+
+## Reporting a vulnerability
+
+Please use GitHub's [private vulnerability
+reporting](https://github.com/swalla02/noidroid/security/advisories/new) rather than a
+public issue. Include what you did, what happened, and what you expected. Expect an
+acknowledgement within a week.
+
+## What is in scope
+
+Paranoid Android runs other people's programs and stores what they did, so the
+security-relevant surface is mostly about containment and integrity:
+
+- **An effect firing when it should not.** A replay must never perform a mediated
+  interaction, and an effect declared `irreversible` must never be performed outside
+  an original recording. A way to make either happen is a vulnerability, not a bug.
+- **A branch reaching outside its own workspace**, or altering its parent's objects.
+- **A recorded trajectory being altered without detection.** `noidroid verify` should
+  catch any object whose bytes no longer match its name.
+- **A recording leaking secrets in a surprising place.** Recordings deliberately
+  contain everything an execution saw: tool responses, HTTP bodies, file contents,
+  screenshots. That is the point, and `.noidroid/` should be treated as sensitive.
+  But a path that copies that data somewhere the operator would not expect is in
+  scope.
+
+## What is not in scope
+
+- A recorded trajectory containing secrets that the recorded program handled. Treat
+  `.noidroid/` as you would treat a heap dump.
+- Running an untrusted program under `noidroid run`. The engine does not sandbox the
+  program it records; the workspace is for reproducibility, not isolation.
+- The browser adapter reaching the network when explicitly allowed to.

--- a/crates/noidroid-core/src/model.rs
+++ b/crates/noidroid-core/src/model.rs
@@ -356,6 +356,71 @@ pub struct StepNote {
 mod tests {
     use super::*;
 
+    /// Pins the exact bytes and address of a known step.
+    ///
+    /// Object names *are* the hash of their bytes, so a change to how a step
+    /// serialises silently invalidates every recording anyone has made: replaying an
+    /// older trajectory would re-derive different hashes and be reported as divergent,
+    /// with nothing to say that the tool changed rather than the program.
+    ///
+    /// If this test fails, that is it doing its job. Decide deliberately:
+    ///   * a field that is `default` on read and skipped on write when absent leaves
+    ///     these bytes unchanged, and needs no version bump;
+    ///   * anything else bumps `STEP_VERSION`, updates this fixture in the same
+    ///     commit, and says in the changelog that old trajectories cannot be replayed.
+    #[test]
+    fn format_is_pinned() {
+        let step = Step::new(
+            Some(Digest::from_hex(
+                "1111111111111111111111111111111111111111111111111111111111111111",
+            )),
+            3,
+            Action::Call {
+                target: "flights.seatmap".into(),
+                args: serde_json::json!({ "flight": "FL-101" }),
+                effect: EffectKind::Read,
+            },
+            vec![Effect {
+                key: "3:read:flights.seatmap".into(),
+                value: Digest::from_hex(
+                    "2222222222222222222222222222222222222222222222222222222222222222",
+                ),
+                effect: EffectKind::Read,
+                provenance: Provenance::Real,
+                outcome: EffectOutcome::Value,
+            }],
+            Digest::from_hex("3333333333333333333333333333333333333333333333333333333333333333"),
+            Provenance::Real,
+            Provenance::Real,
+            None,
+        );
+
+        let encoded = serde_json::to_string(&step).expect("a step serialises");
+        assert_eq!(
+            encoded,
+            concat!(
+                r#"{"type":"step","v":1,"#,
+                r#""parent":"1111111111111111111111111111111111111111111111111111111111111111","#,
+                r#""index":3,"#,
+                r#""action":{"kind":"call","target":"flights.seatmap","args":{"flight":"FL-101"},"effect":"read"},"#,
+                r#""effects":[{"key":"3:read:flights.seatmap","#,
+                r#""value":"2222222222222222222222222222222222222222222222222222222222222222","#,
+                r#""effect":"read","provenance":"real"}],"#,
+                r#""state_root":"3333333333333333333333333333333333333333333333333333333333333333","#,
+                r#""provenance":"real","intervention":null}"#,
+            ),
+            "the on-disk step format changed; see the doc comment on this test"
+        );
+
+        // The address every existing recording's step 3 would be filed under.
+        assert_eq!(
+            Digest::of(encoded.as_bytes()).as_str(),
+            "7bd933a35d2bc7efabf81ce857556d94107edeac200a782dacb254648a4d750b",
+            "the address derived from a step changed; see the doc comment on this test"
+        );
+        assert_eq!(STEP_VERSION, 1, "STEP_VERSION moved without this fixture");
+    }
+
     #[test]
     fn provenance_join_is_monotone_and_conservative() {
         assert_eq!(Provenance::Real.join(Provenance::Real), Provenance::Real);

--- a/docs/technical-proposal.md
+++ b/docs/technical-proposal.md
@@ -514,7 +514,7 @@ build the products the trajectory graph makes possible.
 
 What follows is what exists and has been run, as opposed to what is planned above.
 
-**Built and verified** (23 tests: 10 unit, 11 end-to-end through a real subprocess, 2 driving real Chromium):
+**Built and verified** (24 tests: 11 unit, 11 end-to-end through a real subprocess, 2 driving real Chromium):
 
 | Claim | How it is checked |
 |---|---|
@@ -528,6 +528,7 @@ What follows is what exists and has been run, as opposed to what is planned abov
 | A changed program is reported, not papered over | `a_changed_program_is_reported_rather_than_papered_over` (key mismatch) and `an_unmediated_state_change_is_detected` (state mismatch) |
 | A branch is itself a trajectory | `a_branch_is_itself_a_trajectory_that_can_be_replayed` |
 | A replay is bounded by its recording | `an_injected_failure_stops_the_run_and_stays_stopped_on_replay` — found a real bug: a replay that outlived its recording used to start executing calls for real |
+| The on-disk object format cannot change unnoticed | `format_is_pinned` — asserts the exact serialised bytes and address of a known step, because an object's name *is* the hash of its bytes, so a silent format change would invalidate every recording ever made |
 
 **Deviations from the plan above**, all discovered while building:
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+# Pinned so that `cargo fmt` and `cargo clippy` behave the same for contributors as
+# they do in CI. The minimum supported version is `rust-version` in Cargo.toml.
+[toolchain]
+channel = "stable"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Sets up the workflow the project should have had from the first commit, before
there is enough history for the absence to hurt.

CI runs on every pull request: fmt, clippy with -D warnings, the full suite on
Linux with Chromium installed, the suite *without* Chromium (the browser tests must
skip cleanly, not fail, or contributors cannot run the suite), the suite on macOS
because the engine's Unix-socket transport is a portability claim, and the CLI
example end to end — including a check that branching did not move its parent's
head, which is the invariant a reader is most likely to doubt.

The Linux job also fails if the browser tests report a skip, so the suite cannot
quietly stop running on the one machine that can run it.

Releases come from `v*` tags only, and the workflow refuses a tag that disagrees
with Cargo.toml or has no changelog section.

The substantive addition is `format_is_pinned`. Object names are the hash of their
bytes, so changing how a step serialises silently invalidates every recording
anyone has made: replaying an older trajectory would re-derive different hashes and
be reported as divergent, with nothing to indicate the tool changed rather than the
program. The test asserts the exact bytes and address of a known step, so that
change cannot happen by accident, and CONTRIBUTING.md sets out when it needs a
STEP_VERSION bump and when a byte-compatible addition does not.

Also adds CONTRIBUTING, CHANGELOG, SECURITY, issue and PR templates, Dependabot,
and a pinned toolchain so fmt and clippy agree with CI.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
