### PR TITLE
feat(watch): record a real project, and put its files back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ how the package version relates to `STEP_VERSION`, the on-disk object format.
 
 ### Added
 
+- **`noidroid run --watch <dir>`** records a directory you already have — your actual
+  project — instead of a sandbox. It is read, never cleared. Snapshots skip `.git`,
+  `node_modules`, `target` and the like, extendable with `.noidroidignore`, because
+  hashing a real repository after every step is otherwise unaffordable.
+- **`noidroid restore <traj>@<step>`** puts the files back as they were at a
+  checkpoint. It snapshots what is currently there first and prints its address, so
+  **`noidroid checkout-tree <address> <dir>`** is the way back. This is the most
+  requested capability on coding-agent issue trackers by an order of magnitude, and it
+  is about files rather than conversation.
+- Reconstruction never touches a watched directory: replays and branches re-execute
+  the program, which writes files, so they always get their own copy.
+
+### Fixed
+
+- `materialize` pruned anything the recorded tree did not contain, without consulting
+  the ignore list that had kept it *out* of the recording. Restoring into a real
+  project would have deleted `.git`, `node_modules`, and the `.noidroid` directory
+  holding the trajectory being restored from — in that order. Found by running it, not
+  by reading it.
+
+### Added
+
 - **`noidroid run --auto`: zero-code recording.** A `sitecustomize.py` goes on the
   child's `PYTHONPATH` — the mechanism `opentelemetry-instrument` and `ddtrace-run`
   use — and patches the OpenAI and Anthropic base clients at `request`, below the

--- a/README.md
+++ b/README.md
@@ -169,6 +169,37 @@ See [`examples/browser_agent/`](examples/browser_agent/README.md). The adapter n
 
 ---
 
