### PR TITLE
feat(proxy): record an agent you did not write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,9 @@ how the package version relates to `STEP_VERSION`, the on-disk object format.
   configured base URL, recorded and then replayed with the provider shut down.
   Unlike a trace exported from an observability tool, what is recorded is the request
   itself, which is what makes matching on replay meaningful rather than approximate.
-  It captures provider traffic only; pair it with `--watch` to record the files.
+  It captures provider traffic only; pair it with `--watch` to record the files. A
+  streamed response is buffered rather than passed through: same content, different
+  timing (#45).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,24 @@ how the package version relates to `STEP_VERSION`, the on-disk object format.
 
 ### Added
 
+- **`noidroid run --proxy -- <command>`** records an agent you did not write. Both the
+  Anthropic and OpenAI clients read their endpoint from the environment, so the proxy
+  stands between the agent and the provider and records what crosses the wire — no
+  patching, no TLS interception, and no requirement that the agent be Python or that
+  you have its source. Tested with an agent that has neither a noidroid import nor a
+  configured base URL, recorded and then replayed with the provider shut down.
+  Unlike a trace exported from an observability tool, what is recorded is the request
+  itself, which is what makes matching on replay meaningful rather than approximate.
+  It captures provider traffic only; pair it with `--watch` to record the files.
+
+### Fixed
+
+- The check that catches a missing program treated URLs and flag values as paths,
+  because both contain slashes. Introduced with the check itself and caught by using
+  the proxy, whose upstream is a URL.
+
+### Added
+
 - **`noidroid export` / `noidroid import`** — a trajectory and everything it reaches
   as one committable JSON file. A recording is only a regression test if it can leave
   the machine it was made on, and `.noidroid/` is gitignored and machine-local. The

--- a/README.md
+++ b/README.md
@@ -354,6 +354,7 @@ noidroid diff run-1 alt-1
 | `noidroid replay <traj>` | re-derive a trajectory and check it still hashes the same |
 | `noidroid branch <traj>@<step>` | diverge: `--decide`, `--result` or `--fail` |
 | `noidroid checkout <traj>@<step> <dir>` | write out the workspace as it was |
+| `noidroid run --proxy -- <cmd>` | record an agent you did not write, in any language |
 | `noidroid bisect <traj>` | find which decision, changed, would have flipped the outcome |
 | `noidroid restore <traj>@<step>` | put the files back as they were, keeping a way out |
 | `noidroid export` · `import` | move a trajectory between machines, as one committable file |
@@ -387,6 +388,27 @@ print(reply.content[0].text)                       # a real Message, replayed
 
 Record it once, then replay it with the network unplugged: the recorded response is
 served back and the SDK's own type is rebuilt, so `reply.content[0].text` still works.
+
+### Agents you did not write
+
+`--auto` patches SDKs inside a Python process, which is no help for a coding agent you
+installed or a service in another language. Both common clients read their endpoint
+from the environment, so there is a second way in:
+
+```bash
+noidroid run --proxy -- claude --print "fix the failing test"
+```
+
+The proxy stands between the agent and the provider and records what actually crosses
+the wire. No patching, no TLS interception, no language requirement — and unlike a
+trace exported from an observability tool, what gets recorded is the request itself,
+so a replay matches on what was sent rather than on a lossy summary of it.
+
+It captures the provider traffic and nothing else: files the agent writes, commands it
+runs and other services it calls are invisible to it. Pair it with `--watch` to record
+the files too.
+
+### What neither can do
 
 What automatic capture **cannot** do is branch. No amount of patching can infer that a
 value was a *choice among alternatives*, and that is what an intervention needs — so

--- a/README.md
+++ b/README.md
@@ -406,7 +406,8 @@ so a replay matches on what was sent rather than on a lossy summary of it.
 
 It captures the provider traffic and nothing else: files the agent writes, commands it
 runs and other services it calls are invisible to it. Pair it with `--watch` to record
-the files too.
+the files too. A streamed response is buffered rather than passed through — the content
+is identical, the timing is not.
 
 ### What neither can do
 

--- a/clients/python/noidroid/proxy.py
+++ b/clients/python/noidroid/proxy.py
@@ -24,6 +24,11 @@ response. **What it does not**: anything the agent does that is not that request
 files it writes, commands it runs, other services it calls. Those are invisible here,
 and a replay will not reproduce them.
 
+**A streamed response is buffered.** The whole thing is read before a single byte goes
+back, so the agent gets a complete answer rather than an incremental one. The content
+is identical and the recording is faithful; what changes is the timing, which for a
+long generation can be the difference between a progress bar and a client timeout.
+
 No TLS interception. The agent is pointed at a plain local address and the proxy makes
 the upstream call itself, so nothing has to trust a forged certificate.
 """
@@ -131,11 +136,23 @@ class _Handler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(payload)
 
+    # Anthropic and OpenAI between them use more than two verbs — files and batches
+    # are deleted, assistants are patched. An unhandled method would 501 here, which
+    # is a loud failure but a needless one.
     def do_POST(self):
         self._relay("POST")
 
     def do_GET(self):
         self._relay("GET")
+
+    def do_PUT(self):
+        self._relay("PUT")
+
+    def do_PATCH(self):
+        self._relay("PATCH")
+
+    def do_DELETE(self):
+        self._relay("DELETE")
 
 
 def _free_port() -> int:
@@ -161,13 +178,21 @@ def serve(upstream: str, command: list) -> int:
         environment[variable] = endpoint
     print(f"[noidroid.proxy] recording {upstream} via {endpoint}", file=sys.stderr)
 
+    # A command that cannot even start still has to close its trajectory: an
+    # unfinished one replays as truncated, which describes the recorder's crash
+    # rather than anything the agent did.
+    status = 127
+    detail = {}
     try:
         status = subprocess.call(command, env=environment)
+        detail = {"exit_code": status}
+    except OSError as failure:
+        detail = {"exit_code": status, "error": str(failure)}
+        print(f"[noidroid.proxy] could not run {command[0]}: {failure}", file=sys.stderr)
     finally:
         server.shutdown()
-
-    # The agent's own exit code is its verdict, so it becomes the outcome.
-    session.finish("success" if status == 0 else "failure", {"exit_code": status})
+        # The agent's own exit code is its verdict, so it becomes the outcome.
+        session.finish("success" if status == 0 else "failure", detail)
     return status
 
 

--- a/clients/python/noidroid/proxy.py
+++ b/clients/python/noidroid/proxy.py
@@ -1,0 +1,196 @@
+"""Record an agent you did not write.
+
+`--auto` patches SDKs inside a Python process, which is the right thing when the agent
+is yours and is Python. It cannot help with a coding agent you installed, a Go service,
+or anything whose source you are not editing.
+
+Both the Anthropic and OpenAI clients read their endpoint from an environment variable,
+so there is a second way in that needs no patching and no language: stand between the
+agent and the provider, and record what actually crosses the wire.
+
+    noidroid run --proxy -- claude --print "fix the failing test"
+
+That is a better recording than an instrumented one in one specific way. A trace from
+an observability tool holds whatever a framework callback chose to serialise; this
+holds the request itself, which means a replay can match on the thing that was actually
+sent rather than on a lossy summary of it.
+
+Run directly if you prefer:
+
+    python -m noidroid.proxy --upstream https://api.anthropic.com -- <command...>
+
+**What it captures**: every HTTP request the agent sends to the provider, and the full
+response. **What it does not**: anything the agent does that is not that request —
+files it writes, commands it runs, other services it calls. Those are invisible here,
+and a replay will not reproduce them.
+
+No TLS interception. The agent is pointed at a plain local address and the proxy makes
+the upstream call itself, so nothing has to trust a forged certificate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import socket
+import subprocess
+import sys
+import threading
+import urllib.error
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+from . import READ, connect
+
+#: Endpoint variables the common clients honour, so the agent needs no flags.
+BASE_URL_VARS = {
+    "anthropic": "ANTHROPIC_BASE_URL",
+    "openai": "OPENAI_BASE_URL",
+}
+
+#: Not forwarded upstream: hop-by-hop, or ours to set.
+SKIP_REQUEST_HEADERS = {"host", "connection", "proxy-connection", "keep-alive",
+                        "transfer-encoding", "upgrade", "content-length"}
+SKIP_RESPONSE_HEADERS = {"connection", "keep-alive", "transfer-encoding", "upgrade",
+                         "content-encoding", "content-length"}
+
+
+def _target(path: str) -> str:
+    """Name a call after its endpoint, so a timeline reads as something recognisable."""
+    return "http" + path.split("?", 1)[0].replace("/", ".").rstrip(".")
+
+
+class _Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    # Injected by serve().
+    upstream = ""
+    session = None
+    lock = threading.Lock()
+
+    def log_message(self, *args):
+        pass  # the agent's output is the interesting output
+
+    def _relay(self, method: str) -> None:
+        length = int(self.headers.get("Content-Length") or 0)
+        raw = self.rfile.read(length) if length else b""
+        headers = {
+            k: v for k, v in self.headers.items()
+            if k.lower() not in SKIP_REQUEST_HEADERS
+        }
+
+        # The body is what identifies the call, so it is what a replay matches on.
+        # Parsed when it is JSON, because a dict diffs field by field and a blob does
+        # not — and a divergence you cannot read is a divergence you cannot fix.
+        try:
+            body = json.loads(raw) if raw else None
+        except ValueError:
+            body = {"__raw__": raw.decode("utf-8", "replace")}
+
+        def perform():
+            request = urllib.request.Request(
+                self.upstream.rstrip("/") + self.path,
+                data=raw or None,
+                headers=headers,
+                method=method,
+            )
+            try:
+                with urllib.request.urlopen(request) as response:
+                    payload = response.read()
+                    status = response.status
+                    got = dict(response.headers)
+            except urllib.error.HTTPError as failure:
+                # A provider error is part of what happened, not a reason to stop.
+                payload = failure.read()
+                status = failure.code
+                got = dict(failure.headers)
+            return {
+                "status": status,
+                "headers": {k: v for k, v in got.items()
+                            if k.lower() not in SKIP_RESPONSE_HEADERS},
+                "body": payload.decode("utf-8", "replace"),
+            }
+
+        # One conversation with the engine at a time: the protocol is request and
+        # response over a single socket, and an agent may well be concurrent.
+        with self.lock:
+            recorded = self.session.call(
+                _target(self.path),
+                perform,
+                args={"method": method, "path": self.path, "body": body},
+                effect=READ,
+            )
+
+        payload = (recorded.get("body") or "").encode("utf-8")
+        self.send_response(int(recorded.get("status", 200)))
+        for key, value in (recorded.get("headers") or {}).items():
+            if key.lower() not in SKIP_RESPONSE_HEADERS:
+                self.send_header(key, value)
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def do_POST(self):
+        self._relay("POST")
+
+    def do_GET(self):
+        self._relay("GET")
+
+
+def _free_port() -> int:
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        return probe.getsockname()[1]
+
+
+def serve(upstream: str, command: list) -> int:
+    """Run `command` with the provider endpoint pointed at us, and record it."""
+    session = connect()
+    port = _free_port()
+
+    _Handler.upstream = upstream
+    _Handler.session = session
+    server = ThreadingHTTPServer(("127.0.0.1", port), _Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    endpoint = f"http://127.0.0.1:{port}"
+    environment = dict(os.environ)
+    for variable in BASE_URL_VARS.values():
+        environment[variable] = endpoint
+    print(f"[noidroid.proxy] recording {upstream} via {endpoint}", file=sys.stderr)
+
+    try:
+        status = subprocess.call(command, env=environment)
+    finally:
+        server.shutdown()
+
+    # The agent's own exit code is its verdict, so it becomes the outcome.
+    session.finish("success" if status == 0 else "failure", {"exit_code": status})
+    return status
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m noidroid.proxy",
+        description="Record an agent's provider traffic without changing it.",
+    )
+    parser.add_argument(
+        "--upstream",
+        default=os.environ.get("NOIDROID_PROXY_UPSTREAM", "https://api.anthropic.com"),
+        help="the real provider endpoint (default: %(default)s)",
+    )
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+
+    command = args.command
+    if command and command[0] == "--":
+        command = command[1:]
+    if not command:
+        parser.error("give a command to run after --")
+    return serve(args.upstream, command)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/crates/noidroid-cli/src/main.rs
+++ b/crates/noidroid-cli/src/main.rs
@@ -206,7 +206,18 @@ fn dispatch(cli: Cli) -> Result<ExitCode> {
             watch,
             proxy,
             command,
-        } => cmd_run(&repo, &cwd, name, auto, allow_gaps, watch, proxy, command),
+        } => cmd_run(
+            &repo,
+            &cwd,
+            RunFlags {
+                name,
+                auto,
+                allow_gaps,
+                watch,
+                proxy,
+            },
+            command,
+        ),
         Command::Log { trajectory } => cmd_log(&repo, trajectory),
         Command::Show { reference } => cmd_show(&repo, &reference),
         Command::Replay { trajectory } => cmd_replay(&repo, &cwd, &trajectory),
