### PR TITLE
feat(llm): record model calls, and make the model's tool choice branchable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ how the package version relates to `STEP_VERSION`, the on-disk object format.
   graded honestly — Destructive Power **E**, because it can never change what
   happened — which makes the stat block an accurate capability summary as well as a
   joke. Nothing in the workflow goes through it.
+- **`noidroid.llm.Model`** — an adapter for the one input an agent cannot make
+  deterministic. Recording model calls means a replay serves them back rather than
+  calling the provider, so re-running an agent against a real conversation is free and
+  deterministic; and the model's tool choice is declared as a decision on the agent's
+  behalf, so branching to a different tool needs no instrumentation from the agent at
+  all. Provider-agnostic: it takes a callable, imports no SDK, and understands both
+  the Anthropic content-block and OpenAI `tool_calls` response shapes.
+- An `examples/llm_agent/` worked example with a deterministic stand-in model, so it
+  runs with no API key.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -272,6 +272,27 @@ The client is one dependency-free file speaking newline-delimited JSON over a Un
 socket. That protocol, not the Python package, is the integration contract — a client
 for another language is an afternoon's work.
 
+For agents, `noidroid.llm.Model` wraps the model call — the one input an agent cannot
+make deterministic:
+
+```python
+from noidroid.llm import Model
+
+model = Model(noidroid.connect())
+response = model.complete(
+    lambda: client.messages.create(model=name, max_tokens=1024, messages=messages),
+    request={"model": name, "messages": messages, "temperature": 0},
+    tools=list(REGISTRY),
+)
+```
+
+Two things follow without any further instrumentation. **Replay costs nothing** —
+every recorded response is served back, so you can iterate on your agent's code
+against a real conversation, deterministically, for free. And **the model's tool
+choice becomes a branchable decision**, so "what if it had reached for the other tool"
+is `noidroid branch run-1@2 --decide tool_choice_1=lookup_charges` rather than a
+prompt-engineering session. See [`examples/llm_agent/`](examples/llm_agent/README.md).
+
 For browsers, `noidroid.browser.Browser` wraps a Playwright page and does the
 mediating for you:
 