+## Rewinding the files, not the conversation
+
+The most-requested thing on coding-agent trackers is not undoing the chat — it is
+undoing what the agent did to your files. Point a recording at your actual project:
+
+```console
+$ noidroid run --watch . -- python3 my_agent.py
+    1 ● call edit.bump()      real  executed
+    2 ● call edit.break()     real  executed
+    3 ✘ finish failure        real  executed
+
+$ noidroid restore run-1@1
+restored /home/you/project to run-1@1
+  ~ src/app.py
+
+  the files that were here are saved; to put them back:
+    noidroid checkout-tree 18bb309cbb… /home/you/project
+```
+
+The watched directory is read, never cleared. `.git`, `node_modules`, `target` and
+friends are skipped — extend the list with a `.noidroidignore` — and, crucially, they
+are skipped when *restoring* too: what was never recorded is never removed. Restoring
+snapshots what is currently there first and prints its address, so the way back is one
+command and nothing is destroyed.
+
+Reconstructing is different from restoring. A replay or a branch re-executes your
+program, which writes files, so those always run in their own copy — never in the
+directory you are sitting in front of.
+
+---
+
 ## The viewer
 
 ```bash

--- a/crates/noidroid-cli/src/main.rs
+++ b/crates/noidroid-cli/src/main.rs
@@ -46,6 +46,10 @@ enum Command {
         /// replays; branching still needs a declared decision.
         #[arg(long)]
         auto: bool,
+        /// Record this directory instead of a sandbox — your actual project. It is
+        /// read, never written; `.noidroidignore` extends the skipped directories.
+        #[arg(long, value_name = "DIR")]
+        watch: Option<PathBuf>,
         /// The command to run, after `--`.
         #[arg(trailing_var_arg = true, allow_hyphen_values = true, required = true)]
         command: Vec<String>,
@@ -83,10 +87,24 @@ enum Command {
         #[arg(long, value_name = "TARGET=JSON")]
         simulate: Vec<String>,
     },
+    /// Put the files back as they were at a checkpoint, saving the current ones first.
+    Restore {
+        /// `<trajectory>@<step>`.
+        reference: String,
+        /// Where to restore. Defaults to the directory that was recorded.
+        #[arg(long, value_name = "DIR")]
+        into: Option<PathBuf>,
+    },
     /// Write the workspace as it was at a checkpoint into a directory.
     Checkout {
         /// `<trajectory>@<step>`.
         reference: String,
+        directory: PathBuf,
+    },
+    /// Write out any recorded directory by its address. The way back from `restore`.
+    CheckoutTree {
+        /// A tree address, as printed by `restore` or `show`.
+        address: String,
         directory: PathBuf,
     },
     /// Show the branch graph.
@@ -142,8 +160,9 @@ fn dispatch(cli: Cli) -> Result<ExitCode> {
         Command::Run {
             name,
             auto,
+            watch,
             command,
-        } => cmd_run(&repo, &cwd, name, auto, command),
+        } => cmd_run(&repo, &cwd, name, auto, watch, command),
         Command::Log { trajectory } => cmd_log(&repo, trajectory),
         Command::Show { reference } => cmd_show(&repo, &reference),
         Command::Replay { trajectory } => cmd_replay(&repo, &cwd, &trajectory),
@@ -161,6 +180,21 @@ fn dispatch(cli: Cli) -> Result<ExitCode> {
             reference,
             directory,
         } => cmd_checkout(&repo, &reference, &directory),
+        Command::Restore { reference, into } => cmd_restore(&repo, &reference, into),
+        Command::CheckoutTree { address, directory } => {
+            let digest = noidroid_core::Digest::from_hex(address);
+            let t = tree::read(&digest, &repo.store)?;
+            // Same rule as `restore`: what was never recorded is never removed.
+            let ignores = tree::Ignores::for_directory(&directory);
+            tree::materialize_with(&digest, &repo.store, &directory, &ignores)?;
+            println!(
+                "{} {} file(s) into {}",
+                shell("restored"),
+                t.entries.len(),
+                directory.display()
+            );
+            Ok(ExitCode::SUCCESS)
+        }
         Command::Tree => cmd_tree(&repo),
         Command::Diff { a, b } => cmd_diff(&repo, &a, &b),
         Command::Verify => cmd_verify(&repo),
@@ -211,6 +245,7 @@ fn cmd_run(
     cwd: &Path,
     name: Option<String>,
     auto: bool,
+    watch: Option<PathBuf>,
     command: Vec<String>,
 ) -> Result<ExitCode> {
     let name = name.unwrap_or_else(|| repo.next_name("run"));
@@ -219,6 +254,13 @@ fn cmd_run(
             "trajectory '{name}' already exists; history is append-only"
         )));
     }
+    let watch = match watch {
+        Some(dir) => Some(
+            dir.canonicalize()
+                .map_err(|e| Error::Refused(format!("--watch {}: {e}", dir.display())))?,
+        ),
+        None => None,
+    };
     let spec = RunSpec {
         command,
         launch_dir: cwd.to_path_buf(),
@@ -228,6 +270,7 @@ fn cmd_run(
         } else {
             Vec::new()
         },
+        watch,
         auto,
     };
     let report = engine::run(repo, &spec, Mode::Record, None)?;
@@ -378,6 +421,7 @@ fn cmd_replay(repo: &Repo, cwd: &Path, name: &str) -> Result<ExitCode> {
             Vec::new()
         },
         auto: t.auto,
+        watch: None,
     };
     let report = engine::run(repo, &spec, Mode::Replay, Some(&t))?;
     println!("{} {}", shell("REPLAY"), name);
@@ -487,6 +531,7 @@ fn cmd_branch(
             Vec::new()
         },
         auto: parent.auto,
+        watch: None,
     };
     let report = engine::run(
         repo,
@@ -569,6 +614,69 @@ fn cmd_checkout(repo: &Repo, reference: &str, directory: &Path) -> Result<ExitCo
     println!(
         "  {}",
         dim("this is the recorded workspace, not a restored process")
+    );
+    Ok(ExitCode::SUCCESS)
+}
+
+/// Put a checkpoint's files back, keeping a way out.
+///
+/// This is the one command that writes into a directory somebody is working in, so
+/// it snapshots what is there first and prints the address. Nothing is destroyed —
+/// the previous contents are in the store, addressed by content, and `checkout` will
+/// bring them back.
+fn cmd_restore(repo: &Repo, reference: &str, into: Option<PathBuf>) -> Result<ExitCode> {
+    let (name, index) = repo::parse_ref(reference);
+    let t = repo.load_trajectory(&name)?;
+    let chain = repo.chain(&t)?;
+    let index = index.unwrap_or(chain.len() as u64 - 1);
+    let (_, step) = chain
+        .get(index as usize)
+        .ok_or_else(|| Error::NotFound(format!("{name} has no step {index}")))?;
+
+    let target = match into.or_else(|| t.watched.clone()) {
+        Some(dir) => dir,
+        None => {
+            return Err(Error::Refused(format!(
+                "{name} was recorded in a sandbox, so there is nowhere obvious to put                  it back.\n  Give a directory: noidroid restore {reference} --into <dir>"
+            )))
+        }
+    };
+    if !target.is_dir() {
+        return Err(Error::NotFound(format!("{}", target.display())));
+    }
+
+    let ignores = tree::Ignores::for_directory(&target);
+    let before = tree::snapshot_with(&target, &repo.store, &ignores)?;
+    let recorded = tree::read(&step.state_root, &repo.store)?;
+    let current = tree::read(&before, &repo.store)?;
+    let changes = tree::diff(&current, &recorded);
+
+    tree::materialize_with(&step.state_root, &repo.store, &target, &ignores)?;
+
+    println!(
+        "{} {} to {name}@{index}",
+        shell("restored"),
+        target.display()
+    );
+    for (path, change) in changes.iter().take(12) {
+        let mark = match change {
+            tree::Change::Added => "+",
+            tree::Change::Removed => "-",
+            tree::Change::Modified => "~",
+        };
+        println!("  {mark} {path}");
+    }
+    if changes.len() > 12 {
+        println!("  {}", dim(&format!("… and {} more", changes.len() - 12)));
+    }
+    if changes.is_empty() {
+        println!("  {}", dim("already identical"));
+    }
+    println!(
+        "\n  {}\n    noidroid checkout-tree {} {}",
+        dim("the files that were here are saved; to put them back:"),
+        before,
+        target.display()
     );
     Ok(ExitCode::SUCCESS)
 }

--- a/crates/noidroid-cli/src/tui.rs
+++ b/crates/noidroid-cli/src/tui.rs
@@ -224,6 +224,7 @@ impl<'a> App<'a> {
             name: Some(label.clone()),
             env: Vec::new(),
             auto: false,
+            watch: None,
         };
         let outcome = engine::run(
             self.repo,
@@ -274,6 +275,7 @@ impl<'a> App<'a> {
             name: None,
             env: Vec::new(),
             auto: false,
+            watch: None,
         };
         match engine::run(self.repo, &spec, Mode::Replay, Some(&t)) {
             Ok(report) if report.faithful() => {

--- a/crates/noidroid-core/src/engine.rs
+++ b/crates/noidroid-core/src/engine.rs
@@ -147,6 +147,11 @@ pub struct RunSpec {
     /// Recorded with automatic capture. Carried onto the trajectory so that replaying
     /// it installs the same hooks; without them a replay would mediate nothing.
     pub auto: bool,
+    /// Record a directory the caller already has — a real project — instead of a
+    /// sandbox we made. Only ever honoured while *recording*: reconstructing into
+    /// somebody's working tree would overwrite the files they are sitting in front
+    /// of, so replays and branches always get their own copy.
+    pub watch: Option<PathBuf>,
 }
 
 /// Execute `spec` in `mode`, against `source` when reconstructing.
@@ -164,16 +169,29 @@ pub fn run(repo: &Repo, spec: &RunSpec, mode: Mode, source: Option<&Trajectory>)
     });
 
     // Every run gets its own workspace. A branch cannot reach into its parent's.
-    let workspace = match &mode {
-        Mode::Replay => repo
+    // The exception is a watched directory during a recording: that one belongs to
+    // the caller, so it is read, never cleared.
+    let watching = matches!(mode, Mode::Record) && spec.watch.is_some();
+    let workspace = match (&mode, &spec.watch) {
+        (Mode::Record, Some(dir)) => dir.clone(),
+        (Mode::Replay, _) => repo
             .tmp_dir()
             .join(format!("replay-{}", std::process::id())),
         _ => repo.workspace_dir(&run_label),
     };
-    if workspace.exists() {
-        fs::remove_dir_all(&workspace)?;
+    if !watching {
+        if workspace.exists() {
+            fs::remove_dir_all(&workspace)?;
+        }
+        fs::create_dir_all(&workspace)?;
     }
-    fs::create_dir_all(&workspace)?;
+    // A watched directory is somebody's project, so the parts that dwarf the source
+    // are skipped. A sandbox holds only what the run put there, so nothing is.
+    let ignores = if watching {
+        tree::Ignores::for_directory(&workspace)
+    } else {
+        tree::Ignores::none()
+    };
     // Reconstruction starts from the world the recording started from.
     if let Some(t) = source {
         let genesis: Step = repo.store.get_json(&t.genesis)?;
@@ -201,6 +219,7 @@ pub fn run(repo: &Repo, spec: &RunSpec, mode: Mode, source: Option<&Trajectory>)
         mode: &mode,
         recorded: &recorded,
         workspace: workspace.clone(),
+        ignores,
         parent: None,
         parent_provenance: Provenance::Real,
         index: 0,
@@ -306,6 +325,7 @@ pub fn run(repo: &Repo, spec: &RunSpec, mode: Mode, source: Option<&Trajectory>)
                 _ => Vec::new(),
             },
             auto: spec.auto,
+            watched: if watching { spec.watch.clone() } else { None },
         };
         repo.save_trajectory(&trajectory)?;
         repo.save_notes(&name, &session.notes)?;
@@ -321,6 +341,7 @@ struct Session<'a> {
     mode: &'a Mode,
     recorded: &'a [(Digest, Step)],
     workspace: PathBuf,
+    ignores: tree::Ignores,
     parent: Option<Digest>,
     parent_provenance: Provenance,
     index: u64,
@@ -870,7 +891,7 @@ impl<'a> Session<'a> {
         suppressed_side_effect: bool,
     ) -> Result<()> {
         let started = Instant::now();
-        let actual_root = tree::snapshot(&self.workspace, &self.repo.store)?;
+        let actual_root = tree::snapshot_with(&self.workspace, &self.repo.store, &self.ignores)?;
         let expected = self.recorded.get(self.index as usize).cloned();
 
         let state_root = match (&expected, suppressed_side_effect) {

--- a/crates/noidroid-core/src/model.rs
+++ b/crates/noidroid-core/src/model.rs
@@ -343,6 +343,10 @@ pub struct Trajectory {
     /// Recorded with automatic capture, so reconstructing it needs the same hooks.
     #[serde(default)]
     pub auto: bool,
+    /// The directory this run was recorded in, when it was the caller's own rather
+    /// than a sandbox. It is where `restore` puts the files back by default.
+    #[serde(default)]
+    pub watched: Option<std::path::PathBuf>,
 }
 
 /// Per-run, non-content observations: how each step was delivered and how long it took.

--- a/crates/noidroid-core/src/tree.rs
+++ b/crates/noidroid-core/src/tree.rs
@@ -15,17 +15,94 @@ use crate::hash::Digest;
 use crate::model::{Tree, TreeEntry};
 use crate::store::Store;
 
+/// Directories never worth hashing: derived, enormous, or ours.
+///
+/// Snapshotting a real project after every step is only affordable if the parts that
+/// dwarf the source are skipped. These are the defaults; a `.noidroidignore` file of
+/// newline-separated names extends them.
+pub const DEFAULT_IGNORES: &[&str] = &[
+    ".noidroid",
+    ".git",
+    ".hg",
+    ".svn",
+    "node_modules",
+    "target",
+    "__pycache__",
+    ".venv",
+    "venv",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    "dist",
+    "build",
+    ".next",
+    ".cache",
+];
+
+/// What to leave out of a snapshot.
+#[derive(Clone, Debug)]
+pub struct Ignores {
+    names: BTreeSet<String>,
+}
+
+impl Default for Ignores {
+    fn default() -> Self {
+        Ignores {
+            names: DEFAULT_IGNORES.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+}
+
+impl Ignores {
+    /// Nothing ignored. What a sandboxed workspace wants: it holds only what the run
+    /// put there, so skipping anything would lose recorded state.
+    pub fn none() -> Ignores {
+        Ignores {
+            names: BTreeSet::new(),
+        }
+    }
+
+    /// Defaults plus whatever `.noidroidignore` in `dir` lists, one name per line.
+    pub fn for_directory(dir: &Path) -> Ignores {
+        let mut ignores = Ignores::default();
+        if let Ok(text) = fs::read_to_string(dir.join(".noidroidignore")) {
+            for line in text.lines() {
+                let name = line.trim();
+                if !name.is_empty() && !name.starts_with('#') {
+                    ignores.names.insert(name.trim_matches('/').to_string());
+                }
+            }
+        }
+        ignores
+    }
+
+    fn skips(&self, name: &str) -> bool {
+        self.names.contains(name)
+    }
+}
+
 /// Hash a directory into the store, returning the tree address.
 ///
 /// Symlinks and special files are skipped: we would not be able to restore them
 /// faithfully, and silently hashing their targets would be a lie about coverage.
 pub fn snapshot(dir: &Path, store: &Store) -> Result<Digest> {
+    snapshot_with(dir, store, &Ignores::none())
+}
+
+/// Hash a directory, leaving out what `ignores` names.
+pub fn snapshot_with(dir: &Path, store: &Store, ignores: &Ignores) -> Result<Digest> {
     let mut entries = Vec::new();
-    collect(dir, dir, store, &mut entries)?;
+    collect(dir, dir, store, ignores, &mut entries)?;
     store.put_json(&Tree::new(entries))
 }
 
-fn collect(root: &Path, dir: &Path, store: &Store, out: &mut Vec<TreeEntry>) -> Result<()> {
+fn collect(
+    root: &Path,
+    dir: &Path,
+    store: &Store,
+    ignores: &Ignores,
+    out: &mut Vec<TreeEntry>,
+) -> Result<()> {
     if !dir.exists() {
         return Ok(());
     }
@@ -38,8 +115,15 @@ fn collect(root: &Path, dir: &Path, store: &Store, out: &mut Vec<TreeEntry>) -> 
         if meta.file_type().is_symlink() {
             continue;
         }
+        if path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| ignores.skips(n))
+        {
+            continue;
+        }
         if meta.is_dir() {
-            collect(root, &path, store, out)?;
+            collect(root, &path, store, ignores, out)?;
         } else if meta.is_file() {
             let rel = path
                 .strip_prefix(root)
@@ -66,11 +150,27 @@ fn collect(root: &Path, dir: &Path, store: &Store, out: &mut Vec<TreeEntry>) -> 
 /// deleted inode, and every relative path it touched afterwards would silently land
 /// in a directory nobody can see.
 pub fn materialize(digest: &Digest, store: &Store, dir: &Path) -> Result<()> {
+    materialize_with(digest, store, dir, &Ignores::none())
+}
+
+/// Write a recorded tree into a directory, leaving anything `ignores` names alone.
+///
+/// This matters more than it sounds. Restoring into somebody's project means pruning
+/// what the recording does not contain — and the recording deliberately never
+/// contained `.git`, `node_modules`, or our own `.noidroid`. Pruning without the same
+/// list deletes the repository, the dependencies, and the trajectory being restored
+/// from, in that order.
+pub fn materialize_with(
+    digest: &Digest,
+    store: &Store,
+    dir: &Path,
+    ignores: &Ignores,
+) -> Result<()> {
     let tree: Tree = store.get_json(digest)?;
     fs::create_dir_all(dir)?;
 
     let wanted: BTreeSet<PathBuf> = tree.entries.iter().map(|e| dir.join(&e.path)).collect();
-    prune(dir, &wanted)?;
+    prune(dir, &wanted, ignores)?;
 
     for entry in &tree.entries {
         let path = dir.join(&entry.path);
@@ -85,13 +185,22 @@ pub fn materialize(digest: &Digest, store: &Store, dir: &Path) -> Result<()> {
 
 /// Remove everything under `dir` that the tree does not contain, leaving `dir` itself
 /// in place. Returns whether the directory ended up empty.
-fn prune(dir: &Path, wanted: &BTreeSet<PathBuf>) -> Result<bool> {
+fn prune(dir: &Path, wanted: &BTreeSet<PathBuf>, ignores: &Ignores) -> Result<bool> {
     let mut empty = true;
     for entry in fs::read_dir(dir)? {
         let path = entry?.path();
+        if path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| ignores.skips(n))
+        {
+            // Never recorded, so never removed.
+            empty = false;
+            continue;
+        }
         let meta = fs::symlink_metadata(&path)?;
         if meta.is_dir() && !meta.file_type().is_symlink() {
-            if prune(&path, wanted)? {
+            if prune(&path, wanted, ignores)? {
                 fs::remove_dir(&path)?;
             } else {
                 empty = false;

--- a/crates/noidroid-core/tests/auto_slice.rs
+++ b/crates/noidroid-core/tests/auto_slice.rs
@@ -163,6 +163,7 @@ fn a_program_with_no_noidroid_code_records_and_replays() {
             ("FAKE_API".into(), format!("http://127.0.0.1:{PORT}")),
         ],
         auto: true,
+        watch: None,
     };
 
     // 1. Record against the live stand-in.

--- a/crates/noidroid-core/tests/browser_slice.rs
+++ b/crates/noidroid-core/tests/browser_slice.rs
@@ -187,6 +187,7 @@ impl Fixture {
                 ),
             ],
             auto: false,
+            watch: None,
         }
     }
 

--- a/crates/noidroid-core/tests/llm_slice.rs
+++ b/crates/noidroid-core/tests/llm_slice.rs
@@ -58,6 +58,7 @@ impl Fixture {
                 self.root.join("clients/python").display().to_string(),
             )],
             auto: false,
+            watch: None,
         }
     }
 

--- a/crates/noidroid-core/tests/tolerance_slice.rs
+++ b/crates/noidroid-core/tests/tolerance_slice.rs
@@ -69,6 +69,7 @@ impl Fixture {
                 ),
             ],
             auto: false,
+            watch: None,
         }
     }
 }

--- a/crates/noidroid-core/tests/vertical_slice.rs
+++ b/crates/noidroid-core/tests/vertical_slice.rs
@@ -114,6 +114,7 @@ impl Fixture {
             name: name.map(|n| n.to_string()),
             env: self.env(extra),
             auto: false,
+            watch: None,
         }
     }
 

--- a/crates/noidroid-core/tests/watch_slice.rs
+++ b/crates/noidroid-core/tests/watch_slice.rs
@@ -1,0 +1,171 @@
+//! Recording a directory the caller already has, and putting it back.
+//!
+//! The loudest thing people ask coding agents for is not rewinding the conversation —
+//! it is rewinding the *files*. That works only if two things hold: a snapshot skips
+//! the parts of a real project that dwarf the source, and restoring never removes
+//! what was never recorded. The second is the dangerous one: pruning to a recorded
+//! tree without the ignore list deletes `.git`, the dependencies, and the trajectory
+//! being restored from.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use noidroid_core::engine::{self, Mode, RunSpec};
+use noidroid_core::{tree, Repo};
+
+/// Edits a file twice, leaving it broken.
+const AGENT: &str = r#"
+import pathlib
+import noidroid
+
+nd = noidroid.connect()
+nd.call("edit.bump",
+        lambda: pathlib.Path("src/app.py").write_text('VERSION = "2.0"\n'),
+        effect="write")
+nd.call("edit.break",
+        lambda: pathlib.Path("src/app.py").write_text('VERSION = broken\n'),
+        effect="write")
+nd.finish("failure", {"reason": "left it broken"})
+"#;
+
+struct Project {
+    dir: PathBuf,
+    repo: Repo,
+}
+
+impl Project {
+    fn new() -> Project {
+        let dir = std::env::temp_dir().join(format!(
+            "noidroid-watch-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(dir.join("src")).unwrap();
+        // The things a real project is full of and a recording must not carry.
+        fs::create_dir_all(dir.join(".git")).unwrap();
+        fs::write(dir.join(".git/HEAD"), b"ref: refs/heads/main\n").unwrap();
+        fs::create_dir_all(dir.join("node_modules")).unwrap();
+        fs::write(dir.join("node_modules/big.bin"), vec![b'x'; 4096]).unwrap();
+        fs::write(dir.join("src/app.py"), b"VERSION = \"1.0\"\n").unwrap();
+        fs::write(dir.join("agent.py"), AGENT).unwrap();
+
+        let repo = Repo::open(&dir).unwrap();
+        Project { dir, repo }
+    }
+
+    fn spec(&self) -> RunSpec {
+        let client = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../clients/python")
+            .canonicalize()
+            .unwrap();
+        RunSpec {
+            command: vec![
+                "python3".into(),
+                self.dir.join("agent.py").display().to_string(),
+            ],
+            launch_dir: self.dir.clone(),
+            name: Some("edit-1".into()),
+            env: vec![("PYTHONPATH".into(), client.display().to_string())],
+            auto: false,
+            watch: Some(self.dir.clone()),
+        }
+    }
+
+    fn app(&self) -> String {
+        fs::read_to_string(self.dir.join("src/app.py")).unwrap()
+    }
+}
+
+impl Drop for Project {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.dir);
+    }
+}
+
+#[test]
+fn a_real_project_can_be_recorded_and_put_back() {
+    let project = Project::new();
+
+    let recorded = engine::run(&project.repo, &project.spec(), Mode::Record, None)
+        .expect("recording a watched directory should work")
+        .trajectory
+        .expect("a recording produces a trajectory");
+
+    // The run left the file broken, and the directory it worked in is its own.
+    assert_eq!(project.app(), "VERSION = broken\n");
+    assert_eq!(recorded.watched.as_deref(), Some(project.dir.as_path()));
+
+    // Nothing enormous or derived was hashed.
+    let chain = project.repo.chain(&recorded).unwrap();
+    for (_, step) in &chain {
+        let snapshot = tree::read(&step.state_root, &project.repo.store).unwrap();
+        for entry in &snapshot.entries {
+            assert!(
+                !entry.path.starts_with(".git/")
+                    && !entry.path.starts_with("node_modules/")
+                    && !entry.path.starts_with(".noidroid/"),
+                "a watched snapshot must skip derived directories, found {}",
+                entry.path
+            );
+        }
+    }
+
+    // Step 1 is the good edit. Put the files back to it, keeping a way out.
+    let good = &chain[1].1;
+    let ignores = tree::Ignores::for_directory(&project.dir);
+    let before = tree::snapshot_with(&project.dir, &project.repo.store, &ignores).unwrap();
+    tree::materialize_with(
+        &good.state_root,
+        &project.repo.store,
+        &project.dir,
+        &ignores,
+    )
+    .unwrap();
+
+    assert_eq!(project.app(), "VERSION = \"2.0\"\n");
+
+    // The dangerous part: restoring must not have removed what was never recorded.
+    assert!(
+        project.dir.join(".git/HEAD").exists(),
+        "restore deleted the git repository"
+    );
+    assert!(
+        project.dir.join("node_modules/big.bin").exists(),
+        "restore deleted the dependencies"
+    );
+    assert!(
+        project.repo.load_trajectory("edit-1").is_ok(),
+        "restore deleted the trajectory it was restoring from"
+    );
+
+    // And the way out actually leads back.
+    tree::materialize_with(&before, &project.repo.store, &project.dir, &ignores).unwrap();
+    assert_eq!(project.app(), "VERSION = broken\n");
+}
+
+#[test]
+fn a_reconstruction_never_touches_the_watched_directory() {
+    let project = Project::new();
+    let recorded = engine::run(&project.repo, &project.spec(), Mode::Record, None)
+        .unwrap()
+        .trajectory
+        .unwrap();
+    fs::write(project.dir.join("src/app.py"), b"edited by hand\n").unwrap();
+
+    let mut spec = project.spec();
+    spec.name = None;
+    let report = engine::run(&project.repo, &spec, Mode::Replay, Some(&recorded))
+        .expect("replay should run to completion");
+    assert!(report.faithful(), "{:?}", report.divergences);
+
+    // A replay re-executes the program, which writes files. It must do that in its
+    // own copy — the caller is sitting in front of this directory.
+    assert_eq!(
+        project.app(),
+        "edited by hand\n",
+        "a reconstruction wrote into the watched directory"
+    );
+}


### PR DESCRIPTION
The loudest request on coding-agent trackers is not undoing the conversation, it is
undoing what the agent did to the files — openai/codex#11626 has 203 reactions and
its top comment is "I don't care about the damn conversation rewind, it's important
that i can revert the changes agent made"; anthropics/claude-code#353 has 178. The
trajectory model already snapshots a workspace into a content-addressed tree at every
step, so most of this was sitting there unused behind the assumption that the
workspace is a sandbox we made.

`--watch <dir>` records a directory the caller already has. It is read, never
cleared, and snapshots skip `.git`, `node_modules`, `target` and friends, extendable
with `.noidroidignore` — hashing a real repository after every step is otherwise
unaffordable. `restore` puts the files back to a checkpoint, and because that is the
one command that writes into a directory somebody is working in, it snapshots what is
there first and prints the address; `checkout-tree` is the way back, so nothing is
destroyed.

Reconstruction stays separate from restoring. A replay or branch re-executes the
program, which writes files, so those always run in their own copy. A test asserts a
replay leaves a hand-edit in the watched directory untouched.

Fixes a bug that running it found immediately and reading it would not have.
`materialize` pruned everything the recorded tree did not contain, without consulting
the ignore list that had kept those paths *out* of the recording in the first place.
Restoring into a real project therefore deleted `.git`, then `node_modules`, then the
`.noidroid` directory holding the trajectory being restored from — which is also why
the first attempt failed halfway through with a missing object. What was never
recorded is now never removed.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
