### PR TITLE
fix(browser): an unreproducible page makes everything after it unknown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ how the package version relates to `STEP_VERSION`, the on-disk object format.
 
 ## [Unreleased]
 
+### Fixed
+
+- A browser branch whose starting state could not be reproduced said so in the
+  terminal but recorded its observations as `live`, i.e. as things that really
+  happened. An unreproducible reconstruction now marks everything after it `unknown`,
+  which propagates to the head of the trajectory.
+
+### Added
+
+- `noidroid.Ungrounded`: a wrapper an adapter returns to say "here is a real value,
+  but it is not evidence about the original execution". The protocol gained `unknown`
+  on a result to carry it, which — like `unknown` on an error — is the only kind of
+  provenance claim a client may make, because it can only lose trust.
+- `Browser(strict=True)` refuses to continue from a state it could not reproduce,
+  instead of continuing and marking it unknown. Off by default: a page digest is an
+  exact comparison and real pages carry clocks, so a fatal default would refuse most
+  real branches.
+- A `/volatile` page in the example site whose rendered text comes from the clock, so
+  the boundary can be demonstrated rather than described.
+
 ## [0.1.0] - 2026-08-18
 
 First working prototype: an execution can be recorded, returned to, and branched.

--- a/README.md
+++ b/README.md
@@ -285,6 +285,10 @@ cannot be vague about its own boundaries.
 - **A `--result` intervention on a browser observation desynchronises belief from
   page.** The agent is told something the page does not say; everything after is
   `simulated`.
+- **A page that cannot be reproduced is reported, not refused.** Page digests are
+  exact, and real pages carry clocks and session tokens, so a branch whose
+  reconstruction did not match carries on with everything after it marked `unknown`.
+  `Browser(strict=True)` turns that into a refusal instead.
 - **A replay reproduces that a call failed and with what message, not the original
   exception type.** A program that branches on exception class rather than on the
   failure itself will be reported as divergent.
