### PR TITLE
feat(bundle): make a trajectory something you can commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ how the package version relates to `STEP_VERSION`, the on-disk object format.
 
 ### Added
 
+- **`noidroid export` / `noidroid import`** — a trajectory and everything it reaches
+  as one committable JSON file. A recording is only a regression test if it can leave
+  the machine it was made on, and `.noidroid/` is gitignored and machine-local. The
+  bundle stays readable so a reviewer sees what the agent said in the diff, and every
+  address is re-hashed on import: a bundle arrives from elsewhere, so its claim that
+  an address holds given bytes is checked rather than believed.
+
 - **`noidroid bisect <trajectory>`** — automatic causal attribution. Every recorded
   decision is re-run from its own checkpoint with a different choice, and the earliest
   one that changes the outcome is reported. A trace cannot answer which step *caused*
@@ -34,6 +41,11 @@ how the package version relates to `STEP_VERSION`, the on-disk object format.
   the program, which writes files, so they always get their own copy.
 
 ### Fixed
+
+- Replaying a trajectory whose program is not present reported that the process never
+  connected, which is true and unhelpful. It now says that a trajectory records what a
+  program did rather than the program itself — the first thing anyone hits after
+  importing a bundle.
 
 - `materialize` pruned anything the recorded tree did not contain, without consulting
   the ignore list that had kept it *out* of the recording. Restoring into a real

--- a/README.md
+++ b/README.md
@@ -169,6 +169,30 @@ See [`examples/browser_agent/`](examples/browser_agent/README.md). The adapter n
 
 ---
 
+## Committing a failure
+
+A recording is only a regression test if it can leave the machine it was made on.
+`.noidroid/` is gitignored and full of sharded object files; `export` puts the
+trajectory and everything it reaches into one file you can commit.
+
+```console
+$ noidroid export run-1
+exported run-1 → run-1.noidroid.json (9 object(s), 4.6 KB)
+
+$ noidroid import run-1.noidroid.json     # anywhere, empty store
+imported run-1 (5 step(s), 9 object(s), every address re-checked)
+```
+
+The file is readable JSON, so a reviewer can see what the agent actually said in the
+diff. Every address is re-hashed on the way in — a bundle arrives from somewhere
+else, so its claim that an address holds given bytes is checked, not believed, and a
+tampered one is refused.
+
+What a bundle carries is the recording, not the program. Replaying it needs the
+checkout it was recorded from, and says so plainly if it is missing.
+
+---
+
 ## Which step actually caused it
 
 A trace tells you what happened. It cannot tell you which step *caused* it, because
@@ -304,6 +328,7 @@ noidroid diff run-1 alt-1
 | `noidroid checkout <traj>@<step> <dir>` | write out the workspace as it was |
 | `noidroid bisect <traj>` | find which decision, changed, would have flipped the outcome |
 | `noidroid restore <traj>@<step>` | put the files back as they were, keeping a way out |
+| `noidroid export` · `import` | move a trajectory between machines, as one committable file |
 | `noidroid tree` · `diff` · `verify` | the branch graph, a comparison, a store integrity check |
 | `noidroid tui` | browse trajectories and explore from a checkpoint, interactively |
 | `noidroid stand` | 「 ゴ ゴ ゴ ゴ 」 |

--- a/crates/noidroid-cli/src/main.rs
+++ b/crates/noidroid-cli/src/main.rs
@@ -8,6 +8,7 @@ use std::process::ExitCode;
 use clap::{Parser, Subcommand};
 use serde_json::Value;
 
+use noidroid_core::bundle;
 use noidroid_core::engine::{self, Mode, Report, RunSpec};
 use noidroid_core::model::{Action, Intervention, Provenance, Step, Trajectory};
 use noidroid_core::repo::{self, Repo};
@@ -121,6 +122,20 @@ enum Command {
         #[arg(long, value_name = "TARGET=JSON")]
         simulate: Vec<String>,
     },
+    /// Write a trajectory and everything it reaches to one committable file.
+    Export {
+        trajectory: String,
+        /// Where to write it. Defaults to `<trajectory>.noidroid.json`.
+        #[arg(short, long)]
+        output: Option<PathBuf>,
+    },
+    /// Read a trajectory back in from a bundle.
+    Import {
+        file: PathBuf,
+        /// Import under a different name.
+        #[arg(long = "as", value_name = "NAME")]
+        rename: Option<String>,
+    },
     /// Show the branch graph.
     Tree,
     /// Compare two trajectories.
