### PR TITLE
fix(engine): a refused branch leaves nothing behind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@ how the package version relates to `STEP_VERSION`, the on-disk object format.
 
 ### Fixed
 
+- A branch whose checkpoint could not be reached was refused, and then written to disk
+  anyway. The caller was told the branch failed while a trajectory sat in
+  `noidroid log` claiming an ancestry it did not have. The engine now declines to
+  persist it, and removes its workspace, because "you cannot branch from a checkpoint
+  you cannot reach" is an invariant of the engine rather than advice to the CLI.
 - A browser branch whose starting state could not be reproduced said so in the
   terminal but recorded its observations as `live`, i.e. as things that really
   happened. An unreproducible reconstruction now marks everything after it `unknown`,

--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ and anything resembling a universal simulator.
 ## Development
 
 ```bash
-cargo test --all                # 32 tests: unit, end-to-end, and real-browser
+cargo test --all                # 33 tests: unit, end-to-end, and real-browser
 cargo clippy --all-targets
 
 # the browser tests need Chromium; they print SKIP and pass without it

--- a/crates/noidroid-cli/src/main.rs
+++ b/crates/noidroid-cli/src/main.rs
@@ -446,7 +446,7 @@ fn cmd_branch(
     let prefix_divergence = report.divergences.iter().find(|d| d.index < at);
     if let Some(d) = prefix_divergence {
         return Err(Error::Refused(format!(
-            "cannot branch from {name}@{at}: the prefix could not be reconstructed ({d})"
+            "cannot branch from {name}@{at}: the checkpoint could not be reached ({d}).\n               Nothing was written; {name} is untouched."
         )));
     }
 

--- a/crates/noidroid-cli/src/tui.rs
+++ b/crates/noidroid-cli/src/tui.rs
@@ -369,7 +369,7 @@ fn handle(app: &mut App, code: KeyCode) -> bool {
                 picker.selected = picker.selected.saturating_sub(1);
             }
             KeyCode::Down | KeyCode::Char('j') => {
-                picker.selected = (picker.selected + 1).min(picker.options.len() - 1);
+                picker.selected = (picker.selected + 1).min(picker.options.len().saturating_sub(1));
             }
             KeyCode::Enter => {
                 let decision = picker.decision.clone();
@@ -403,7 +403,9 @@ fn handle(app: &mut App, code: KeyCode) -> bool {
                 app.step = (app.step + 1).min(app.chain.len().saturating_sub(1));
             }
             Focus::Trajectories => {
-                app.trajectory = (app.trajectory + 1).min(app.trajectories.len() - 1);
+                // Saturating: an empty list would underflow, and the list is only
+                // guaranteed non-empty at startup, not after a reload.
+                app.trajectory = (app.trajectory + 1).min(app.trajectories.len().saturating_sub(1));
                 app.step = 0;
                 let _ = app.load();
             }

--- a/crates/noidroid-core/src/engine.rs
+++ b/crates/noidroid-core/src/engine.rs
@@ -251,7 +251,23 @@ pub fn run(repo: &Repo, spec: &RunSpec, mode: Mode, source: Option<&Trajectory>)
         });
     }
 
+    // You cannot branch from a checkpoint you cannot reach. If the prefix did not
+    // reconstruct, the run that just happened is not a branch of anything, so it is
+    // not written down: persisting it would leave a trajectory on disk claiming an
+    // ancestry it does not have, while the caller was told the branch was refused.
+    let unreachable_checkpoint = match &mode {
+        Mode::Branch { at, .. } => report.divergences.iter().any(|d| d.index < *at),
+        _ => false,
+    };
+    if unreachable_checkpoint {
+        let _ = fs::remove_dir_all(&workspace);
+    }
+
     if let (Some(name), Some(head)) = (spec.name.clone(), session.parent.clone()) {
+        if unreachable_checkpoint {
+            report.steps = session.index;
+            return Ok(report);
+        }
         let outcome = session.outcome.clone().unwrap_or(Outcome {
             status: "aborted".into(),
             result: Value::Null,

--- a/crates/noidroid-core/tests/vertical_slice.rs
+++ b/crates/noidroid-core/tests/vertical_slice.rs
@@ -540,3 +540,48 @@ fn a_recorded_failure_is_reproduced_as_a_failure() {
     );
     assert_eq!(report.steps, branch.steps);
 }
+
+#[test]
+fn a_branch_from_an_unreachable_checkpoint_leaves_nothing_behind() {
+    let f = Fixture::new("unreachable");
+    let parent = f.record();
+
+    // Same program, different behaviour, so the prefix cannot be reconstructed. The
+    // branch has to be refused — and refusing it has to mean nothing was written,
+    // not merely that the caller was told.
+    let report = engine::run(
+        &f.repo,
+        &f.spec(Some("alt-unreachable"), &[("VARIANT", "b")]),
+        Mode::Branch {
+            at: 3,
+            intervention: Intervention::ReplaceDecision {
+                name: "pick".into(),
+                value: serde_json::json!("b"),
+            },
+            simulate: BTreeMap::new(),
+        },
+        Some(&parent),
+    )
+    .expect("the run itself completes; it is the branch that is refused");
+
+    assert!(
+        report.divergences.iter().any(|d| d.index < 3),
+        "the prefix should have diverged, got {:?}",
+        report.divergences
+    );
+    assert!(
+        report.trajectory.is_none(),
+        "a branch whose checkpoint could not be reached is not a trajectory"
+    );
+    assert!(
+        f.repo.load_trajectory("alt-unreachable").is_err(),
+        "nothing may be left on disk claiming an ancestry it does not have"
+    );
+    assert!(
+        !f.repo.workspace_dir("alt-unreachable").exists(),
+        "its workspace should be gone too"
+    );
+
+    // The parent is exactly as it was.
+    assert_eq!(f.repo.load_trajectory("run-1").unwrap(), parent);
+}

--- a/docs/technical-proposal.md
+++ b/docs/technical-proposal.md
@@ -514,7 +514,7 @@ build the products the trajectory graph makes possible.
 
 What follows is what exists and has been run, as opposed to what is planned above.
 
-**Built and verified** (32 tests: 18 unit, 11 end-to-end through a real subprocess, 3 driving real Chromium):
+**Built and verified** (33 tests: 18 unit, 12 end-to-end through a real subprocess, 3 driving real Chromium):
 
 | Claim | How it is checked |
 |---|---|


### PR DESCRIPTION
Reopened: #8 was closed by an automated rebase, unmerged.

A branch from an unreachable checkpoint was refused and persisted anyway, so `noidroid log` showed a trajectory claiming an ancestry it did not have. The engine now declines to persist it and removes its workspace.

Verified by `a_branch_from_an_unreachable_checkpoint_leaves_nothing_behind`.