### PR TITLE
feat(bisect): find which decision actually caused the outcome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ how the package version relates to `STEP_VERSION`, the on-disk object format.
 
 ### Added
 
+- **`noidroid bisect <trajectory>`** — automatic causal attribution. Every recorded
+  decision is re-run from its own checkpoint with a different choice, and the earliest
+  one that changes the outcome is reported. A trace cannot answer which step *caused*
+  a failure, because that is a question about a world that did not happen; the
+  published baseline for judging it from a transcript is around 14% accurate. Each
+  probe is a real trajectory that can be opened, diffed and replayed, and the prefix
+  of each costs nothing because it is served from the recording. When nothing flips it
+  says so and exits non-zero, rather than naming a plausible step and calling it the
+  cause.
+
+### Added
+
 - **`noidroid run --watch <dir>`** records a directory you already have — your actual
   project — instead of a sandbox. It is read, never cleared. Snapshots skip `.git`,
   `node_modules`, `target` and the like, extendable with `.noidroidignore`, because

--- a/README.md
+++ b/README.md
@@ -169,6 +169,40 @@ See [`examples/browser_agent/`](examples/browser_agent/README.md). The adapter n
 
 ---
 
+## Which step actually caused it
+
+A trace tells you what happened. It cannot tell you which step *caused* it, because
+that is a question about a world that did not occur — and judging it from the
+transcript is close to guessing: the published baseline for attributing an agent
+failure to a step is around 14% accurate.
+
+A branchable trajectory can settle it by experiment.
+
+```console
+$ noidroid bisect run-1
+BISECT run-1 (ended failure)
+  probing 1 alternative(s) across 1 decision(s)
+
+  @2 tool_choice_1 = "lookup_charges"   success  ← flips it
+
+  earliest flip: run-1@2, choosing "lookup_charges" for tool_choice_1
+    noidroid diff run-1 run-1~2~lookup_charges
+  everything after this step is downstream of a choice already made
+```
+
+Every recorded decision is re-run from its own checkpoint with a different choice, and
+the earliest one that changes the outcome is the one worth looking at. In this example
+the decision was the model's choice of tool, which the agent never declared — the model
+adapter did, so this needed no instrumentation at all.
+
+Each probe is a real trajectory you can open, diff and replay. Up to the divergence
+point they cost nothing, because that part is served from the recording.
+
+When nothing flips, it says so and exits non-zero, rather than picking a plausible
+step and calling it the cause.
+
+---
+
 ## Rewinding the files, not the conversation
 
 The most-requested thing on coding-agent trackers is not undoing the chat — it is
@@ -268,6 +302,8 @@ noidroid diff run-1 alt-1
 | `noidroid replay <traj>` | re-derive a trajectory and check it still hashes the same |
 | `noidroid branch <traj>@<step>` | diverge: `--decide`, `--result` or `--fail` |
 | `noidroid checkout <traj>@<step> <dir>` | write out the workspace as it was |
+| `noidroid bisect <traj>` | find which decision, changed, would have flipped the outcome |
+| `noidroid restore <traj>@<step>` | put the files back as they were, keeping a way out |
 | `noidroid tree` · `diff` · `verify` | the branch graph, a comparison, a store integrity check |
 | `noidroid tui` | browse trajectories and explore from a checkpoint, interactively |
 | `noidroid stand` | 「 ゴ ゴ ゴ ゴ 」 |

--- a/crates/noidroid-cli/src/main.rs
+++ b/crates/noidroid-cli/src/main.rs
@@ -107,6 +107,20 @@ enum Command {
         address: String,
         directory: PathBuf,
     },
+    /// Find which decision, changed, would have flipped the outcome.
+    Bisect {
+        /// The trajectory to explain.
+        trajectory: String,
+        /// The outcome to search for. Defaults to anything other than the original's.
+        #[arg(long)]
+        goal: Option<String>,
+        /// Stop after the first decision that flips it.
+        #[arg(long)]
+        first: bool,
+        /// Stated-simulated value for an irreversible effect, as for `branch`.
+        #[arg(long, value_name = "TARGET=JSON")]
+        simulate: Vec<String>,
+    },
     /// Show the branch graph.
     Tree,
     /// Compare two trajectories.
@@ -195,6 +209,12 @@ fn dispatch(cli: Cli) -> Result<ExitCode> {
             );
             Ok(ExitCode::SUCCESS)
         }
+        Command::Bisect {
+            trajectory,
+            goal,
+            first,
+            simulate,
+        } => cmd_bisect(&repo, &cwd, &trajectory, goal, first, simulate),
         Command::Tree => cmd_tree(&repo),
         Command::Diff { a, b } => cmd_diff(&repo, &a, &b),
         Command::Verify => cmd_verify(&repo),
@@ -679,6 +699,202 @@ fn cmd_restore(repo: &Repo, reference: &str, into: Option<PathBuf>) -> Result<Ex
         target.display()
     );
     Ok(ExitCode::SUCCESS)
