### PR TITLE
feat(auto): record a program that does not mention us

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install Playwright and Chromium
         run: |
           python -m pip install --upgrade pip
-          python -m pip install playwright
+          python -m pip install playwright anthropic
           python -m playwright install --with-deps chromium
       - name: Run every test, including the ones that drive a real browser
         run: cargo test --all --verbose -- --nocapture 2>&1 | tee test-output.txt
@@ -49,6 +49,10 @@ jobs:
         run: |
           if grep -q "SKIP: browser adapter test" test-output.txt; then
             echo "::error::browser tests skipped on the job that installs a browser"
+            exit 1
+          fi
+          if grep -q "SKIP: automatic capture test" test-output.txt; then
+            echo "::error::auto-capture test skipped on the job that installs the SDK"
             exit 1
           fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ how the package version relates to `STEP_VERSION`, the on-disk object format.
 
 ### Added
 
+- **`noidroid run --auto`: zero-code recording.** A `sitecustomize.py` goes on the
+  child's `PYTHONPATH` — the mechanism `opentelemetry-instrument` and `ddtrace-run`
+  use — and patches the OpenAI and Anthropic base clients at `request`, below the
+  retry loop, so one logical call is one recorded step however many times it retried.
+  A program that never mentions Paranoid Android can now be recorded and replayed; the
+  SDK's own response type is rebuilt on replay, so `reply.content[0].text` still
+  works. Tested against the real Anthropic SDK with the API shut down.
+  It cannot make anything *branchable*: no patching can infer that a value was a
+  choice among alternatives, so `decide()` stays explicit. The honest shape is
+  **zero code to record and replay, two lines to branch**.
+- **`volatile=` on `call`** — names arguments that change every run without changing
+  what the call means, such as a timestamp or a request id. Without it an argument
+  carrying a clock makes every replay diverge, which is true and useless.
+- **Divergence reports say what differed**, field by field, and point out when the
+  call the run wants is recorded further along — which usually means an interaction
+  was inserted or removed, rather than changed.
+
+### Added
+
 - **`noidroid tui`** — the viewer the manifesto calls V0.1, built with
   [ratatui](https://ratatui.rs). Three panes and one verb: the timeline is coloured by
   provenance, and pressing `e` on a recorded decision reconstructs the prefix,

--- a/README.md
+++ b/README.md
@@ -245,6 +245,44 @@ noidroid diff run-1 alt-1
 
 ## Integrating your own program
 
+**Zero code to record and replay. Two lines to branch.**
+
+```bash
+pip install -e clients/python
+noidroid run --auto -- python3 your_agent.py
+```
+
+`--auto` puts a `sitecustomize.py` on the child's `PYTHONPATH` — the same mechanism
+`opentelemetry-instrument` and `ddtrace-run` use — and patches the OpenAI and
+Anthropic base clients at `request`, below the retry loop, so a call that retried
+three times is recorded once. Your program does not mention Paranoid Android at all:
+
+```python
+import anthropic                                   # no noidroid import
+
+client = anthropic.Anthropic()
+reply = client.messages.create(model=…, messages=…)
+print(reply.content[0].text)                       # a real Message, replayed
+```
+
+Record it once, then replay it with the network unplugged: the recorded response is
+served back and the SDK's own type is rebuilt, so `reply.content[0].text` still works.
+
+What automatic capture **cannot** do is branch. No amount of patching can infer that a
+value was a *choice among alternatives*, and that is what an intervention needs — so
+`decide()` stays explicit, and it is the only thing that does:
+
+```python
+pick = nd.decide("route", options=candidates, choice=candidates[0])
+```
+
+It also does not capture async clients, streaming responses, non-SDK HTTP, the clock,
+or randomness. `--auto` prints what it hooked; anything not listed was not recorded.
+Say it plainly, because a replay tool that quietly misses an effect produces a
+trajectory that looks real.
+
+## Integrating it by hand
+
 Three declarations. Everything else is your code, unchanged.
 
 ```python

--- a/clients/python/noidroid/__init__.py
+++ b/clients/python/noidroid/__init__.py
@@ -49,6 +49,8 @@ __all__ = [
     "InjectedFailure",
     "Unavailable",
     "Ungrounded",
+    "VOLATILE",
+    "mask_volatile",
     "READ",
     "WRITE",
     "IRREVERSIBLE",
@@ -79,6 +81,30 @@ class Divergence(NoidroidError):
 
 class InjectedFailure(NoidroidError):
     """A branch deliberately made this interaction fail."""
+
+
+#: Stands in for a value deliberately left out of a call's identity.
+VOLATILE = "<volatile>"
+
+
+def mask_volatile(args: dict, volatile: Optional[Iterable[str]]) -> dict:
+    """Replace volatile keys with a marker, at any depth.
+
+    Nested because request payloads bury their timestamps: `{"meta": {"ts": ...}}` is
+    at least as common as a top-level one.
+    """
+    keys = set(volatile or ())
+    if not keys:
+        return args
+    return _mask(args, keys)
+
+
+def _mask(value: Any, keys: set) -> Any:
+    if isinstance(value, dict):
+        return {k: (VOLATILE if k in keys else _mask(v, keys)) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_mask(v, keys) for v in value]
+    return value
 
 
 class Ungrounded:
@@ -151,14 +177,30 @@ class Session:
         run: Callable[[], Any],
         args: Optional[dict] = None,
         effect: str = READ,
+        volatile: Optional[Iterable[str]] = None,
     ) -> Any:
         """Mediate one interaction with the world.
 
         ``run`` is invoked only if Paranoid Android says to. Its return value must be
         JSON-serialisable: that is what gets stored, replayed and branched.
+
+        ``volatile`` names argument keys that change every run without changing what
+        the call means — a timestamp, a request id, a nonce. They are replaced with a
+        marker *before* anything is recorded, so the same call still identifies as the
+        same call on the next run. Without this, an argument carrying a clock makes
+        every replay diverge, which is technically true and practically useless.
+
+        The trade is explicit: a volatile value is excluded from the trajectory, so
+        you cannot inspect it later. Anything you might want to read afterwards
+        belongs in the response, which is recorded in full.
         """
         response = self._rpc(
-            {"op": "call", "target": target, "args": args or {}, "effect": effect}
+            {
+                "op": "call",
+                "target": target,
+                "args": mask_volatile(args or {}, volatile),
+                "effect": effect,
+            }
         )
         directive = response.get("directive")
         if directive == "execute":

--- a/clients/python/noidroid/_bootstrap/sitecustomize.py
+++ b/clients/python/noidroid/_bootstrap/sitecustomize.py
@@ -1,0 +1,30 @@
+"""Injected onto PYTHONPATH by `noidroid run --auto`, exactly as
+`opentelemetry-instrument` and `ddtrace-run` do it.
+
+Python imports `sitecustomize` automatically at startup, before the program runs, so
+this is the last moment at which an SDK can be patched without the program's help.
+"""
+
+import os
+import sys
+
+# Only when a run is actually being recorded, and only once: a program that spawns
+# children would otherwise re-patch in every one of them.
+if os.environ.get("NOIDROID_SOCKET") and not os.environ.get("_NOIDROID_BOOTSTRAPPED"):
+    os.environ["_NOIDROID_BOOTSTRAPPED"] = "1"
+    try:
+        from noidroid import auto
+
+        hooked = auto.install()
+        if os.environ.get("NOIDROID_AUTO_VERBOSE") == "1":
+            listed = ", ".join(hooked) if hooked else "nothing"
+            print(f"[noidroid.auto] hooked: {listed}", file=sys.stderr)
+    except Exception as exc:  # noqa: BLE001
+        # Loud, because a recording that silently missed the model calls looks real.
+        print(f"[noidroid.auto] could not install automatic capture: {exc}", file=sys.stderr)
+
+# Anything the program itself expects from a sitecustomize still has to run.
+try:
+    import sitecustomize_original  # noqa: F401
+except ImportError:
+    pass

--- a/clients/python/noidroid/auto.py
+++ b/clients/python/noidroid/auto.py
@@ -1,0 +1,159 @@
+"""Automatic capture, so recording needs no changes to your program.
+
+The adoption tax on a tool like this is the wrapping. `opentelemetry-instrument` and
+`ddtrace-run` solved it the same way and it is worth copying exactly: put a
+`sitecustomize.py` on `PYTHONPATH` before launching the child, and patch the SDKs from
+there. `noidroid run --auto` does that; this module is what the bootstrap calls.
+
+**Where it hooks.** Not at `Completions.create`, but at the base client's `request`,
+which both the OpenAI and Anthropic SDKs generate from the same template and which
+contains the retry loop — so one patch covers every endpoint and a call that retried
+three times is recorded once, as one logical call.
+
+**What it gives you.** Recording and replay with zero code. It cannot give you
+`decide()`: no amount of patching can infer that a value was a *choice among
+alternatives*, and that is what branching needs. So the honest shape of this tool is:
+
+    zero code to record and replay, two lines to branch.
+
+**What it does not capture** — stated because a replay tool that quietly misses an
+effect produces a trajectory that looks real:
+
+* async clients and streaming responses
+* anything not going through the OpenAI/Anthropic SDKs
+* time, randomness, and the filesystem
+
+`noidroid run --auto` prints what it hooked. If something you rely on is not listed,
+it was not recorded.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+from typing import Any, Callable, Optional
+
+from . import READ, connect
+
+__all__ = ["install", "hooked"]
+
+#: Base clients generated from the same template, so one patch each covers everything.
+PROVIDERS = ("openai", "anthropic")
+
+_session = None
+_hooked: list[str] = []
+
+
+def hooked() -> list[str]:
+    """What was successfully patched, in the order it was patched."""
+    return list(_hooked)
+
+
+def _shared_session():
+    global _session
+    if _session is None:
+        _session = connect()
+    return _session
+
+
+# ------------------------------------------------------------------ serialisation
+
+
+def _dump(value: Any) -> Any:
+    """Make an SDK response storable, remembering its type so replay can rebuild it.
+
+    An agent does `response.content[0].text`, so handing back a plain dict on replay
+    would break it. The type name travels with the payload.
+    """
+    for method in ("model_dump", "to_dict", "dict"):
+        converter = getattr(value, method, None)
+        if callable(converter):
+            try:
+                payload = converter()
+            except TypeError:
+                continue
+            cls = type(value)
+            return {
+                "__nd_type__": f"{cls.__module__}:{cls.__qualname__}",
+                "data": payload,
+            }
+    return value
+
+
+def _load(value: Any) -> Any:
+    """Rebuild the SDK object a recorded response came from, if we can."""
+    if not isinstance(value, dict) or "__nd_type__" not in value:
+        return value
+    reference, payload = value["__nd_type__"], value.get("data")
+    module_name, _, qualname = reference.partition(":")
+    try:
+        module = importlib.import_module(module_name)
+        cls: Any = module
+        for part in qualname.split("."):
+            cls = getattr(cls, part)
+        for builder in ("model_validate", "parse_obj", "from_dict"):
+            build = getattr(cls, builder, None)
+            if callable(build):
+                return build(payload)
+        return cls(**payload)
+    except Exception:
+        # Better a dict than a crash: the recorded content is intact either way, and
+        # the divergence will be obvious rather than mysterious.
+        return payload
+
+
+# ---------------------------------------------------------------------- patching
+
+
+def _describe(options: Any) -> tuple[str, dict]:
+    """Name the call after its endpoint, and record what would change the answer."""
+    url = getattr(options, "url", "") or ""
+    endpoint = str(url).strip("/").replace("/", ".") or "request"
+    body = getattr(options, "json_data", None)
+    if not isinstance(body, dict):
+        body = {}
+    return endpoint, body
+
+
+def _wrap_request(client_cls: Any, provider: str) -> None:
+    original = client_cls.request
+
+    def mediated(self, *args, **kwargs):
+        options = kwargs.get("options")
+        if options is None:
+            options = next((a for a in args if hasattr(a, "url")), None)
+        endpoint, body = _describe(options) if options is not None else ("request", {})
+
+        session = _shared_session()
+        payload = session.call(
+            f"{provider}.{endpoint}",
+            lambda: _dump(original(self, *args, **kwargs)),
+            args=body,
+            effect=READ,
+        )
+        return _load(payload)
+
+    mediated.__noidroid_wrapped__ = True  # so a second install is a no-op
+    client_cls.request = mediated
+
+
+def install(providers: Optional[tuple] = None) -> list[str]:
+    """Patch whichever supported SDKs are installed. Returns what was hooked.
+
+    Import errors are skipped — not every program uses every provider — but an SDK
+    that is present and fails to patch raises, because silently failing to record a
+    model call is how a trajectory ends up lying.
+    """
+    for provider in providers or PROVIDERS:
+        try:
+            base = importlib.import_module(f"{provider}._base_client")
+        except ImportError:
+            continue
+        client_cls = getattr(base, "SyncAPIClient", None)
+        if client_cls is None:
+            continue
+        if getattr(client_cls.request, "__noidroid_wrapped__", False):
+            continue
+        _wrap_request(client_cls, provider)
+        _hooked.append(f"{provider}._base_client.SyncAPIClient.request")
+    return hooked()

--- a/clients/python/noidroid/llm.py
+++ b/clients/python/noidroid/llm.py
@@ -115,6 +115,7 @@ class Model:
         *,
         tools: Optional[Sequence[str]] = None,
         decide_tool: bool = True,
+        volatile: Optional[Sequence[str]] = None,
     ) -> Any:
         """Perform one model call, or serve the recorded one.
 
@@ -129,6 +130,7 @@ class Model:
             lambda: as_jsonable(run()),
             args={"call": self._calls, **(request or {})},
             effect=READ,
+            volatile=volatile,
         )
         self._account(response)
 

--- a/crates/noidroid-cli/src/main.rs
+++ b/crates/noidroid-cli/src/main.rs
@@ -42,6 +42,10 @@ enum Command {
         /// Name for the trajectory (default: run-N).
         #[arg(long)]
         name: Option<String>,
+        /// Capture supported SDK calls without changing your program. Records and
+        /// replays; branching still needs a declared decision.
+        #[arg(long)]
+        auto: bool,
         /// The command to run, after `--`.
         #[arg(trailing_var_arg = true, allow_hyphen_values = true, required = true)]
         command: Vec<String>,
@@ -135,7 +139,11 @@ fn dispatch(cli: Cli) -> Result<ExitCode> {
     let cwd = std::env::current_dir()?;
     let repo = Repo::discover(&cwd)?;
     match cli.command {
-        Command::Run { name, command } => cmd_run(&repo, &cwd, name, command),
+        Command::Run {
+            name,
+            auto,
+            command,
+        } => cmd_run(&repo, &cwd, name, auto, command),
         Command::Log { trajectory } => cmd_log(&repo, trajectory),
         Command::Show { reference } => cmd_show(&repo, &reference),
         Command::Replay { trajectory } => cmd_replay(&repo, &cwd, &trajectory),
@@ -164,10 +172,45 @@ fn dispatch(cli: Cli) -> Result<ExitCode> {
     }
 }
 
+/// Locate the bootstrap directory inside the installed Python client.
+///
+/// The same trick as `opentelemetry-instrument`: a directory containing
+/// `sitecustomize.py` goes on `PYTHONPATH`, and Python imports it before the program
+/// runs. Asking Python where its own package lives is more reliable than guessing.
+fn auto_capture_env() -> Result<Vec<(String, String)>> {
+    let output = std::process::Command::new("python3")
+        .args([
+            "-c",
+            "import os, noidroid._bootstrap as b; print(os.path.dirname(b.__file__))",
+        ])
+        .output()
+        .map_err(|e| Error::Refused(format!("could not run python3 for --auto: {e}")))?;
+    if !output.status.success() {
+        return Err(Error::Refused(
+            "--auto needs the noidroid Python client importable:\n               pip install -e clients/python   (or: export PYTHONPATH=$PWD/clients/python)"
+                .into(),
+        ));
+    }
+    let dir = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if dir.is_empty() {
+        return Err(Error::Refused(
+            "could not locate the noidroid bootstrap".into(),
+        ));
+    }
+    let existing = std::env::var("PYTHONPATH").unwrap_or_default();
+    let joined = if existing.is_empty() {
+        dir
+    } else {
+        format!("{dir}:{existing}")
+    };
+    Ok(vec![("PYTHONPATH".to_string(), joined)])
+}
+
 fn cmd_run(
     repo: &Repo,
     cwd: &Path,
     name: Option<String>,
+    auto: bool,
     command: Vec<String>,
 ) -> Result<ExitCode> {
     let name = name.unwrap_or_else(|| repo.next_name("run"));
@@ -180,7 +223,12 @@ fn cmd_run(
         command,
         launch_dir: cwd.to_path_buf(),
         name: Some(name.clone()),
-        env: Vec::new(),
+        env: if auto {
+            auto_capture_env()?
+        } else {
+            Vec::new()
+        },
+        auto,
     };
     let report = engine::run(repo, &spec, Mode::Record, None)?;
     print_child_output(&report);
@@ -324,7 +372,12 @@ fn cmd_replay(repo: &Repo, cwd: &Path, name: &str) -> Result<ExitCode> {
         command: t.command.clone(),
         launch_dir: cwd.to_path_buf(),
         name: None,
-        env: Vec::new(),
+        env: if t.auto {
+            auto_capture_env()?
+        } else {
+            Vec::new()
+        },
+        auto: t.auto,
     };
     let report = engine::run(repo, &spec, Mode::Replay, Some(&t))?;
     println!("{} {}", shell("REPLAY"), name);
@@ -428,7 +481,12 @@ fn cmd_branch(
         command: parent.command.clone(),
         launch_dir: cwd.to_path_buf(),
         name: Some(label.clone()),
-        env: Vec::new(),
+        env: if parent.auto {
+            auto_capture_env()?
+        } else {
+            Vec::new()
+        },
+        auto: parent.auto,
     };
     let report = engine::run(
         repo,

--- a/crates/noidroid-cli/src/tui.rs
+++ b/crates/noidroid-cli/src/tui.rs
@@ -223,6 +223,7 @@ impl<'a> App<'a> {
             launch_dir: self.cwd.clone(),
             name: Some(label.clone()),
             env: Vec::new(),
+            auto: false,
         };
         let outcome = engine::run(
             self.repo,
@@ -272,6 +273,7 @@ impl<'a> App<'a> {
             launch_dir: self.cwd.clone(),
             name: None,
             env: Vec::new(),
+            auto: false,
         };
         match engine::run(self.repo, &spec, Mode::Replay, Some(&t)) {
             Ok(report) if report.faithful() => {

--- a/crates/noidroid-core/src/engine.rs
+++ b/crates/noidroid-core/src/engine.rs
@@ -144,6 +144,9 @@ pub struct RunSpec {
     /// Extra environment for the child. The ambient environment is *not* captured,
     /// so anything a run depends on here must be supplied again to reconstruct it.
     pub env: Vec<(String, String)>,
+    /// Recorded with automatic capture. Carried onto the trajectory so that replaying
+    /// it installs the same hooks; without them a replay would mediate nothing.
+    pub auto: bool,
 }
 
 /// Execute `spec` in `mode`, against `source` when reconstructing.
@@ -302,6 +305,7 @@ pub fn run(repo: &Repo, spec: &RunSpec, mode: Mode, source: Option<&Trajectory>)
                 } => vec![(*at, intervention.clone())],
                 _ => Vec::new(),
             },
+            auto: spec.auto,
         };
         repo.save_trajectory(&trajectory)?;
         repo.save_notes(&name, &session.notes)?;
@@ -490,18 +494,13 @@ impl<'a> Session<'a> {
             });
         };
         if actions_agree(&recorded.action, action) {
-            Ok(())
-        } else {
-            Err(Divergence {
-                index: self.index,
-                kind: DivergenceKind::KeyMismatch,
-                detail: format!(
-                    "recorded {} but this run wants {}",
-                    recorded.action.summary(),
-                    action.summary()
-                ),
-            })
+            return Ok(());
         }
+        Err(Divergence {
+            index: self.index,
+            kind: DivergenceKind::KeyMismatch,
+            detail: describe_mismatch(&recorded.action, action, self.recorded, self.index),
+        })
     }
 
     fn on_divergence(&mut self, d: Divergence) -> Result<Response> {
@@ -1007,6 +1006,141 @@ fn actions_agree(recorded: &Action, incoming: &Action) -> bool {
         (Action::Finish { .. }, Action::Finish { .. }) => true,
         _ => false,
     }
+}
+
+/// Say what actually differs, field by field.
+///
+/// "recorded X but this run wants Y" is true and useless once the arguments are more
+/// than a few characters: the reader has to diff two long lines by eye. Every
+/// record/replay tool that has been used in anger ends up here — it is the single
+/// most complained-about thing about the ones that did not.
+fn describe_mismatch(
+    recorded: &Action,
+    incoming: &Action,
+    chain: &[(Digest, Step)],
+    index: u64,
+) -> String {
+    let mut lines: Vec<String> = Vec::new();
+
+    match (recorded, incoming) {
+        (
+            Action::Call {
+                target: was,
+                args: was_args,
+                effect: was_effect,
+            },
+            Action::Call {
+                target: now,
+                args: now_args,
+                effect: now_effect,
+            },
+        ) => {
+            if was != now {
+                lines.push(format!("target: recorded {was:?}, got {now:?}"));
+            }
+            if was_effect != now_effect {
+                lines.push(format!(
+                    "effect: recorded {}, got {}",
+                    was_effect.label(),
+                    now_effect.label()
+                ));
+            }
+            lines.extend(diff_values("args", was_args, now_args));
+        }
+        (
+            Action::Decide {
+                name: was,
+                options: was_options,
+                ..
+            },
+            Action::Decide {
+                name: now,
+                options: now_options,
+                ..
+            },
+        ) => {
+            if was != now {
+                lines.push(format!("decision: recorded {was:?}, got {now:?}"));
+            }
+            lines.extend(diff_values("options", was_options, now_options));
+        }
+        (was, now) => lines.push(format!(
+            "recorded {} but this run wants {}",
+            was.summary(),
+            now.summary()
+        )),
+    }
+
+    // The most common cause of a mismatch is an inserted or removed interaction, not
+    // a changed one. If what the run wants is sitting further along the recording,
+    // say so — it turns a puzzle into a one-line explanation.
+    if let Some(found) = chain
+        .iter()
+        .enumerate()
+        .skip(index as usize + 1)
+        .find(|(_, (_, step))| actions_agree(&step.action, incoming))
+        .map(|(i, _)| i)
+    {
+        lines.push(format!(
+            "this call is recorded at step {found}; it looks like {} interaction(s) \
+             were removed",
+            found as u64 - index
+        ));
+    } else if chain
+        .iter()
+        .take(index as usize)
+        .any(|(_, step)| actions_agree(&step.action, incoming))
+    {
+        lines.push("this call already happened earlier in the recording".to_string());
+    }
+
+    if lines.is_empty() {
+        return "the actions differ".to_string();
+    }
+    format!("\n      {}", lines.join("\n      "))
+}
+
+/// Field-by-field for objects; whole-value otherwise.
+fn diff_values(label: &str, was: &Value, now: &Value) -> Vec<String> {
+    if was == now {
+        return Vec::new();
+    }
+    let (Value::Object(was_map), Value::Object(now_map)) = (was, now) else {
+        return vec![format!(
+            "{label}: recorded {}, got {}",
+            crate::model::compact_value(was),
+            crate::model::compact_value(now)
+        )];
+    };
+
+    let mut lines = Vec::new();
+    for (key, value) in was_map {
+        match now_map.get(key) {
+            None => lines.push(format!(
+                "{label}.{key}: recorded {}, absent now",
+                compact(value)
+            )),
+            Some(other) if other != value => lines.push(format!(
+                "{label}.{key}: recorded {}, got {}",
+                compact(value),
+                compact(other)
+            )),
+            Some(_) => {}
+        }
+    }
+    for key in now_map.keys() {
+        if !was_map.contains_key(key) {
+            lines.push(format!(
+                "{label}.{key}: not recorded, got {}",
+                compact(&now_map[key])
+            ));
+        }
+    }
+    lines
+}
+
+fn compact(value: &Value) -> String {
+    crate::model::compact_value(value)
 }
 
 fn spawn(

--- a/crates/noidroid-core/src/model.rs
+++ b/crates/noidroid-core/src/model.rs
@@ -340,6 +340,9 @@ pub struct Trajectory {
     pub outcome: Outcome,
     #[serde(default)]
     pub interventions: Vec<(u64, Intervention)>,
+    /// Recorded with automatic capture, so reconstructing it needs the same hooks.
+    #[serde(default)]
+    pub auto: bool,
 }
 
 /// Per-run, non-content observations: how each step was delivered and how long it took.

--- a/crates/noidroid-core/tests/auto_slice.rs
+++ b/crates/noidroid-core/tests/auto_slice.rs
@@ -1,0 +1,208 @@
+//! Automatic capture, against a real SDK.
+//!
+//! The adoption tax on this tool is the wrapping, so the claim worth testing is that
+//! a program containing *no* reference to noidroid can be recorded and replayed. The
+//! agent here imports `anthropic` and nothing else; the recording is driven entirely
+//! by the bootstrap that `noidroid run --auto` puts on `PYTHONPATH`.
+//!
+//! The proof is the second half: the local API is shut down before the replay, so
+//! anything that still works came out of the recording. And the agent reads
+//! `reply.content[0].text`, which only works if the SDK's own type was rebuilt rather
+//! than a dict handed back in its place.
+//!
+//! Skipped with a note when the Anthropic SDK is not installed.
+
+use std::fs;
+use std::net::TcpStream;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use noidroid_core::engine::{self, Mode, RunSpec};
+use noidroid_core::Repo;
+
+const PORT: u16 = 8789;
+
+const FAKE_API: &str = r#"
+import json, sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *a): pass
+    def do_POST(self):
+        body = json.dumps({
+            "id": "msg_local", "type": "message", "role": "assistant",
+            "model": "claude-opus-5", "stop_reason": "end_turn", "stop_sequence": None,
+            "content": [{"type": "text", "text": "four"}],
+            "usage": {"input_tokens": 11, "output_tokens": 2},
+        }).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+ThreadingHTTPServer(("127.0.0.1", int(sys.argv[1])), Handler).serve_forever()
+"#;
+
+/// Contains no reference to noidroid. That is the point.
+const AGENT: &str = r#"
+import os
+import anthropic
+
+client = anthropic.Anthropic(api_key="not-a-real-key", base_url=os.environ["FAKE_API"])
+reply = client.messages.create(
+    model="claude-opus-5",
+    max_tokens=16,
+    messages=[{"role": "user", "content": "what is two plus two?"}],
+)
+with open("answer.txt", "w", encoding="utf-8") as handle:
+    handle.write(f"{reply.content[0].text}:{type(reply).__name__}")
+"#;
+
+fn sdk_available() -> bool {
+    matches!(
+        Command::new("python3")
+            .args(["-c", "import anthropic"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status(),
+        Ok(s) if s.success()
+    )
+}
+
+fn client_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../clients/python")
+        .canonicalize()
+        .expect("the python client is part of the repository")
+}
+
+/// Where `sitecustomize.py` lives, the same way the CLI finds it.
+fn bootstrap_path() -> PathBuf {
+    client_path().join("noidroid/_bootstrap")
+}
+
+struct Api(Child);
+
+impl Api {
+    fn start(script: &Path) -> Api {
+        let mut child = Command::new("python3")
+            .arg(script)
+            .arg(PORT.to_string())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("the stand-in API should start");
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while Instant::now() < deadline {
+            if TcpStream::connect(("127.0.0.1", PORT)).is_ok() {
+                return Api(child);
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        let _ = child.kill();
+        let _ = child.wait();
+        panic!("the stand-in API never came up");
+    }
+
+    fn stop(mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while Instant::now() < deadline {
+            if TcpStream::connect(("127.0.0.1", PORT)).is_err() {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        panic!("the API refused to stop; the replay would prove nothing");
+    }
+}
+
+impl Drop for Api {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+#[test]
+fn a_program_with_no_noidroid_code_records_and_replays() {
+    if !sdk_available() {
+        eprintln!("SKIP: automatic capture test needs the anthropic SDK (pip install anthropic)");
+        return;
+    }
+
+    let dir = std::env::temp_dir().join(format!(
+        "noidroid-auto-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    fs::create_dir_all(&dir).unwrap();
+    let api_script = dir.join("fake_api.py");
+    fs::write(&api_script, FAKE_API).unwrap();
+    let agent = dir.join("agent.py");
+    fs::write(&agent, AGENT).unwrap();
+    assert!(
+        !AGENT.contains("import noidroid"),
+        "the agent must not be instrumented, or this test proves nothing"
+    );
+
+    let repo = Repo::open(&dir).unwrap();
+    let pythonpath = format!("{}:{}", bootstrap_path().display(), client_path().display());
+    let spec = |name: Option<&str>| RunSpec {
+        command: vec!["python3".into(), agent.display().to_string()],
+        launch_dir: dir.clone(),
+        name: name.map(str::to_string),
+        env: vec![
+            ("PYTHONPATH".into(), pythonpath.clone()),
+            ("FAKE_API".into(), format!("http://127.0.0.1:{PORT}")),
+        ],
+        auto: true,
+    };
+
+    // 1. Record against the live stand-in.
+    let api = Api::start(&api_script);
+    let recorded = engine::run(&repo, &spec(Some("auto-1")), Mode::Record, None)
+        .expect("recording an uninstrumented program should work")
+        .trajectory
+        .expect("a recording produces a trajectory");
+
+    let chain = repo.chain(&recorded).unwrap();
+    assert!(
+        chain
+            .iter()
+            .any(|(_, s)| s.action.summary().contains("anthropic")),
+        "the SDK call should have been captured: {:?}",
+        chain
+            .iter()
+            .map(|(_, s)| s.action.summary())
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(
+        fs::read_to_string(repo.workspace_dir("auto-1").join("answer.txt")).unwrap(),
+        "four:Message"
+    );
+
+    // 2. Take the API away. Anything that still works came out of the recording.
+    api.stop();
+
+    let report = engine::run(&repo, &spec(None), Mode::Replay, Some(&recorded))
+        .expect("replay should run to completion");
+    assert!(
+        report.faithful(),
+        "an uninstrumented program should replay exactly: {:?}",
+        report.divergences
+    );
+    assert_eq!(
+        report.delivery.get("executed").copied().unwrap_or(0),
+        0,
+        "nothing may be executed during a replay; the API is not even running"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}

--- a/crates/noidroid-core/tests/browser_slice.rs
+++ b/crates/noidroid-core/tests/browser_slice.rs
@@ -18,6 +18,19 @@ use noidroid_core::engine::{self, Mode, RunSpec};
 use noidroid_core::model::{Intervention, Provenance, Trajectory};
 use noidroid_core::Repo;
 
+/// One browser at a time.
+///
+/// Each test in this file launches Chromium and drives a real page; three at once on
+/// a loaded machine produces timeouts that look like product bugs and are not. Test
+/// binaries run their tests in parallel by default, so this is the guard.
+static BROWSER: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+fn one_at_a_time() -> std::sync::MutexGuard<'static, ()> {
+    BROWSER
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
 fn repo_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("../..")
@@ -173,6 +186,7 @@ impl Fixture {
                     },
                 ),
             ],
+            auto: false,
         }
     }
 
@@ -230,6 +244,7 @@ impl Drop for Fixture {
 
 #[test]
 fn a_browser_session_reconstructs_from_recorded_responses_alone() {
+    let _serial = one_at_a_time();
     if !browser_available() {
         eprintln!(
             "SKIP: browser adapter test needs playwright and chromium \
@@ -305,6 +320,7 @@ fn a_browser_session_reconstructs_from_recorded_responses_alone() {
 
 #[test]
 fn a_browser_branch_can_reach_a_different_outcome() {
+    let _serial = one_at_a_time();
     if !browser_available() {
         eprintln!("SKIP: browser adapter test needs playwright and chromium");
         return;
@@ -339,6 +355,7 @@ fn a_browser_branch_can_reach_a_different_outcome() {
 
 #[test]
 fn a_page_that_cannot_be_reproduced_makes_everything_after_it_unknown() {
+    let _serial = one_at_a_time();
     if !browser_available() {
         eprintln!("SKIP: browser adapter test needs playwright and chromium");
         return;

--- a/crates/noidroid-core/tests/llm_slice.rs
+++ b/crates/noidroid-core/tests/llm_slice.rs
@@ -57,6 +57,7 @@ impl Fixture {
                 "PYTHONPATH".into(),
                 self.root.join("clients/python").display().to_string(),
             )],
+            auto: false,
         }
     }
 

--- a/crates/noidroid-core/tests/tolerance_slice.rs
+++ b/crates/noidroid-core/tests/tolerance_slice.rs
@@ -1,0 +1,118 @@
+//! Volatile arguments.
+//!
+//! An argument that carries a clock or a request id changes every run without
+//! changing what the call means. Exact matching reports that as a divergence, which
+//! is technically true and practically useless: every replay of a real program would
+//! fail. This is the escape hatch, and the test is that it is actually needed.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use noidroid_core::engine::{self, DivergenceKind, Mode, RunSpec};
+use noidroid_core::Repo;
+
+/// Sends a timestamp with every call. `VOLATILE=1` declares it as not part of the
+/// call's identity.
+const AGENT: &str = r#"
+import os, time
+import noidroid
+
+nd = noidroid.connect()
+volatile = ["sent_at"] if os.environ.get("VOLATILE") == "1" else None
+
+nd.call(
+    "api.fetch",
+    lambda: {"ok": True},
+    args={"query": "flights", "sent_at": time.time_ns()},
+    volatile=volatile,
+)
+nd.finish("success", {})
+"#;
+
+struct Fixture {
+    dir: PathBuf,
+    repo: Repo,
+    agent: PathBuf,
+}
+
+impl Fixture {
+    fn new(tag: &str) -> Fixture {
+        let dir = std::env::temp_dir().join(format!(
+            "noidroid-tol-{tag}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        let agent = dir.join("agent.py");
+        fs::write(&agent, AGENT).unwrap();
+        let repo = Repo::open(&dir).unwrap();
+        Fixture { dir, repo, agent }
+    }
+
+    fn spec(&self, name: Option<&str>, volatile: bool) -> RunSpec {
+        let client = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../clients/python")
+            .canonicalize()
+            .unwrap();
+        RunSpec {
+            command: vec!["python3".into(), self.agent.display().to_string()],
+            launch_dir: self.dir.clone(),
+            name: name.map(str::to_string),
+            env: vec![
+                ("PYTHONPATH".into(), client.display().to_string()),
+                (
+                    "VOLATILE".into(),
+                    if volatile { "1".into() } else { "0".into() },
+                ),
+            ],
+            auto: false,
+        }
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.dir);
+    }
+}
+
+#[test]
+fn an_undeclared_clock_makes_every_replay_diverge() {
+    let f = Fixture::new("without");
+    let recorded = engine::run(&f.repo, &f.spec(Some("run-1"), false), Mode::Record, None)
+        .unwrap()
+        .trajectory
+        .unwrap();
+
+    let report = engine::run(&f.repo, &f.spec(None, false), Mode::Replay, Some(&recorded)).unwrap();
+
+    assert!(
+        report
+            .divergences
+            .iter()
+            .any(|d| d.kind == DivergenceKind::KeyMismatch),
+        "a timestamp in the arguments should be reported as a different call: {:?}",
+        report.divergences
+    );
+}
+
+#[test]
+fn declaring_it_volatile_makes_the_replay_faithful() {
+    let f = Fixture::new("with");
+    let recorded = engine::run(&f.repo, &f.spec(Some("run-1"), true), Mode::Record, None)
+        .unwrap()
+        .trajectory
+        .unwrap();
+
+    let report = engine::run(&f.repo, &f.spec(None, true), Mode::Replay, Some(&recorded)).unwrap();
+
+    assert!(
+        report.faithful(),
+        "the same call should identify as the same call: {:?}",
+        report.divergences
+    );
+    assert_eq!(report.reproduced, report.expected);
+}

--- a/crates/noidroid-core/tests/vertical_slice.rs
+++ b/crates/noidroid-core/tests/vertical_slice.rs
@@ -113,6 +113,7 @@ impl Fixture {
             launch_dir: self.dir.clone(),
             name: name.map(|n| n.to_string()),
             env: self.env(extra),
+            auto: false,
         }
     }
 


### PR DESCRIPTION
Research into why tools like this fail to get adopted returned one answer
repeatedly, and it was not the model: it was the wrapping. OpenTelemetry brands the
category "zero-code" and leads its Python docs with it; the first question on
Langfuse's Launch HN was "why do I need to import openai from langfuse"; a competing
proxy markets itself on being "zero-instrumentation" against tools shaped like this
one. Asking people to route their side effects through a client is the ceiling.

So `noidroid run --auto` puts a sitecustomize.py on the child's PYTHONPATH, which is
exactly what opentelemetry-instrument and ddtrace-run do, and patches the OpenAI and
Anthropic base clients. The hook is at `request` rather than at each endpoint,
because both SDKs are generated from one template and because the retry loop lives
inside it — so one patch covers every endpoint and a call that retried three times is
one recorded step rather than three.

Responses carry their own type through the recording, so a replay rebuilds the SDK's
object rather than handing back a dict; an agent doing `reply.content[0].text` keeps
working. Tested against the real Anthropic SDK, with the API shut down before the
replay, so anything that still works came out of the recording.

What this cannot do is make anything branchable. No patching can infer that a value
was a choice among alternatives, and that is what an intervention needs. So `decide()`
stays explicit and the honest shape of the tool is: zero code to record and replay,
two lines to branch. Both halves are now in the README, along with what automatic
capture misses — async, streaming, non-SDK HTTP, the clock, randomness — because a
replay tool that quietly drops an effect produces a trajectory that looks real.

Two smaller things from the same research. `volatile=` names arguments that change
every run without changing what a call means; without it an argument carrying a clock
makes every replay diverge, which is true and useless, and it is the single most
common complaint about cassette-style tools. And divergence reports now say what
actually differed field by field, and point out when the call the run wants is
recorded further along — usually meaning an interaction was inserted or removed
rather than changed. That was the top complaint about nock for a decade.

Browser tests now take a mutex: three Chromium instances launching at once produced a
timeout that looked like a product bug and was not.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
