### PR TITLE
chore(release): 0.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,26 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - name: Install Playwright and Chromium
+      - name: Install Playwright
         run: |
           python -m pip install --upgrade pip
           python -m pip install playwright anthropic
-          python -m playwright install --with-deps chromium
+          echo "PW_VERSION=$(python -m playwright --version | tr ' ' '-')" >> "$GITHUB_ENV"
+      - name: Cache the browser
+        id: browser-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-${{ env.PW_VERSION }}-chromium
+      - name: Install Chromium
+        # System packages are not cached, so they install either way; only the
+        # browser download is skipped on a hit.
+        run: |
+          if [ "${{ steps.browser-cache.outputs.cache-hit }}" = "true" ]; then
+            python -m playwright install-deps chromium
+          else
+            python -m playwright install --with-deps chromium
+          fi
       - name: Run every test, including the ones that drive a real browser
         run: cargo test --all --verbose -- --nocapture 2>&1 | tee test-output.txt
       - name: Fail if the browser tests silently skipped

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,11 +21,26 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - name: Install Playwright and Chromium
+      - name: Install Playwright
         run: |
           python -m pip install --upgrade pip
           python -m pip install playwright
-          python -m playwright install --with-deps chromium
+          echo "PW_VERSION=$(python -m playwright --version | tr ' ' '-')" >> "$GITHUB_ENV"
+      - name: Cache the browser
+        id: browser-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-${{ env.PW_VERSION }}-chromium
+      - name: Install Chromium
+        # System packages are not cached, so they install either way; only the
+        # browser download is skipped on a hit.
+        run: |
+          if [ "${{ steps.browser-cache.outputs.cache-hit }}" = "true" ]; then
+            python -m playwright install-deps chromium
+          else
+            python -m playwright install --with-deps chromium
+          fi
       - run: cargo test --all
       - name: The tag must match the version in Cargo.toml
         run: |
@@ -61,7 +76,9 @@ jobs:
           cp "target/${{ matrix.target }}/release/noidroid" "dist/$name/"
           cp README.md LICENSE manifesto.md "dist/$name/"
           tar -C dist -czf "dist/$name.tar.gz" "$name"
-          shasum -a 256 "dist/$name.tar.gz" > "dist/$name.tar.gz.sha256"
+          # Written from inside dist/ so the file names itself alone. With a path
+          # in it, `sha256sum -c` fails wherever the artifact is unpacked.
+          ( cd dist && shasum -a 256 "$name.tar.gz" > "$name.tar.gz.sha256" )
       - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.target }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ how the package version relates to `STEP_VERSION`, the on-disk object format.
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-08-19
+
+### Fixed
+
+- Release checksum files recorded `dist/<name>.tar.gz` as the path, so `sha256sum -c`
+  failed for anyone who downloaded them anywhere else. Found by verifying the
+  published v0.1.0 artifacts rather than by reading the workflow.
+- CI re-downloaded Chromium on every run, which was most of the wall time on the
+  slowest job. It is now cached against the Playwright version.
+
 ### Added
 
 - **`noidroid export` / `noidroid import`** — a trajectory and everything it reaches
@@ -173,5 +183,6 @@ only the sandboxed workspace is captured, the ambient environment is not capture
 branch is not a prediction, browser reconstruction is bounded by the recorded page
 set, and no scale work.
 
-[Unreleased]: https://github.com/swalla02/noidroid/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/swalla02/noidroid/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/swalla02/noidroid/releases/tag/v0.2.0
 [0.1.0]: https://github.com/swalla02/noidroid/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "noidroid-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "noidroid-core",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "noidroid-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "blake3",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/noidroid-core", "crates/noidroid-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/swalla02/noidroid"

--- a/README.md
+++ b/README.md
@@ -169,6 +169,34 @@ See [`examples/browser_agent/`](examples/browser_agent/README.md). The adapter n
 
 ---
 
+## Replay is already a regression test
+
+`noidroid replay` re-executes the *current* program against a recorded trajectory. If
+the program changed, it says where its behaviour stopped matching, field by field, and
+exits non-zero:
+
+```console
+$ noidroid replay run-1
+  steps re-derived       2/4
+  divergences:
+    @2 key_mismatch —
+      target: recorded "flights.seatmap", got "flights.availability"
+      args.flight: recorded "FL-101", absent now
+      args.id: not recorded, got "FL-101"
+$ echo $?
+1
+```
+
+Export the trajectory, commit it, and a production failure becomes a test that fails
+the day somebody changes the decision that caused it.
+
+The boundary is the same as everywhere else: this checks the program still behaves as
+recorded given the inputs that were recorded. It is not a claim that the world stayed
+the same, and it is not a substitute for running against a live model when what you
+changed is the prompt or the model.
+
+---
+
 ## Committing a failure
 
 A recording is only a regression test if it can leave the machine it was made on.

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "noidroid"
-version = "0.1.0"
+version = "0.2.0"
 description = "Python client for the Paranoid Android trajectory engine."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/crates/noidroid-cli/Cargo.toml
+++ b/crates/noidroid-cli/Cargo.toml
@@ -12,7 +12,7 @@ name = "noidroid"
 path = "src/main.rs"
 
 [dependencies]
-noidroid-core = { path = "../noidroid-core", version = "0.1.0" }
+noidroid-core = { path = "../noidroid-core", version = "0.2.0" }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 ratatui = "0.30.2"


### PR DESCRIPTION
The viewer and the Stand, zero-code recording, recording a real project and putting
its files back, causal bisection, committable bundles, and six bug fixes.

Two of the fixes are in the release machinery itself. Checksum files recorded
`dist/<name>.tar.gz` as the path, so `sha256sum -c` failed for anyone who downloaded
them anywhere else — found by verifying the published v0.1.0 artifacts rather than by
reading the workflow. And CI re-downloaded Chromium on every run, which was most of
the wall time on the slowest job; it is now cached against the Playwright version.

The README also stops leading with "replay costs zero tokens". It is true and it is
the weakest thing to say: a published study forking live trajectories found that after
a model swap only about 3% of replayed states remain valid, so the claim collapses for
exactly the change people make most often. What survives is the part nobody else does
— re-executing the program against recorded inputs and reporting the exact step where
behaviour stopped matching.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