@@ -215,6 +230,8 @@ fn dispatch(cli: Cli) -> Result<ExitCode> {
             first,
             simulate,
         } => cmd_bisect(&repo, &cwd, &trajectory, goal, first, simulate),
+        Command::Export { trajectory, output } => cmd_export(&repo, &trajectory, output),
+        Command::Import { file, rename } => cmd_import(&repo, &file, rename.as_deref()),
         Command::Tree => cmd_tree(&repo),
         Command::Diff { a, b } => cmd_diff(&repo, &a, &b),
         Command::Verify => cmd_verify(&repo),
@@ -895,6 +912,68 @@ fn slug(value: &Value) -> String {
         })
         .collect();
     cleaned.trim_matches('-').chars().take(24).collect()
+}
+
+/// Make a recording into something you can commit.
+///
+/// A trajectory is only a regression test if it can leave the machine it was recorded
+/// on. `.noidroid/` is gitignored and full of sharded object files; a bundle is one
+/// file holding the trajectory and everything it reaches.
+fn cmd_export(repo: &Repo, name: &str, output: Option<PathBuf>) -> Result<ExitCode> {
+    let bundle = bundle::export(repo, name)?;
+    let path = output.unwrap_or_else(|| PathBuf::from(format!("{name}.noidroid.json")));
+    let encoded = serde_json::to_vec_pretty(&bundle)?;
+    std::fs::write(&path, &encoded)?;
+    println!(
+        "{} {} {}",
+        shell("exported"),
+        name,
+        dim(&format!(
+            "→ {} ({} object(s), {})",
+            path.display(),
+            bundle.objects.len(),
+            human_size(encoded.len())
+        ))
+    );
+    println!(
+        "  {}\n    noidroid import {}\n    noidroid replay {name}",
+        dim("commit it, and anywhere it lands:"),
+        path.display()
+    );
+    Ok(ExitCode::SUCCESS)
+}
+
+fn cmd_import(repo: &Repo, file: &Path, rename: Option<&str>) -> Result<ExitCode> {
+    let bytes = std::fs::read(file)?;
+    let bundle: bundle::Bundle = serde_json::from_slice(&bytes)?;
+    let objects = bundle.objects.len();
+    let trajectory = bundle::import(repo, bundle, rename)?;
+    println!(
+        "{} {} {}",
+        shell("imported"),
+        trajectory.name,
+        dim(&format!(
+            "({} step(s), {objects} object(s), every address re-checked)",
+            trajectory.steps
+        ))
+    );
+    println!("    noidroid log {}", trajectory.name);
+    Ok(ExitCode::SUCCESS)
+}
+
+fn human_size(bytes: usize) -> String {
+    const UNITS: [&str; 4] = ["B", "KB", "MB", "GB"];
+    let mut size = bytes as f64;
+    let mut unit = 0;
+    while size >= 1024.0 && unit + 1 < UNITS.len() {
+        size /= 1024.0;
+        unit += 1;
+    }
+    if unit == 0 {
+        format!("{bytes} B")
+    } else {
+        format!("{size:.1} {}", UNITS[unit])
+    }
 }
 
 fn cmd_tree(repo: &Repo) -> Result<ExitCode> {

--- a/crates/noidroid-cli/tests/bisect.rs
+++ b/crates/noidroid-cli/tests/bisect.rs
@@ -113,3 +113,57 @@ nd.finish("failure", {"reason": "always"})
 
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+#[test]
+fn a_trajectory_survives_leaving_the_machine_it_was_recorded_on() {
+    let dir = workdir("bundle");
+    let agent = repo_root().join("examples/llm_agent/agent.py");
+    let (_, ok) = noidroid(&dir, &["run", "--", "python3", agent.to_str().unwrap()]);
+    assert!(ok);
+
+    let bundle = dir.join("run-1.noidroid.json");
+    let (out, ok) = noidroid(&dir, &["export", "run-1", "-o", bundle.to_str().unwrap()]);
+    assert!(ok, "{out}");
+    assert!(
+        bundle.exists(),
+        "the bundle should have been written: {out}"
+    );
+
+    // A bundle is meant to be committed, so it has to be text a reviewer can read.
+    let text = std::fs::read_to_string(&bundle).unwrap();
+    assert!(
+        text.contains("search_faq"),
+        "the recorded content should be legible in a diff"
+    );
+
+    // Somewhere else entirely, with an empty store.
+    let elsewhere = workdir("elsewhere");
+    let (out, ok) = noidroid(&elsewhere, &["import", bundle.to_str().unwrap()]);
+    assert!(ok, "{out}");
+    let (log, ok) = noidroid(&elsewhere, &["log", "run-1"]);
+    assert!(ok && log.contains("tool_choice_1"), "{log}");
+
+    // Importing the same bundle again is refused rather than silently duplicating.
+    let (out, ok) = noidroid(&elsewhere, &["import", bundle.to_str().unwrap()]);
+    assert!(!ok && out.contains("already exists"), "{out}");
+    let (out, ok) = noidroid(
+        &elsewhere,
+        &["import", bundle.to_str().unwrap(), "--as", "from-ci"],
+    );
+    assert!(ok, "{out}");
+
+    // A tampered bundle is caught, because every address is re-checked on the way in.
+    let tampered = elsewhere.join("tampered.json");
+    std::fs::write(&tampered, text.replace("search_faq", "search_fax")).unwrap();
+    let (out, ok) = noidroid(
+        &elsewhere,
+        &["import", tampered.to_str().unwrap(), "--as", "bad"],
+    );
+    assert!(
+        !ok && (out.contains("corrupt") || out.contains("hash")),
+        "a bundle whose contents do not match their addresses must be refused: {out}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+    let _ = std::fs::remove_dir_all(&elsewhere);
+}

--- a/crates/noidroid-core/src/bundle.rs
+++ b/crates/noidroid-core/src/bundle.rs
@@ -1,0 +1,211 @@
+//! Portable trajectories.
+//!
+//! A recording lives in `.noidroid/`, which is gitignored, machine-local, and full of
+//! sharded object files. That is right for working but useless for the thing a
+//! recording is most valuable as: a regression test. To replay a failure in CI, the
+//! trajectory has to be a file somebody can commit.
+//!
+//! A bundle is that file — one self-describing JSON document holding the trajectory
+//! and every object it reaches, and nothing else. Because objects are content-
+//! addressed, importing is idempotent and cannot corrupt an existing store: an object
+//! either is already there under that address, byte for byte, or it is new.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{Error, Result};
+use crate::hash::Digest;
+use crate::model::{Step, Trajectory, Tree};
+use crate::repo::Repo;
+
+pub const BUNDLE_VERSION: u32 = 1;
+
+#[derive(Serialize, Deserialize)]
+pub struct Bundle {
+    #[serde(rename = "type")]
+    pub type_: String,
+    pub v: u32,
+    pub trajectory: Trajectory,
+    /// Every object the trajectory reaches, by address. Binary content is base64;
+    /// everything else is stored as the text it already was, so a bundle stays
+    /// readable and diffable in a pull request.
+    pub objects: BTreeMap<String, Object>,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "encoding", rename_all = "lowercase")]
+pub enum Object {
+    Utf8 { content: String },
+    Base64 { content: String },
+}
+
+impl Object {
+    fn of(bytes: &[u8]) -> Object {
+        match std::str::from_utf8(bytes) {
+            Ok(text) => Object::Utf8 {
+                content: text.to_string(),
+            },
+            Err(_) => Object::Base64 {
+                content: base64(bytes),
+            },
+        }
+    }
+
+    fn bytes(&self) -> Result<Vec<u8>> {
+        match self {
+            Object::Utf8 { content } => Ok(content.as_bytes().to_vec()),
+            Object::Base64 { content } => unbase64(content),
+        }
+    }
+}
+
+/// Collect a trajectory and everything it reaches.
+pub fn export(repo: &Repo, name: &str) -> Result<Bundle> {
+    let trajectory = repo.load_trajectory(name)?;
+    let mut objects = BTreeMap::new();
+
+    for (digest, step) in repo.chain(&trajectory)? {
+        take(repo, &digest, &mut objects)?;
+        take(repo, &step.state_root, &mut objects)?;
+        let tree: Tree = repo.store.get_json(&step.state_root)?;
+        for entry in &tree.entries {
+            take(repo, &entry.blob, &mut objects)?;
+        }
+        for effect in &step.effects {
+            take(repo, &effect.value, &mut objects)?;
+        }
+    }
+
+    Ok(Bundle {
+        type_: "bundle".to_string(),
+        v: BUNDLE_VERSION,
+        trajectory,
+        objects,
+    })
+}
+
+fn take(repo: &Repo, digest: &Digest, into: &mut BTreeMap<String, Object>) -> Result<()> {
+    if into.contains_key(digest.as_str()) {
+        return Ok(());
+    }
+    into.insert(digest.to_string(), Object::of(&repo.store.get(digest)?));
+    Ok(())
+}
+
+/// Put a bundle into a repository, under `rename` if given.
+///
+/// Every object is re-hashed on the way in. A bundle is something that arrives from
+/// elsewhere — a colleague, a pull request, a bug report — so its claim that a given
+/// address holds given bytes is checked rather than believed.
+pub fn import(repo: &Repo, bundle: Bundle, rename: Option<&str>) -> Result<Trajectory> {
+    if bundle.v != BUNDLE_VERSION {
+        return Err(Error::Refused(format!(
+            "this bundle is version {}, and this build understands {BUNDLE_VERSION}",
+            bundle.v
+        )));
+    }
+
+    for (address, object) in &bundle.objects {
+        let bytes = object.bytes()?;
+        let stored = repo.store.put(&bytes)?;
+        if stored.as_str() != address {
+            return Err(Error::Corrupt {
+                digest: address.clone(),
+                detail: format!("the bundle's contents hash to {}", stored.short()),
+            });
+        }
+    }
+
+    let mut trajectory = bundle.trajectory;
+    if let Some(name) = rename {
+        trajectory.name = name.to_string();
+    }
+    // A watched directory is a path on whoever recorded it, and means nothing here.
+    trajectory.watched = None;
+    if repo.has_trajectory(&trajectory.name) {
+        return Err(Error::Refused(format!(
+            "trajectory '{}' already exists; import it under another name with --as",
+            trajectory.name
+        )));
+    }
+
+    // The head has to actually be reachable, or the bundle was incomplete.
+    let _: Step = repo.store.get_json(&trajectory.head)?;
+    repo.save_trajectory(&trajectory)?;
+    repo.chain(&trajectory)?;
+    Ok(trajectory)
+}
+
+const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+fn base64(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len().div_ceil(3) * 4);
+    for chunk in bytes.chunks(3) {
+        let b = [
+            chunk[0],
+            *chunk.get(1).unwrap_or(&0),
+            *chunk.get(2).unwrap_or(&0),
+        ];
+        let n = ((b[0] as u32) << 16) | ((b[1] as u32) << 8) | b[2] as u32;
+        for i in 0..4 {
+            if i <= chunk.len() {
+                out.push(ALPHABET[((n >> (18 - 6 * i)) & 0x3F) as usize] as char);
+            } else {
+                out.push('=');
+            }
+        }
+    }
+    out
+}
+
+fn unbase64(text: &str) -> Result<Vec<u8>> {
+    let mut lookup = [255u8; 256];
+    for (i, c) in ALPHABET.iter().enumerate() {
+        lookup[*c as usize] = i as u8;
+    }
+    let mut out = Vec::with_capacity(text.len() / 4 * 3);
+    let mut buffer = 0u32;
+    let mut bits = 0u32;
+    for c in text.bytes() {
+        if c == b'=' {
+            break;
+        }
+        let value = lookup[c as usize];
+        if value == 255 {
+            return Err(Error::Protocol(format!("bad base64 character {c:?}")));
+        }
+        buffer = (buffer << 6) | value as u32;
+        bits += 6;
+        if bits >= 8 {
+            bits -= 8;
+            out.push((buffer >> bits) as u8);
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn base64_round_trips_every_byte() {
+        for length in 0..=32usize {
+            let bytes: Vec<u8> = (0..length).map(|i| (i * 7 % 256) as u8).collect();
+            let encoded = base64(&bytes);
+            assert_eq!(unbase64(&encoded).unwrap(), bytes, "length {length}");
+        }
+        // Something that is definitely not valid UTF-8.
+        let bytes = vec![0xff, 0xfe, 0x00, 0x80];
+        assert_eq!(unbase64(&base64(&bytes)).unwrap(), bytes);
+    }
+
+    #[test]
+    fn text_stays_readable_in_a_bundle() {
+        match Object::of(b"{\"hello\": true}") {
+            Object::Utf8 { content } => assert_eq!(content, "{\"hello\": true}"),
+            Object::Base64 { .. } => panic!("text should not be base64 in a bundle"),
+        }
+    }
+}

--- a/crates/noidroid-core/src/engine.rs
+++ b/crates/noidroid-core/src/engine.rs
@@ -1172,7 +1172,7 @@ fn spawn(
     stdout_path: &Path,
     stderr_path: &Path,
 ) -> Result<Child> {
-    let resolved = resolve_command(&spec.command, &spec.launch_dir);
+    let resolved = resolve_command(&spec.command, &spec.launch_dir)?;
     let (program, args) = resolved
         .split_first()
         .ok_or_else(|| Error::Protocol("no command given".into()))?;
@@ -1192,24 +1192,34 @@ fn spawn(
 
 /// The child runs with the workspace as its working directory, so any path arguments
 /// that were relative to the launch directory are resolved before we hand them over.
-fn resolve_command(command: &[String], launch_dir: &Path) -> Vec<String> {
-    command
-        .iter()
-        .map(|arg| {
-            if arg.starts_with('-') {
-                return arg.clone();
-            }
-            let candidate = launch_dir.join(arg);
-            if candidate.exists() {
+fn resolve_command(command: &[String], launch_dir: &Path) -> Result<Vec<String>> {
+    let mut resolved = Vec::with_capacity(command.len());
+    for arg in command {
+        if arg.starts_with('-') {
+            resolved.push(arg.clone());
+            continue;
+        }
+        let candidate = launch_dir.join(arg);
+        if candidate.exists() {
+            resolved.push(
                 candidate
                     .canonicalize()
                     .map(|p| p.to_string_lossy().to_string())
-                    .unwrap_or_else(|_| arg.clone())
-            } else {
-                arg.clone()
-            }
-        })
-        .collect()
+                    .unwrap_or_else(|_| arg.clone()),
+            );
+            continue;
+        }
+        // Something that looks like a path and is not there. Catching it now turns a
+        // confusing "the process never connected" into the actual problem — which for
+        // an imported bundle is that a recording is not a program.
+        if arg.contains('/') && !Path::new(arg).is_absolute() {
+            return Err(Error::NotFound(format!(
+                "the recorded command refers to '{arg}', which is not here.\n  A trajectory records what a program did, not the program itself —\n  run this from the checkout it was recorded in."
+            )));
+        }
+        resolved.push(arg.clone());
+    }
+    Ok(resolved)
 }
 
 fn accept(listener: &UnixListener, child: &mut Child) -> Result<Option<UnixStream>> {

--- a/crates/noidroid-core/src/lib.rs
+++ b/crates/noidroid-core/src/lib.rs
@@ -9,6 +9,7 @@
 //! The core knows nothing about flights, browsers, robots or laboratories. It knows
 //! `call`, `decide`, `result` and `finish` — see [`proto`].
 
+pub mod bundle;
 pub mod engine;
 pub mod error;
 pub mod hash;


### PR DESCRIPTION
A recording is only a regression test if it can leave the machine it was made on, and
until now it could not: `.noidroid/` is gitignored, machine-local, and full of sharded
object files. `export` writes the trajectory and everything it reaches into one file;
`import` reads it back anywhere.

The bundle stays readable JSON rather than an archive, because the point of committing
one is that a reviewer can see what the agent actually said in the diff. Binary blobs
fall back to base64; text stays text.

Every address is re-hashed on import. A bundle arrives from somewhere else — a
colleague, a pull request, a bug report — so its claim that a given address holds
given bytes is checked rather than believed, and a tampered one is refused. Because
objects are content-addressed, importing is idempotent and cannot corrupt an existing
store: an object either is already there under that address, byte for byte, or it is
new.

Also fixes the first thing anyone hits after importing one. Replaying a trajectory
whose program is absent reported that the process never connected, which is true and
unhelpful; it now says that a trajectory records what a program did rather than the
program itself, and that you need the checkout it was recorded from.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