+}
+
+/// Which decision, taken differently, would have changed how this ended?
+///
+/// A trace tells you what happened; it cannot tell you which step *caused* it,
+/// because that is a question about a world that did not occur. Judging it from the
+/// transcript is what people do today and it is close to guessing — the published
+/// baseline for attributing an agent failure to a step is around 14% accurate.
+///
+/// An immutable, branchable trajectory can answer it by experiment instead: take each
+/// recorded decision, re-run from exactly that checkpoint with a different choice, and
+/// see which one flips the outcome. The earliest such decision is the one worth
+/// looking at, because everything after it is downstream of a choice that was already
+/// wrong.
+///
+/// The cost is one re-execution per alternative. Up to the divergence point that is
+/// served from the recording and free; past it, it is a real run.
+fn cmd_bisect(
+    repo: &Repo,
+    cwd: &Path,
+    name: &str,
+    goal: Option<String>,
+    stop_at_first: bool,
+    simulate: Vec<String>,
+) -> Result<ExitCode> {
+    let parent = repo.load_trajectory(name)?;
+    let chain = repo.chain(&parent)?;
+    let original = parent.outcome.status.clone();
+
+    let mut simulated = BTreeMap::new();
+    for entry in &simulate {
+        let (target, value) = split_kv(entry)?;
+        simulated.insert(target, parse_value(&value));
+    }
+
+    // Every recorded decision that had an alternative to take.
+    let mut probes: Vec<(u64, String, Value)> = Vec::new();
+    for (_, step) in &chain {
+        let Action::Decide {
+            name: decision,
+            options,
+            choice,
+        } = &step.action
+        else {
+            continue;
+        };
+        let Some(items) = options.as_array() else {
+            continue;
+        };
+        for option in items {
+            if option != choice {
+                probes.push((step.index, decision.clone(), option.clone()));
+            }
+        }
+    }
+
+    println!(
+        "{} {} {}",
+        shell("BISECT"),
+        name,
+        dim(&format!("(ended {original})"))
+    );
+    if probes.is_empty() {
+        println!(
+            "  {}",
+            dim("no recorded decision had an alternative — declare choices with                  nd.decide() to make them explorable")
+        );
+        return Ok(ExitCode::SUCCESS);
+    }
+    println!(
+        "  {}",
+        dim(&format!(
+            "probing {} alternative(s) across {} decision(s)",
+            probes.len(),
+            probes
+                .iter()
+                .map(|(i, _, _)| *i)
+                .collect::<std::collections::BTreeSet<_>>()
+                .len()
+        ))
+    );
+    println!();
+
+    let mut flipped: Option<(u64, String, Value, String)> = None;
+    for (at, decision, option) in probes {
+        let label = format!("{name}~{at}~{}", slug(&option));
+        if repo.has_trajectory(&label) {
+            continue;
+        }
+        let spec = RunSpec {
+            command: parent.command.clone(),
+            launch_dir: cwd.to_path_buf(),
+            name: Some(label.clone()),
+            env: if parent.auto {
+                auto_capture_env()?
+            } else {
+                Vec::new()
+            },
+            auto: parent.auto,
+            watch: None,
+        };
+        let report = engine::run(
+            repo,
+            &spec,
+            Mode::Branch {
+                at,
+                intervention: Intervention::ReplaceDecision {
+                    name: decision.clone(),
+                    value: option.clone(),
+                },
+                simulate: simulated.clone(),
+            },
+            Some(&parent),
+        )?;
+
+        let outcome = match &report.trajectory {
+            Some(branch) => branch.outcome.status.clone(),
+            None => "unreachable".to_string(),
+        };
+        let flips = match &goal {
+            Some(wanted) => &outcome == wanted,
+            None => outcome != original && outcome != "unreachable",
+        };
+        println!(
+            "  @{at} {} = {:<18} {}{}",
+            dim(&decision),
+            noidroid_core::model::compact_value(&option),
+            status_text(&outcome),
+            if flips {
+                format!("  {}", ok("← flips it"))
+            } else {
+                String::new()
+            }
+        );
+        // `is_none_or` would read better but is newer than our stated MSRV.
+        let earlier = match &flipped {
+            Some((seen, ..)) => at < *seen,
+            None => true,
+        };
+        if flips && earlier {
+            flipped = Some((at, decision.clone(), option.clone(), label.clone()));
+        }
+        if flips && stop_at_first {
+            break;
+        }
+    }
+
+    match flipped {
+        Some((at, decision, option, label)) => {
+            println!();
+            println!(
+                "  {} {}@{at}, choosing {} for {}",
+                shell("earliest flip:"),
+                name,
+                noidroid_core::model::compact_value(&option),
+                decision
+            );
+            println!("    noidroid diff {name} {label}");
+            println!(
+                "  {}",
+                dim("everything after this step is downstream of a choice already made")
+            );
+            Ok(ExitCode::SUCCESS)
+        }
+        None => {
+            println!();
+            println!(
+                "  {}",
+                warn("no single decision changed the outcome on its own")
+            );
+            println!(
+                "  {}",
+                dim("the cause is earlier than any declared decision, outside them, or                      needs more than one changed at once")
+            );
+            Ok(ExitCode::from(1))
+        }
+    }
+}
+
+/// A filesystem- and eye-friendly name for a chosen value.
+fn slug(value: &Value) -> String {
+    let raw = match value {
+        Value::String(s) => s.clone(),
+        other => other.to_string(),
+    };
+    let cleaned: String = raw
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    cleaned.trim_matches('-').chars().take(24).collect()
 }
 
 fn cmd_tree(repo: &Repo) -> Result<ExitCode> {

--- a/crates/noidroid-cli/tests/bisect.rs
+++ b/crates/noidroid-cli/tests/bisect.rs
@@ -1,0 +1,115 @@
+//! `noidroid bisect`, through the real binary.
+//!
+//! The question a trace cannot answer is which step *caused* the outcome, because
+//! that is a question about a world that did not happen. Judging it from the
+//! transcript is what tooling does today and it is close to guessing. An immutable,
+//! branchable trajectory can settle it by experiment, and this checks that it does.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("the workspace root is two levels up")
+}
+
+fn workdir(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "noidroid-bisect-{tag}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn noidroid(dir: &Path, args: &[&str]) -> (String, bool) {
+    let root = repo_root();
+    let output = Command::new(env!("CARGO_BIN_EXE_noidroid"))
+        .args(args)
+        .current_dir(dir)
+        .env("PYTHONPATH", root.join("clients/python"))
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("the binary should run");
+    let mut text = String::from_utf8_lossy(&output.stdout).to_string();
+    text.push_str(&String::from_utf8_lossy(&output.stderr));
+    (text, output.status.success())
+}
+
+#[test]
+fn bisect_names_the_decision_that_caused_the_failure() {
+    let dir = workdir("llm");
+    let agent = repo_root().join("examples/llm_agent/agent.py");
+
+    let (recorded, ok) = noidroid(&dir, &["run", "--", "python3", agent.to_str().unwrap()]);
+    assert!(ok, "recording failed: {recorded}");
+    assert!(
+        recorded.contains("failure"),
+        "the example should fail: {recorded}"
+    );
+
+    let (report, ok) = noidroid(&dir, &["bisect", "run-1"]);
+    assert!(ok, "bisect should find a flip: {report}");
+
+    // The model reached for the wrong tool. Nothing in the agent declared that choice
+    // — the model adapter did — so this is attribution with no extra instrumentation.
+    assert!(
+        report.contains("tool_choice_1"),
+        "the model's tool choice should have been probed: {report}"
+    );
+    assert!(
+        report.contains("flips it"),
+        "changing the tool should flip the outcome: {report}"
+    );
+    assert!(
+        report.contains("earliest flip"),
+        "the earliest causal decision should be named: {report}"
+    );
+
+    // And the counterfactual it found is a real trajectory you can go and read.
+    let (tree, _) = noidroid(&dir, &["tree"]);
+    assert!(
+        tree.contains("run-1~2~lookup_charges"),
+        "the flipping branch should be kept: {tree}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn bisect_says_so_when_nothing_flips() {
+    let dir = workdir("nothing");
+    let agent = dir.join("agent.py");
+    // One declared decision, but the outcome does not depend on it.
+    std::fs::write(
+        &agent,
+        r#"
+import noidroid
+nd = noidroid.connect()
+nd.decide("irrelevant", options=["a", "b"], choice="a")
+nd.finish("failure", {"reason": "always"})
+"#,
+    )
+    .unwrap();
+
+    let (_, ok) = noidroid(&dir, &["run", "--", "python3", agent.to_str().unwrap()]);
+    assert!(ok);
+
+    let (report, ok) = noidroid(&dir, &["bisect", "run-1"]);
+    assert!(
+        !ok,
+        "finding no cause is a non-zero exit, not a silent success: {report}"
+    );
+    assert!(
+        report.contains("no single decision changed the outcome"),
+        "it should say plainly that it found nothing: {report}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
A trace says what happened. It cannot say which step *caused* it, because that is a
question about a world that did not occur, and the published baseline for judging it
from a transcript is around 14% accurate. This is the one question an immutable
branchable trajectory is uniquely able to answer, and as far as the research went,
nobody ships it.

`noidroid bisect` re-runs every recorded decision from its own checkpoint with a
different choice and reports the earliest one that changes the outcome. Everything
after that step is downstream of a choice already made, which is why the earliest one
is the one worth reading.

It costs one re-execution per alternative, but only past the divergence point: the
prefix is served from the recording, so the expensive half of each probe is free. And
each probe is left behind as a real trajectory that can be opened, diffed and replayed
— the answer is not a claim, it is a run you can go and look at.

On the model example it identifies the tool choice, which the agent never declared:
the model adapter declared it, so attribution needed no instrumentation at all.

When nothing flips, it says so and exits non-zero rather than naming a plausible step
and calling it the cause. There is a test for that case specifically, because a tool
that always produces an answer to this question is worse than one that admits it
found none.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