--- a/clients/python/noidroid/llm.py
+++ b/clients/python/noidroid/llm.py
@@ -1,0 +1,220 @@
+"""Model adapter.
+
+A model call is the one input an agent cannot make deterministic, so it is the input
+worth recording. Route yours through here and three things follow:
+
+1. **Replay costs nothing.** Re-running the agent serves every recorded response back
+   without touching the provider, so you can iterate on your agent's code against a
+   real conversation, deterministically, for free.
+2. **The model's choices become branchable.** A tool call in a response is declared as
+   a decision point, so "what if it had called the other tool" is a branch rather than
+   a prompt-engineering session.
+3. **Its answers become substitutable.** `--result` replaces a whole response, which
+   is how you test the handling of malformed output, refusals and truncation without
+   waiting for the model to produce them.
+
+Provider-agnostic on purpose: you pass a callable that performs the request, exactly
+as with `Browser`. Nothing here imports an SDK.
+
+    from noidroid.llm import Model
+
+    nd = noidroid.connect()
+    model = Model(nd)
+
+    reply = model.complete(
+        lambda: client.messages.create(model=name, max_tokens=1024, messages=msgs),
+        request={"model": name, "messages": msgs, "temperature": 0},
+    )
+
+The response has to be JSON-serialisable, because that is what gets stored, replayed
+and branched. Objects exposing `model_dump()`, `to_dict()` or `dict()` are converted
+for you, which covers the current Anthropic and OpenAI clients.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Callable, Optional, Sequence
+
+from . import READ, Session
+
+__all__ = ["Model", "as_jsonable", "tool_calls_in"]
+
+
+def as_jsonable(value: Any) -> Any:
+    """Best effort conversion of an SDK response into something storable."""
+    for method in ("model_dump", "to_dict", "dict"):
+        converter = getattr(value, method, None)
+        if callable(converter):
+            try:
+                return _plain(converter())
+            except TypeError:
+                continue
+    return _plain(value)
+
+
+def _plain(value: Any) -> Any:
+    try:
+        json.dumps(value)
+        return value
+    except (TypeError, ValueError):
+        if isinstance(value, dict):
+            return {str(k): _plain(v) for k, v in value.items()}
+        if isinstance(value, (list, tuple)):
+            return [_plain(v) for v in value]
+        return str(value)
+
+
+def tool_calls_in(response: Any) -> list[dict]:
+    """Pull tool calls out of a response, whichever shape the provider uses.
+
+    Understands the Anthropic content-block shape and the OpenAI tool_calls shape.
+    Returns `[{"name": ..., "arguments": {...}}]`, empty when the model just talked.
+    """
+    calls: list[dict] = []
+    if not isinstance(response, dict):
+        return calls
+
+    # Anthropic: content blocks with type "tool_use".
+    for block in response.get("content") or []:
+        if isinstance(block, dict) and block.get("type") == "tool_use":
+            calls.append({"name": block.get("name"), "arguments": block.get("input") or {}})
+
+    # OpenAI: choices[].message.tool_calls[].function
+    for choice in response.get("choices") or []:
+        message = (choice or {}).get("message") or {}
+        for call in message.get("tool_calls") or []:
+            function = (call or {}).get("function") or {}
+            arguments = function.get("arguments")
+            if isinstance(arguments, str):
+                try:
+                    arguments = json.loads(arguments)
+                except ValueError:
+                    pass
+            calls.append({"name": function.get("name"), "arguments": arguments or {}})
+
+    return calls
+
+
+class Model:
+    """Mediates the calls an agent makes to a model."""
+
+    def __init__(self, session: Session, *, target: str = "model.complete") -> None:
+        self._nd = session
+        self._target = target
+        self._calls = 0
+        self._tokens = {"input": 0, "output": 0}
+        self._replayed = 0
+
+    # ------------------------------------------------------------------ calling
+
+    def complete(
+        self,
+        run: Callable[[], Any],
+        request: Optional[dict] = None,
+        *,
+        tools: Optional[Sequence[str]] = None,
+        decide_tool: bool = True,
+    ) -> Any:
+        """Perform one model call, or serve the recorded one.
+
+        `request` is what identifies the call: it is what a replay matches against, so
+        it should contain everything that would change the answer — the model name,
+        the messages, the sampling parameters. It is *not* sent anywhere; `run` does
+        the sending.
+        """
+        self._calls += 1
+        response = self._nd.call(
+            self._target,
+            lambda: as_jsonable(run()),
+            args={"call": self._calls, **(request or {})},
+            effect=READ,
+        )
+        self._account(response)
+
+        if decide_tool:
+            response = self._declare_tool_choice(response, tools)
+        return response
+
+    def _declare_tool_choice(self, response: Any, tools: Optional[Sequence[str]]) -> Any:
+        """Make the model's tool choice a branchable decision.
+
+        The model picking a tool is the agent's most consequential fork, and it is
+        invisible to noidroid unless somebody declares it. Declaring it here means
+        `noidroid branch …@k --decide` works on any agent that calls tools, with no
+        further instrumentation.
+        """
+        calls = tool_calls_in(response)
+        if not calls:
+            return response
+        taken = str(calls[0]["name"])
+
+        # The options are what the agent *could* have called, not what the model did
+        # call. Recording only the latter makes the decision unbranchable, which is
+        # the whole reason for declaring it.
+        candidates = {str(name) for name in (tools or [])}
+        candidates.update(str(call["name"]) for call in calls if call.get("name"))
+        candidates.add(taken)
+
+        chosen = self._nd.decide(
+            f"tool_choice_{self._calls}",
+            options=sorted(candidates),
+            choice=taken,
+        )
+        if chosen == taken:
+            return response
+        # A branch overrode the choice, so the response has to say what the agent is
+        # about to act on. Rewriting it keeps the two consistent; the step is already
+        # marked `simulated`, so nothing here claims to be what the model said.
+        return _rewrite_tool_choice(response, chosen)
+
+    # ------------------------------------------------------------------ counting
+
+    def _account(self, response: Any) -> None:
+        usage = response.get("usage") if isinstance(response, dict) else None
+        if not isinstance(usage, dict):
+            return
+        for key in ("input_tokens", "prompt_tokens"):
+            if isinstance(usage.get(key), int):
+                self._tokens["input"] += usage[key]
+                break
+        for key in ("output_tokens", "completion_tokens"):
+            if isinstance(usage.get(key), int):
+                self._tokens["output"] += usage[key]
+                break
+
+    @property
+    def calls(self) -> int:
+        return self._calls
+
+    @property
+    def tokens(self) -> dict:
+        """Tokens the recording accounts for. During a replay none were spent."""
+        return dict(self._tokens)
+
+    def summary(self) -> str:
+        spent = getattr(self._nd, "mode", "off") in ("record", "off")
+        verb = "spent" if spent else "served from the recording, costing nothing"
+        return (
+            f"{self._calls} model call(s), "
+            f"{self._tokens['input']} in / {self._tokens['output']} out — {verb}"
+        )
+
+
+def _rewrite_tool_choice(response: Any, chosen: str) -> Any:
+    if not isinstance(response, dict):
+        return response
+    rewritten = json.loads(json.dumps(response))
+    for block in rewritten.get("content") or []:
+        if isinstance(block, dict) and block.get("type") == "tool_use":
+            block["name"] = chosen
+            break
+    for choice in rewritten.get("choices") or []:
+        message = (choice or {}).get("message") or {}
+        for call in message.get("tool_calls") or []:
+            function = (call or {}).get("function")
+            if isinstance(function, dict):
+                function["name"] = chosen
+                break
+        break
+    return rewritten

--- a/crates/noidroid-core/tests/llm_slice.rs
+++ b/crates/noidroid-core/tests/llm_slice.rs
@@ -1,0 +1,166 @@
+//! The model adapter, end to end.
+//!
+//! A model call is the one input an agent cannot make deterministic, so it is the one
+//! worth recording. The claims here are that recording it makes the agent replayable
+//! without touching a provider, and that the model's tool choice becomes branchable
+//! without the agent declaring anything itself.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use noidroid_core::engine::{self, Mode, RunSpec};
+use noidroid_core::model::{Action, Intervention, Provenance, Trajectory};
+use noidroid_core::Repo;
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("the workspace root is two levels up")
+}
+
+struct Fixture {
+    dir: PathBuf,
+    repo: Repo,
+    root: PathBuf,
+}
+
+impl Fixture {
+    fn new(tag: &str) -> Fixture {
+        let root = repo_root();
+        let dir = std::env::temp_dir().join(format!(
+            "noidroid-llm-{tag}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        let repo = Repo::open(&dir).unwrap();
+        Fixture { dir, repo, root }
+    }
+
+    fn spec(&self, name: Option<&str>) -> RunSpec {
+        RunSpec {
+            command: vec![
+                "python3".into(),
+                self.root
+                    .join("examples/llm_agent/agent.py")
+                    .display()
+                    .to_string(),
+            ],
+            launch_dir: self.dir.clone(),
+            name: name.map(str::to_string),
+            env: vec![(
+                "PYTHONPATH".into(),
+                self.root.join("clients/python").display().to_string(),
+            )],
+        }
+    }
+
+    fn decision(&self, t: &Trajectory) -> u64 {
+        self.repo
+            .chain(t)
+            .unwrap()
+            .iter()
+            .find(|(_, s)| matches!(&s.action, Action::Decide { .. }))
+            .map(|(_, s)| s.index)
+            .expect("the adapter declares the model's tool choice")
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.dir);
+    }
+}
+
+#[test]
+fn a_models_tool_choice_is_branchable_without_the_agent_declaring_it() {
+    let f = Fixture::new("tool");
+    let recorded = engine::run(&f.repo, &f.spec(Some("run-1")), Mode::Record, None)
+        .expect("recording should succeed")
+        .trajectory
+        .expect("a recording produces a trajectory");
+    assert_eq!(
+        recorded.outcome.status, "failure",
+        "the model picks the wrong tool"
+    );
+
+    // The agent never called `decide`; the adapter did, on its behalf.
+    let at = f.decision(&recorded);
+    let (_, step) = f.repo.chain(&recorded).unwrap().remove(at as usize);
+    let Action::Decide { options, .. } = &step.action else {
+        panic!("step {at} should be the declared tool choice");
+    };
+    let options = options.as_array().expect("options are recorded as a list");
+    assert!(
+        options.len() > 1,
+        "the alternatives have to be recorded or the decision cannot be branched: {options:?}"
+    );
+
+    let branch = engine::run(
+        &f.repo,
+        &f.spec(Some("alt-1")),
+        Mode::Branch {
+            at,
+            intervention: Intervention::ReplaceDecision {
+                name: format!("tool_choice_{}", 1),
+                value: serde_json::json!("lookup_charges"),
+            },
+            simulate: BTreeMap::new(),
+        },
+        Some(&recorded),
+    )
+    .expect("the branch should run")
+    .trajectory
+    .expect("the branch should produce a trajectory");
+
+    assert_eq!(
+        branch.outcome.status, "success",
+        "the other tool answers the question"
+    );
+    assert_eq!(
+        f.repo.chain(&branch).unwrap().last().unwrap().1.provenance,
+        Provenance::Simulated,
+        "a counterfactual never claims to be what the model actually said"
+    );
+
+    // The prefix is the parent's objects, not a copy.
+    let parent_chain = f.repo.chain(&recorded).unwrap();
+    let branch_chain = f.repo.chain(&branch).unwrap();
+    for i in 0..at as usize {
+        assert_eq!(
+            parent_chain[i].0, branch_chain[i].0,
+            "step {i} must be shared"
+        );
+    }
+}
+
+#[test]
+fn replaying_an_agent_never_calls_the_model() {
+    let f = Fixture::new("replay");
+    let recorded = engine::run(&f.repo, &f.spec(Some("run-1")), Mode::Record, None)
+        .unwrap()
+        .trajectory
+        .unwrap();
+
+    let report = engine::run(&f.repo, &f.spec(None), Mode::Replay, Some(&recorded))
+        .expect("replay should run to completion");
+
+    assert!(report.faithful(), "{:?}", report.divergences);
+    // Every step was served from the recording. Nothing was executed, so nothing was
+    // spent: that is the whole proposition of recording model calls.
+    assert_eq!(
+        report.delivery.get("executed").copied().unwrap_or(0),
+        0,
+        "a replay that executed anything would have called the provider"
+    );
+    assert_eq!(
+        report.delivery.get("replayed").copied().unwrap_or(0),
+        report.steps,
+        "every step should have been served from the recording"
+    );
+}

--- a/examples/llm_agent/README.md
+++ b/examples/llm_agent/README.md
@@ -1,0 +1,47 @@
+# LLM agent
+
+A support agent asks a model which tool to use, and is told the wrong one.
+
+```bash
+export PYTHONPATH=$PWD/clients/python
+noidroid run -- python3 examples/llm_agent/agent.py     # → failure
+noidroid show run-1@2                                   # the model's tool choice
+noidroid branch run-1@2 --decide tool_choice_1=lookup_charges
+noidroid diff run-1 alt-1
+```
+
+```
+    1 ● call model.complete({"call":1,"messages":[…    real      replayed
+    2 ◆ decide tool_choice_1 = "lookup_charges"        simulated intervened
+    3 ● call tool.lookup_charges({"account":"acct_42"}) simulated executed
+    4 ✔ finish success                                 simulated executed
+```
+
+The agent never wrote a `decide` call. The adapter declared the model's tool choice on
+its behalf, which is what makes "what if it had reached for the other tool" a branch
+instead of a prompt-engineering session.
+
+`fake_model.py` is deterministic so the example runs without an API key. It answers in
+the Anthropic content-block shape, including `usage`; swap it for a real client and
+nothing in `agent.py` changes:
+
+```python
+response = model.complete(
+    lambda: client.messages.create(model=name, max_tokens=1024, messages=messages),
+    request={"model": name, "messages": messages, "temperature": 0},
+    tools=list(REGISTRY),
+)
+```
+
+`request` is what a replay matches against, so it should hold everything that would
+change the answer. It is not sent anywhere — the lambda does the sending.
+
+## Replay costs nothing
+
+```bash
+noidroid replay run-1
+```
+
+Every model call is served from the recording, so re-running the agent against a real
+conversation is free and deterministic. Change the agent's code and replay again: it
+tells you exactly where its behaviour stopped matching.

--- a/examples/llm_agent/agent.py
+++ b/examples/llm_agent/agent.py
@@ -1,0 +1,51 @@
+"""A support agent that asks a model which tool to use, and gets told the wrong one.
+
+The only noidroid-specific code is `Model` and `nd.finish`. Point `respond` at a real
+client and everything else is unchanged.
+"""
+
+import noidroid
+from noidroid.llm import Model
+
+import fake_model
+import tools
+
+QUESTION = "Why was I charged twice this month?"
+
+
+def main():
+    nd = noidroid.connect()
+    model = Model(nd)
+
+    messages = [{"role": "user", "content": QUESTION}]
+
+    # In a real agent this lambda is the provider call:
+    #   lambda: client.messages.create(model=..., max_tokens=1024, messages=messages)
+    response = model.complete(
+        lambda: fake_model.complete(messages, list(tools.REGISTRY)),
+        request={"model": "fake-model-1", "messages": messages, "temperature": 0},
+        tools=list(tools.REGISTRY),
+    )
+
+    call = next(b for b in response["content"] if b["type"] == "tool_use")
+    print(f"model chose: {call['name']}")
+
+    result = nd.call(
+        f"tool.{call['name']}",
+        lambda: tools.REGISTRY[call["name"]](**call["input"]),
+        args=call["input"],
+    )
+
+    duplicates = result.get("duplicates") or []
+    print(model.summary())
+
+    if duplicates:
+        print(f"found {len(duplicates)} duplicate charge(s)")
+        nd.finish("success", {"tool": call["name"], "duplicates": duplicates})
+    else:
+        print("could not explain the charge")
+        nd.finish("failure", {"tool": call["name"], "reason": "no_duplicates_found"})
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/llm_agent/fake_model.py
+++ b/examples/llm_agent/fake_model.py
@@ -1,0 +1,26 @@
+"""A deterministic stand-in for a model, so the example runs with no API key.
+
+It answers in the Anthropic content-block shape, including `tool_use` blocks and a
+`usage` count, because that is the shape the adapter has to cope with. Swap it for a
+real client and nothing else in `agent.py` changes — that is the point of the example.
+"""
+
+
+def complete(messages, tools):
+    """Pick a tool. Badly, the first time — which is the bug worth exploring."""
+    question = messages[-1]["content"]
+
+    # The model reaches for the FAQ whenever it sees the word "charge", which is a
+    # plausible failure and the wrong move for a question about a specific account.
+    name = "search_faq" if "charge" in question.lower() else "lookup_charges"
+    return {
+        "id": "msg_example",
+        "model": "fake-model-1",
+        "role": "assistant",
+        "stop_reason": "tool_use",
+        "content": [
+            {"type": "text", "text": f"Looking into: {question}"},
+            {"type": "tool_use", "name": name, "input": {"account": "acct_42"}},
+        ],
+        "usage": {"input_tokens": 180, "output_tokens": 24},
+    }

--- a/examples/llm_agent/tools.py
+++ b/examples/llm_agent/tools.py
@@ -1,0 +1,31 @@
+"""The tools the agent can call. Local and deterministic."""
+
+FAQ = [
+    "Charges appear within three business days.",
+    "Refunds take five to ten business days.",
+]
+
+CHARGES = {
+    "acct_42": [
+        {"id": "ch_1", "amount": 4200, "description": "Pro plan"},
+        {"id": "ch_2", "amount": 4200, "description": "Pro plan"},
+    ]
+}
+
+
+def search_faq(account=None):
+    return {"results": FAQ}
+
+
+def lookup_charges(account):
+    charges = CHARGES.get(account, [])
+    seen, duplicates = {}, []
+    for charge in charges:
+        key = (charge["amount"], charge["description"])
+        if key in seen:
+            duplicates.append({"first": seen[key], "second": charge["id"]})
+        seen[key] = charge["id"]
+    return {"charges": charges, "duplicates": duplicates}
+
+
+REGISTRY = {"search_faq": search_faq, "lookup_charges": lookup_charges}


### PR DESCRIPTION
A model call is the one input an agent cannot make deterministic, so it is the one
worth recording. Two things follow, and neither needs the agent to do anything beyond
routing the call through the adapter.

Replay costs nothing. Every recorded response is served back instead of reaching the
provider, so re-running an agent against a real conversation is free, deterministic,
and offline. A test asserts a replay executes zero steps and serves all of them, which
is the property that makes that claim true rather than aspirational.

The model's tool choice becomes a branchable decision. The adapter declares it on the
agent's behalf, with the options being the tools the agent *could* have called rather
than the one the model did call — recording only the latter would leave the decision
unbranchable, which is the whole reason for declaring it. So "what if it had reached
for the other tool" is a branch rather than a prompt-engineering session, on any agent
that calls tools.

Provider-agnostic on purpose: it takes a callable and imports no SDK, understanding
both the Anthropic content-block and OpenAI tool_calls shapes, and converting
responses that expose model_dump/to_dict/dict.

The worked example ships a deterministic stand-in model so it runs with no API key,
and demonstrates the failure worth exploring: the model reaches for the FAQ when asked
about a specific account, and branching to the other tool finds the duplicate charge.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