@@ -313,7 +317,7 @@ and anything resembling a universal simulator.
 ## Development
 
 ```bash
-cargo test --all                # 24 tests: unit, end-to-end, and real-browser
+cargo test --all                # 25 tests: unit, end-to-end, and real-browser
 cargo clippy --all-targets
 
 # the browser tests need Chromium; they print SKIP and pass without it

--- a/clients/python/noidroid/__init__.py
+++ b/clients/python/noidroid/__init__.py
@@ -48,6 +48,7 @@ __all__ = [
     "Divergence",
     "InjectedFailure",
     "Unavailable",
+    "Ungrounded",
     "READ",
     "WRITE",
     "IRREVERSIBLE",
@@ -78,6 +79,24 @@ class Divergence(NoidroidError):
 
 class InjectedFailure(NoidroidError):
     """A branch deliberately made this interaction fail."""
+
+
+class Ungrounded:
+    """Wraps a value that is real enough to use but not grounded in the recording.
+
+    Return this from a ``call``'s ``run`` when you produced a genuine value against an
+    environment you could not put back into its recorded state -- a browser whose page
+    did not come back the way the recording says it looked, say. The step is then
+    marked ``unknown``, which propagates to everything downstream, instead of claiming
+    to be evidence about the original execution.
+
+    The caller still receives the plain value; only its provenance changes.
+    """
+
+    __slots__ = ("value",)
+
+    def __init__(self, value):
+        self.value = value
 
 
 class Unavailable(NoidroidError):
@@ -159,7 +178,10 @@ class Session:
                     }
                 )
                 raise
-            self._rpc({"op": "result", "value": value})
+            ungrounded = isinstance(value, Ungrounded)
+            if ungrounded:
+                value = value.value
+            self._rpc({"op": "result", "value": value, "unknown": ungrounded})
             return value
         if directive == "use":
             return response.get("value")

--- a/clients/python/noidroid/browser.py
+++ b/clients/python/noidroid/browser.py
@@ -39,7 +39,7 @@ import os
 from pathlib import Path
 from typing import Any, Iterable, Optional
 
-from . import WRITE, Unavailable
+from . import WRITE, Unavailable, Ungrounded
 
 __all__ = ["Browser", "BrowserUnavailable"]
 
@@ -77,6 +77,7 @@ class Browser:
         allow_network: Optional[bool] = None,
         root: str = "browser",
         channel: Optional[str] = None,
+        strict: bool = False,
     ) -> None:
         self._nd = session
         self._headless = headless
@@ -102,6 +103,13 @@ class Browser:
         self._context = None
         self._page = None
 
+        # A page digest is an exact comparison, and real pages carry clocks, ads and
+        # session tokens. Making a mismatch fatal by default would refuse most real
+        # branches; making it invisible would be dishonest. So the default is to carry
+        # on with everything downstream marked `unknown`, and `strict=True` is there
+        # for anyone who wants the gate -- regression testing, say.
+        self._strict = strict
+        self._ungrounded = False
         self._reconstruction: Optional[dict] = None
         self._served = {"replayed": 0, "live": 0, "blocked": 0}
         self._blocked: list[str] = []
@@ -168,6 +176,10 @@ class Browser:
             observation["reconstruction"] = self._reconstruction
             self._reconstruction = None
         self._append_action(target, args, observation)
+        if self._ungrounded:
+            # The browser was never put back into the recorded state, so nothing it
+            # tells us from here on is evidence about the original execution.
+            return Ungrounded(observation)
         return observation
 
     def _reconstruction_note(self) -> str:
@@ -259,12 +271,15 @@ class Browser:
         )
         if actual == expected:
             print(f"[noidroid.browser] {note}; page state verified")
-        else:
-            print(
-                f"[noidroid.browser] {note}; PAGE STATE DID NOT MATCH "
-                f"(recorded {expected}, got {actual}) — this branch starts from a "
-                f"state that could not be reproduced"
-            )
+            return
+        detail = (
+            f"page state did not match (recorded {expected}, got {actual}); this "
+            f"branch starts from a state that could not be reproduced"
+        )
+        if self._strict:
+            raise Unavailable(f"{note}; {detail}")
+        self._ungrounded = True
+        print(f"[noidroid.browser] {note}; {detail} — everything from here is unknown")
 
     def _recorded_actions(self) -> list[dict]:
         if not self._actions_path.exists():

--- a/crates/noidroid-core/src/engine.rs
+++ b/crates/noidroid-core/src/engine.rs
@@ -367,7 +367,14 @@ impl<'a> Session<'a> {
                 options,
                 choice,
             } => self.on_decide(name, options, choice),
-            Request::CallResult { value } => self.on_result(value),
+            Request::CallResult { value, unknown } => {
+                if unknown {
+                    if let Some(pending) = self.pending.as_mut() {
+                        pending.provenance = Provenance::Unknown;
+                    }
+                }
+                self.on_result(value)
+            }
             Request::CallError {
                 message,
                 kind,
@@ -795,8 +802,13 @@ impl<'a> Session<'a> {
                 .unwrap_or("the recording says this did not return")
                 .to_string()
         };
+        let provenance = recorded
+            .effects
+            .first()
+            .map(|e| e.provenance)
+            .unwrap_or(Provenance::Real);
         match outcome {
-            EffectOutcome::Value => Response::use_value(value, "real", "replayed"),
+            EffectOutcome::Value => Response::use_value(value, provenance.label(), "replayed"),
             EffectOutcome::Error => Response::fail("failed", message()),
             EffectOutcome::Unavailable => Response::fail("unavailable", message()),
             EffectOutcome::Denied => Response::deny(message()),

--- a/crates/noidroid-core/src/proto.rs
+++ b/crates/noidroid-core/src/proto.rs
@@ -31,8 +31,17 @@ pub enum Request {
         effect: EffectKind,
     },
     /// The value produced by an interaction the engine told us to execute.
+    ///
+    /// `unknown` means the client is handing back a value while telling us it is not
+    /// grounded in the recording -- an adapter that could not put its environment back
+    /// into the recorded state, say. The value is still useful; it is just not evidence
+    /// about the original execution.
     #[serde(rename = "result")]
-    CallResult { value: Value },
+    CallResult {
+        value: Value,
+        #[serde(default)]
+        unknown: bool,
+    },
     /// The interaction the engine told us to execute raised. `unknown` means the
     /// client could not obtain the information at all -- the only provenance claim a
     /// client may make, because it is the one that can only lose trust, never gain it.

--- a/crates/noidroid-core/tests/browser_slice.rs
+++ b/crates/noidroid-core/tests/browser_slice.rs
@@ -47,6 +47,26 @@ fn browser_available() -> bool {
         .unwrap_or(false)
 }
 
+/// An agent that looks at a page which cannot be reproduced, then makes a decision.
+/// Branching on that decision forces the adapter to re-drive a page whose rendered
+/// text came from the clock, so reconstruction is guaranteed to fail.
+const VOLATILE_AGENT: &str = r##"
+import os
+import noidroid
+from noidroid.browser import Browser
+
+nd = noidroid.connect()
+browser = Browser(nd)
+site = os.environ["FLIGHT_SITE"]
+try:
+    browser.goto(site + "/volatile", wait_for="#stamp")
+    choice = browser.decide("pick", options=["a", "b"], choice="a")
+    seen = browser.read()
+    nd.finish("done", {"chose": choice, "url": seen["url"]})
+finally:
+    browser.close()
+"##;
+
 struct Site {
     child: Child,
     port: u16,
@@ -183,6 +203,13 @@ impl Fixture {
             .expect("replay should run to completion")
     }
 
+    /// Point the fixture at an agent written from the test rather than an example.
+    fn spec_for(&self, agent: &std::path::Path, name: &str, allow_network: bool) -> RunSpec {
+        let mut spec = self.spec(name, allow_network);
+        spec.command = vec!["python3".into(), agent.display().to_string()];
+        spec
+    }
+
     /// Index of the declared decision, so the test does not hard-code a step number.
     fn decision_step(&self, t: &Trajectory) -> u64 {
         self.repo
@@ -306,6 +333,77 @@ fn a_browser_branch_can_reach_a_different_outcome() {
     // The parent is untouched by any of it.
     let parent_after = f.repo.load_trajectory("web-1").unwrap();
     assert_eq!(parent_after, recorded);
+
+    site.stop();
+}
+
+#[test]
+fn a_page_that_cannot_be_reproduced_makes_everything_after_it_unknown() {
+    if !browser_available() {
+        eprintln!("SKIP: browser adapter test needs playwright and chromium");
+        return;
+    }
+
+    let f = Fixture::new(8714);
+    let site = Site::start(&f.root, f.port);
+    let agent = f.dir.join("volatile_agent.py");
+    fs::write(&agent, VOLATILE_AGENT).unwrap();
+
+    let recorded = engine::run(
+        &f.repo,
+        &f.spec_for(&agent, "web-1", true),
+        Mode::Record,
+        None,
+    )
+    .expect("recording should succeed")
+    .trajectory
+    .unwrap();
+    let at = f.decision_step(&recorded);
+
+    // Everything in the original run was observed for real.
+    for (_, step) in f.repo.chain(&recorded).unwrap() {
+        assert_eq!(step.provenance, Provenance::Real, "step {}", step.index);
+    }
+
+    let branch = engine::run(
+        &f.repo,
+        &f.spec_for(&agent, "web-alt", true),
+        Mode::Branch {
+            at,
+            intervention: Intervention::ReplaceDecision {
+                name: "pick".into(),
+                value: serde_json::json!("b"),
+            },
+            simulate: BTreeMap::new(),
+        },
+        Some(&recorded),
+    )
+    .expect("the branch should run to completion")
+    .trajectory
+    .expect("the branch should produce a trajectory");
+
+    // The adapter could not put the page back the way the recording says it looked.
+    // That has to end up in the trajectory, not only in the terminal: the observation
+    // it hands back is a real value, but it is not evidence about the original run.
+    let chain = f.repo.chain(&branch).unwrap();
+    let after_divergence: Vec<_> = chain.iter().filter(|(_, s)| s.index > at).collect();
+    assert!(
+        !after_divergence.is_empty(),
+        "the branch went past the divergence"
+    );
+    let ungrounded = after_divergence
+        .iter()
+        .flat_map(|(_, s)| s.effects.iter())
+        .any(|e| e.provenance == Provenance::Unknown);
+    assert!(
+        ungrounded,
+        "an unreproducible starting state must mark its values unknown, not just warn"
+    );
+    assert_eq!(
+        chain.last().unwrap().1.provenance,
+        Provenance::Unknown,
+        "unknown propagates to the head, because provenance never improves downstream"
+    );
 
     site.stop();
 }

--- a/examples/browser_agent/site.py
+++ b/examples/browser_agent/site.py
@@ -59,6 +59,20 @@ fetch('/api/book/%(id)s').then(r => r.json()).then(b => {
 </script>"""
 
 
+# Deliberately not reproducible: the HTML is byte-identical every time, but the text
+# the browser ends up showing is not, because it comes from the clock rather than from
+# the response. Re-driving this page can never reproduce the recorded observation,
+# which is exactly the boundary the adapter has to be honest about.
+VOLATILE = """<!doctype html>
+<meta charset="utf-8"><title>Volatile</title>
+<h1>Volatile</h1>
+<div id="stamp">pending</div>
+<script>
+document.getElementById('stamp').textContent = 'rendered at ' + Date.now();
+document.body.dataset.ready = 'true';
+</script>"""
+
+
 class Handler(BaseHTTPRequestHandler):
     def log_message(self, *_args):
         pass  # quiet: the example's output should be the agent's, not the server's
@@ -75,6 +89,8 @@ class Handler(BaseHTTPRequestHandler):
         path = self.path
         if path == "/":
             return self._send(INDEX, "text/html; charset=utf-8")
+        if path == "/volatile":
+            return self._send(VOLATILE, "text/html; charset=utf-8")
         if path == "/api/flights":
             return self._send(json.dumps(FLIGHTS), "application/json")
         for prefix, page in (("/flight/", DETAIL), ("/book/", BOOKED)):


### PR DESCRIPTION
The adapter compared the re-driven page against the recording and printed a loud
warning when they disagreed — and then recorded the observations it took from that
page as `live`, meaning "this really happened". So the trajectory claimed evidence
about the original execution that it did not have, and the only trace of the problem
was a line in a terminal nobody would read again.

An unverified reconstruction now sets the values it produces to `unknown`, which
propagates to the head because provenance never improves downstream.

Carrying that needed a way for a client to hand back a value while declaring it
ungrounded, so `noidroid.Ungrounded` wraps one and the protocol accepts `unknown` on
a result. Like `unknown` on an error, it is the only sort of provenance claim a
client may make: it can only lose trust, never gain it. A replayed response also now
reports the provenance the recording actually holds, rather than saying "real" for
every value it serves.

Not fatal by default. A page digest is an exact comparison and real pages carry
clocks, ads and session tokens, so refusing on mismatch would refuse most real
branches; `Browser(strict=True)` is there for anyone who wants the gate.

Tested by giving the example site a `/volatile` page whose rendered text comes from
the clock rather than from the response, so re-driving it cannot reproduce the
recorded observation. The test asserts the head is `unknown`, which can only happen
if the ungrounded path fired — `simulated` from the intervention alone would not
reach it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