@@ -302,16 +313,24 @@ fn auto_capture_env() -> Result<Vec<(String, String)>> {
     Ok(vec![("PYTHONPATH".to_string(), joined)])
 }
 
-fn cmd_run(
-    repo: &Repo,
-    cwd: &Path,
+/// How a recording was asked for. Grouped because these travel together and there
+/// are now enough of them that a positional list is a bug waiting to be written.
+struct RunFlags {
     name: Option<String>,
     auto: bool,
     allow_gaps: bool,
     watch: Option<PathBuf>,
     proxy: Option<String>,
-    command: Vec<String>,
-) -> Result<ExitCode> {
+}
+
+fn cmd_run(repo: &Repo, cwd: &Path, flags: RunFlags, command: Vec<String>) -> Result<ExitCode> {
+    let RunFlags {
+        name,
+        auto,
+        allow_gaps,
+        watch,
+        proxy,
+    } = flags;
     let name = name.unwrap_or_else(|| repo.next_name("run"));
     if repo.has_trajectory(&name) {
         return Err(Error::Refused(format!(

--- a/crates/noidroid-cli/src/main.rs
+++ b/crates/noidroid-cli/src/main.rs
@@ -55,6 +55,11 @@ enum Command {
         /// read, never written; `.noidroidignore` extends the skipped directories.
         #[arg(long, value_name = "DIR")]
         watch: Option<PathBuf>,
+        /// Record provider traffic by standing between the agent and the API, for
+        /// agents you did not write and programs in any language.
+        #[arg(long, value_name = "URL", num_args = 0..=1,
+              default_missing_value = "https://api.anthropic.com")]
+        proxy: Option<String>,
         /// The command to run, after `--`.
         #[arg(trailing_var_arg = true, allow_hyphen_values = true, required = true)]
         command: Vec<String>,
@@ -199,8 +204,9 @@ fn dispatch(cli: Cli) -> Result<ExitCode> {
             auto,
             allow_gaps,
             watch,
+            proxy,
             command,
-        } => cmd_run(&repo, &cwd, name, auto, allow_gaps, watch, command),
+        } => cmd_run(&repo, &cwd, name, auto, allow_gaps, watch, proxy, command),
         Command::Log { trajectory } => cmd_log(&repo, trajectory),
         Command::Show { reference } => cmd_show(&repo, &reference),
         Command::Replay { trajectory } => cmd_replay(&repo, &cwd, &trajectory),
@@ -303,6 +309,7 @@ fn cmd_run(
     auto: bool,
     allow_gaps: bool,
     watch: Option<PathBuf>,
+    proxy: Option<String>,
     command: Vec<String>,
 ) -> Result<ExitCode> {
     let name = name.unwrap_or_else(|| repo.next_name("run"));
@@ -311,6 +318,23 @@ fn cmd_run(
             "trajectory '{name}' already exists; history is append-only"
         )));
     }
+    // The proxy is an ordinary client of the protocol that happens to run the agent
+    // as its own child, so the engine still supervises exactly one process.
+    let command = match &proxy {
+        Some(upstream) => {
+            let mut wrapped = vec![
+                "python3".to_string(),
+                "-m".to_string(),
+                "noidroid.proxy".to_string(),
+                "--upstream".to_string(),
+                upstream.clone(),
+                "--".to_string(),
+            ];
+            wrapped.extend(command);
+            wrapped
+        }
+        None => command,
+    };
     let watch = match watch {
         Some(dir) => Some(
             dir.canonicalize()
@@ -322,7 +346,7 @@ fn cmd_run(
         command,
         launch_dir: cwd.to_path_buf(),
         name: Some(name.clone()),
-        env: if auto {
+        env: if auto || proxy.is_some() {
             auto_capture_env_with(allow_gaps)?
         } else {
             Vec::new()

--- a/crates/noidroid-core/src/engine.rs
+++ b/crates/noidroid-core/src/engine.rs
@@ -1228,11 +1228,15 @@ fn spawn(
 /// that were relative to the launch directory are resolved before we hand them over.
 fn resolve_command(command: &[String], launch_dir: &Path) -> Result<Vec<String>> {
     let mut resolved = Vec::with_capacity(command.len());
+    let mut after_flag = false;
     for arg in command {
         if arg.starts_with('-') {
             resolved.push(arg.clone());
+            after_flag = true;
             continue;
         }
+        let was_flag_value = after_flag;
+        after_flag = false;
         let candidate = launch_dir.join(arg);
         if candidate.exists() {
             resolved.push(
@@ -1243,10 +1247,14 @@ fn resolve_command(command: &[String], launch_dir: &Path) -> Result<Vec<String>>
             );
             continue;
         }
-        // Something that looks like a path and is not there. Catching it now turns a
-        // confusing "the process never connected" into the actual problem — which for
-        // an imported bundle is that a recording is not a program.
-        if arg.contains('/') && !Path::new(arg).is_absolute() {
+        // Something that looks like a local path and is not there. Catching it now
+        // turns a confusing "the process never connected" into the actual problem —
+        // which for an imported bundle is that a recording is not a program.
+        //
+        // A URL is not a path, and neither is the value of a flag: both routinely
+        // contain slashes and neither is ours to resolve.
+        let looks_local = arg.contains('/') && !arg.contains("://") && !was_flag_value;
+        if looks_local && !Path::new(arg).is_absolute() {
             return Err(Error::NotFound(format!(
                 "the recorded command refers to '{arg}', which is not here.\n  A trajectory records what a program did, not the program itself —\n  run this from the checkout it was recorded in."
             )));

--- a/crates/noidroid-core/tests/proxy_slice.rs
+++ b/crates/noidroid-core/tests/proxy_slice.rs
@@ -1,0 +1,201 @@
+//! Recording an agent that knows nothing about us.
+//!
+//! `--auto` patches SDKs inside a Python process. That is no help for a coding agent
+//! you installed, or a service in another language. Both common clients read their
+//! endpoint from the environment, so the proxy stands between the agent and the
+//! provider and records what actually crosses the wire — no patching, no TLS
+//! interception, no language requirement.
+//!
+//! The agent here has no noidroid import *and* no configured base URL. The proof is
+//! the same as everywhere else: the provider is shut down before the replay, so
+//! anything that still works came out of the recording.
+
+use std::fs;
+use std::net::TcpStream;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use noidroid_core::engine::{self, Mode, RunSpec};
+use noidroid_core::Repo;
+
+const PORT: u16 = 8791;
+
+const PROVIDER: &str = r#"
+import json, sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *a): pass
+    def do_POST(self):
+        body = json.dumps({
+            "id": "msg_local", "type": "message", "role": "assistant",
+            "model": "claude-opus-5", "stop_reason": "end_turn", "stop_sequence": None,
+            "content": [{"type": "text", "text": "four"}],
+            "usage": {"input_tokens": 11, "output_tokens": 2},
+        }).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+ThreadingHTTPServer(("127.0.0.1", int(sys.argv[1])), Handler).serve_forever()
+"#;
+
+/// No noidroid import, and no base_url — it comes from the environment.
+const AGENT: &str = r#"
+import anthropic
+
+client = anthropic.Anthropic(api_key="not-a-real-key")
+reply = client.messages.create(
+    model="claude-opus-5",
+    max_tokens=16,
+    messages=[{"role": "user", "content": "what is two plus two?"}],
+)
+with open("answer.txt", "w", encoding="utf-8") as handle:
+    handle.write(f"{reply.content[0].text}:{type(reply).__name__}")
+"#;
+
+fn sdk_available() -> bool {
+    matches!(
+        Command::new("python3").args(["-c", "import anthropic"])
+            .stdout(Stdio::null()).stderr(Stdio::null()).status(),
+        Ok(s) if s.success()
+    )
+}
+
+fn client_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../clients/python")
+        .canonicalize()
+        .expect("the python client is part of the repository")
+}
+
+struct Provider(Child);
+
+impl Provider {
+    fn start(script: &Path) -> Provider {
+        let mut child = Command::new("python3")
+            .arg(script)
+            .arg(PORT.to_string())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("the stand-in provider should start");
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while Instant::now() < deadline {
+            if TcpStream::connect(("127.0.0.1", PORT)).is_ok() {
+                return Provider(child);
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        let _ = child.kill();
+        let _ = child.wait();
+        panic!("the stand-in provider never came up");
+    }
+
+    fn stop(mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while Instant::now() < deadline {
+            if TcpStream::connect(("127.0.0.1", PORT)).is_err() {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        panic!("the provider refused to stop; the replay would prove nothing");
+    }
+}
+
+impl Drop for Provider {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+#[test]
+fn an_agent_that_knows_nothing_about_us_records_and_replays() {
+    if !sdk_available() {
+        eprintln!("SKIP: proxy test needs the anthropic SDK (pip install anthropic)");
+        return;
+    }
+
+    let dir = std::env::temp_dir().join(format!(
+        "noidroid-proxy-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    fs::create_dir_all(&dir).unwrap();
+    let provider_script = dir.join("provider.py");
+    fs::write(&provider_script, PROVIDER).unwrap();
+    let agent = dir.join("agent.py");
+    fs::write(&agent, AGENT).unwrap();
+    assert!(
+        !AGENT.contains("noidroid") && !AGENT.contains("base_url"),
+        "the agent must know nothing about us, or this proves nothing"
+    );
+
+    let repo = Repo::open(&dir).unwrap();
+    // Exactly what `noidroid run --proxy` builds: the proxy is an ordinary client of
+    // the protocol that happens to run the agent as its own child.
+    let spec = |name: Option<&str>| RunSpec {
+        command: vec![
+            "python3".into(),
+            "-m".into(),
+            "noidroid.proxy".into(),
+            "--upstream".into(),
+            format!("http://127.0.0.1:{PORT}"),
+            "--".into(),
+            "python3".into(),
+            agent.display().to_string(),
+        ],
+        launch_dir: dir.clone(),
+        name: name.map(str::to_string),
+        env: vec![("PYTHONPATH".into(), client_path().display().to_string())],
+        auto: false,
+        watch: None,
+    };
+
+    let provider = Provider::start(&provider_script);
+    let recorded = engine::run(&repo, &spec(Some("proxied")), Mode::Record, None)
+        .expect("recording through the proxy should work")
+        .trajectory
+        .expect("a recording produces a trajectory");
+
+    let chain = repo.chain(&recorded).unwrap();
+    assert!(
+        chain
+            .iter()
+            .any(|(_, s)| s.action.summary().contains("http.v1.messages")),
+        "the wire request should be what was recorded: {:?}",
+        chain
+            .iter()
+            .map(|(_, s)| s.action.summary())
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(
+        fs::read_to_string(repo.workspace_dir("proxied").join("answer.txt")).unwrap(),
+        "four:Message",
+        "the agent should have received a real SDK object"
+    );
+
+    // Take the provider away.
+    provider.stop();
+
+    let report = engine::run(&repo, &spec(None), Mode::Replay, Some(&recorded))
+        .expect("replay should run to completion");
+    assert!(report.faithful(), "{:?}", report.divergences);
+    assert_eq!(
+        report.delivery.get("executed").copied().unwrap_or(0),
+        0,
+        "nothing may be executed during a replay; the provider is not even running"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
Closes #23

Automatic capture patches SDKs inside a Python process, which is no help for a coding
agent somebody installed or a service in another language — and those are exactly the
programs people most want recorded and least want to modify.

Both the Anthropic and OpenAI clients read their endpoint from the environment, so
there is a second way in that needs neither patching nor a certificate: stand between
the agent and the provider. `noidroid run --proxy -- <command>` runs the agent with
its endpoint pointed at a local address and records what actually crosses the wire.

This is the honest alternative to importing traces from an observability tool, which
was the other candidate and which I dropped after researching it. A trace holds
whatever a framework callback chose to serialise, so replaying against one forces
fuzzy matching on a lossy summary — precisely where tools in this space quietly lie.
A proxy records the request itself, so matching means comparing what was sent. It also
avoids the deeper problem that traces are trees and trajectories are ordered
sequences, with no defensible flattening under concurrency.

The proxy is an ordinary client of the protocol that happens to run the agent as its
own child, so the engine still supervises exactly one process and nothing about the
core changed.

Tested with an agent that has neither a noidroid import nor a configured base URL,
recorded and then replayed with the provider shut down.

It captures provider traffic and nothing else — files written, commands run, other
services called are invisible to it, and the README says so rather than leaving it to
be discovered.

Also fixes the missing-program check added last change, which treated URLs and flag
values as paths because both contain slashes. Found by using the proxy, whose upstream
is a URL.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>