### PR TITLE
feat(replay): re-run only the part you changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,19 @@ No migration.
   have produced bogus divergences rather than an honest refusal.
 - `_PassThrough.call` did not accept `volatile=`, so a program using it raised
   `TypeError` when run *without* noidroid — defeating the point of the pass-through.
+- **`noidroid replay <traj> --live <target>`** — re-run part of a recording for real.
+  A plain replay is the wrong instrument when the thing you changed is upstream of the
+  recording, such as a prompt or a model: a published study forking live trajectories
+  after a model swap found only about 3% of replayed states remained valid. So the
+  operator names what should be new — `--live model` covers every `model.*` call — and
+  the tools, network and clock still come from the recording, so exactly one thing
+  changed and the comparison means something.
+  Everything before the first live call still reproduces and is verified. Everything
+  after is `live`, and a call the run still makes in the same order is still served
+  from the recording, so it keeps its grip for as long as it tracks and only executes
+  what the recording genuinely cannot answer. The result is kept as its own trajectory,
+  because comparing it against its recording is the whole point, and it is never
+  called faithful — part of it was asked to be new.
 
 ## [0.2.0] - 2026-08-19
 

--- a/README.md
+++ b/README.md
@@ -210,8 +210,35 @@ the day somebody changes the decision that caused it.
 
 The boundary is the same as everywhere else: this checks the program still behaves as
 recorded given the inputs that were recorded. It is not a claim that the world stayed
-the same, and it is not a substitute for running against a live model when what you
-changed is the prompt or the model.
+the same.
+
+### When what changed is the prompt or the model
+
+Then a plain replay is the wrong instrument, and honestly so: forking live trajectories
+with a swapped model leaves [about 3% of replayed states
+valid](https://arxiv.org/html/2608.08239). So name the part that should be new:
+
+```bash
+noidroid replay run-1 --live model
+```
+
+The model answers now; the tools, the network and the clock still come from the
+recording, so only one thing changed and the comparison means something. Everything
+before the first live call still reproduces exactly and is checked. Everything after it
+is marked `live` — really executed, in a world that did not happen — and stays
+comparable:
+
+```console
+  steps re-derived   1/1 identical objects
+  values by provenance   1 real, 2 live
+
+  live  up to the first live call this reproduced exactly; everything after it is new
+    noidroid diff run-1 run-1~live-1
+```
+
+A step the run still asks for in the same order is still served from the recording, so
+the run keeps its grip for as long as it tracks; the first thing the recording cannot
+answer is executed instead. It degrades where it must, not everywhere at once.
 
 ---
 

--- a/crates/noidroid-cli/src/main.rs
+++ b/crates/noidroid-cli/src/main.rs
@@ -76,7 +76,17 @@ enum Command {
         reference: String,
     },
     /// Re-derive a recorded trajectory and check it still hashes the same.
-    Replay { trajectory: String },
+    Replay {
+        trajectory: String,
+        /// Execute these targets for real instead of serving them from the recording
+        /// — `--live model` covers every `model.*` call. Tools, network and clock
+        /// still come from the recording, so only the named part is new.
+        #[arg(long, value_name = "TARGET")]
+        live: Vec<String>,
+        /// Name for the trajectory a live replay produces.
+        #[arg(long)]
+        label: Option<String>,
+    },
     /// Explore from a checkpoint by deliberately doing something else.
     Branch {
         /// `<trajectory>@<step>` — the step at which to diverge.
@@ -221,7 +231,11 @@ fn dispatch(cli: Cli) -> Result<ExitCode> {
         ),
         Command::Log { trajectory } => cmd_log(&repo, trajectory),
         Command::Show { reference } => cmd_show(&repo, &reference),
-        Command::Replay { trajectory } => cmd_replay(&repo, &cwd, &trajectory),
+        Command::Replay {
+            trajectory,
+            live,
+            label,
+        } => cmd_replay(&repo, &cwd, &trajectory, live, label),
         Command::Branch {
             reference,
             label,
@@ -562,12 +576,25 @@ fn cmd_show(repo: &Repo, reference: &str) -> Result<ExitCode> {
     Ok(ExitCode::SUCCESS)
 }
 
-fn cmd_replay(repo: &Repo, cwd: &Path, name: &str) -> Result<ExitCode> {
+fn cmd_replay(
+    repo: &Repo,
+    cwd: &Path,
+    name: &str,
+    live: Vec<String>,
+    label: Option<String>,
+) -> Result<ExitCode> {
     let t = repo.load_trajectory(name)?;
+    // A live replay produces a genuinely different run, so it is kept: comparing it
+    // against the recording it came from is the entire point.
+    let keep = if live.is_empty() {
+        None
+    } else {
+        Some(label.unwrap_or_else(|| repo.next_name(&format!("{name}~live"))))
+    };
     let spec = RunSpec {
         command: t.command.clone(),
         launch_dir: cwd.to_path_buf(),
-        name: None,
+        name: keep,
         env: if t.auto {
             auto_capture_env_with(t.allow_gaps)?
         } else {
@@ -576,8 +603,18 @@ fn cmd_replay(repo: &Repo, cwd: &Path, name: &str) -> Result<ExitCode> {
         auto: t.auto,
         watch: None,
     };
-    let report = engine::run(repo, &spec, Mode::Replay, Some(&t))?;
-    println!("{} {}", shell("REPLAY"), name);
+    let live_targets = live.clone();
+    let report = engine::run(repo, &spec, Mode::Replay { live }, Some(&t))?;
+    println!(
+        "{} {}{}",
+        shell("REPLAY"),
+        name,
+        if live_targets.is_empty() {
+            String::new()
+        } else {
+            dim(&format!("  live: {}", live_targets.join(", ")))
+        }
+    );
     println!(
         "  {:<22} {}",
         dim("steps re-derived"),
@@ -603,6 +640,23 @@ fn cmd_replay(repo: &Repo, cwd: &Path, name: &str) -> Result<ExitCode> {
         dim("(mediated effects are never re-executed during replay)")
     );
     print_census(&report);
+    if !live_targets.is_empty() {
+        // Calling this "faithful" would be a lie: part of it was asked to be new, so
+        // what happened is a comparison, not a reproduction.
+        println!(
+            "\n  {} up to the first live call this reproduced exactly; \
+             everything after it is new",
+            ink_provenance("live")
+        );
+        if let Some(made) = report.trajectory.as_ref() {
+            println!("    noidroid diff {name} {}", made.name);
+        }
+        return Ok(if report.divergences.is_empty() {
+            ExitCode::SUCCESS
+        } else {
+            ExitCode::from(1)
+        });
+    }
     if report.divergences.is_empty() {
         println!(
             "\n  {} the reconstruction addresses the same objects as the recording",

--- a/crates/noidroid-cli/src/tui.rs
+++ b/crates/noidroid-cli/src/tui.rs
@@ -277,7 +277,12 @@ impl<'a> App<'a> {
             auto: false,
             watch: None,
         };
-        match engine::run(self.repo, &spec, Mode::Replay, Some(&t)) {
+        match engine::run(
+            self.repo,
+            &spec,
+            Mode::Replay { live: Vec::new() },
+            Some(&t),
+        ) {
             Ok(report) if report.faithful() => {
                 self.flash = FLASH_FRAMES;
                 self.note = Some(Note::Good(format!(

--- a/crates/noidroid-core/src/engine.rs
+++ b/crates/noidroid-core/src/engine.rs
@@ -49,7 +49,15 @@ pub enum Mode {
     /// Run for real and write down what happened.
     Record,
     /// Re-derive a recorded trajectory and check it still hashes the same.
-    Replay,
+    ///
+    /// `live` names targets to execute for real instead of serving from the
+    /// recording. That is how a recording stays useful when the thing you changed is
+    /// the prompt or the model: the tools, the network and the clock still come from
+    /// the recording, so the run is controlled, but the model answers now.
+    ///
+    /// It is not a reproduction, and the engine does not pretend otherwise —
+    /// everything from the first live call onward is counterfactual.
+    Replay { live: Vec<String> },
     /// Re-derive a prefix, then deliberately do something else.
     Branch {
         at: u64,
@@ -64,7 +72,7 @@ impl Mode {
     fn label(&self) -> &'static str {
         match self {
             Mode::Record => "record",
-            Mode::Replay => "replay",
+            Mode::Replay { .. } => "replay",
             Mode::Branch { .. } => "branch",
         }
     }
@@ -198,7 +206,7 @@ pub fn run(repo: &Repo, spec: &RunSpec, mode: Mode, source: Option<&Trajectory>)
     let watching = matches!(mode, Mode::Record) && spec.watch.is_some();
     let workspace = match (&mode, &spec.watch) {
         (Mode::Record, Some(dir)) => dir.clone(),
-        (Mode::Replay, _) => repo
+        (Mode::Replay { .. }, _) => repo
             .tmp_dir()
             .join(format!("replay-{}", std::process::id())),
         _ => repo.workspace_dir(&run_label),
@@ -257,6 +265,7 @@ pub fn run(repo: &Repo, spec: &RunSpec, mode: Mode, source: Option<&Trajectory>)
         mode: &mode,
         recorded: &recorded,
         env: situation,
+        gone_live: false,
         parent: None,
         parent_provenance: Provenance::Real,
         index: 0,
@@ -402,6 +411,8 @@ struct Session<'a> {
     recorded: &'a [(Digest, Step)],
     /// The world, in parts. Everything this module knows about state goes through it.
     env: Situation,
+    /// Set the first time a call is executed live during a replay.
+    gone_live: bool,
     parent: Option<Digest>,
     parent_provenance: Provenance,
     index: u64,
@@ -525,8 +536,14 @@ impl<'a> Session<'a> {
     fn phase(&self) -> Phase {
         match self.mode {
             Mode::Record => Phase::Fresh,
-            Mode::Replay => {
-                if (self.index as usize) < self.recorded.len() {
+            Mode::Replay { .. } => {
+                // Once something has been executed live, the rest of the run is a
+                // counterfactual: its steps cannot be expected to address the same
+                // objects, and saying they diverged would be reporting a decision the
+                // operator made as if it were a fault.
+                if self.gone_live {
+                    Phase::Counterfactual
+                } else if (self.index as usize) < self.recorded.len() {
                     Phase::Reconstructing
                 } else {
                     Phase::PastRecording
@@ -611,6 +628,37 @@ impl<'a> Session<'a> {
         }
 
         match self.phase() {
+            // A live replay keeps serving the recording for everything it did not
+            // ask to run live, for as long as the run still tracks it. The model
+            // answering differently is the point; the tools, the network and the
+            // clock staying put is what makes the comparison mean anything.
+            //
+            // The moment the run asks for something the recording does not have at
+            // this position, it has genuinely left the recording and is executed.
+            // Inngest calls this graceful determinism and it is the right shape:
+            // degrade where you must, not everywhere at once.
+            Phase::Counterfactual if self.replaying_live() && !self.runs_live(&target) => {
+                match self.recorded_step().cloned() {
+                    Some(recorded) if actions_agree(&recorded.action, &action) => {
+                        let value = self.recorded_value(&recorded)?;
+                        self.commit_recorded(&recorded, Delivery::Replayed)?;
+                        Ok(self.replayed_response(&recorded, value))
+                    }
+                    _ => {
+                        if effect == EffectKind::Irreversible && !self.may_perform_irreversible() {
+                            return self.deny_irreversible(action, target);
+                        }
+                        self.pending = Some(Pending {
+                            action,
+                            effect,
+                            provenance: Provenance::Live,
+                            started: Instant::now(),
+                            outcome: EffectOutcome::Value,
+                        });
+                        Ok(Response::execute())
+                    }
+                }
+            }
             // Nothing recorded to lean on: the application really performs it.
             Phase::Fresh | Phase::Counterfactual => {
                 if effect == EffectKind::Irreversible && !self.may_perform_irreversible() {
@@ -629,7 +677,20 @@ impl<'a> Session<'a> {
                 Ok(Response::execute())
             }
             // Reconstructing: serve the recording. The engine never says "execute"
-            // here, so a replay structurally cannot touch the world.
+            // here, so a replay structurally cannot touch the world — except for a
+            // target the operator explicitly asked to run live, which is the one way
+            // a recording stays useful after the prompt or the model changed.
+            Phase::Reconstructing if self.runs_live(&target) => {
+                self.gone_live = true;
+                self.pending = Some(Pending {
+                    action,
+                    effect,
+                    provenance: Provenance::Live,
+                    started: Instant::now(),
+                    outcome: EffectOutcome::Value,
+                });
+                Ok(Response::execute())
+            }
             Phase::Reconstructing => {
                 let recorded = self
                     .recorded_step()
@@ -755,6 +816,23 @@ impl<'a> Session<'a> {
             false,
         )?;
         Ok(Response::use_value(value, "simulated", "intervened"))
+    }
+
+    /// Was this target named as one to execute for real?
+    ///
+    /// Prefix matching, so `--live model` covers every `model.*` call without asking
+    /// anyone to write a glob.
+    fn runs_live(&self, target: &str) -> bool {
+        match self.mode {
+            Mode::Replay { live } => live
+                .iter()
+                .any(|p| target == p || target.starts_with(&format!("{p}."))),
+            _ => false,
+        }
+    }
+
+    fn replaying_live(&self) -> bool {
+        matches!(self.mode, Mode::Replay { live } if !live.is_empty())
     }
 
     fn may_perform_irreversible(&self) -> bool {

--- a/crates/noidroid-core/tests/auto_slice.rs
+++ b/crates/noidroid-core/tests/auto_slice.rs
@@ -196,8 +196,13 @@ fn a_program_with_no_noidroid_code_records_and_replays() {
     // 2. Take the API away. Anything that still works came out of the recording.
     api.stop();
 
-    let report = engine::run(&repo, &spec(None), Mode::Replay, Some(&recorded))
-        .expect("replay should run to completion");
+    let report = engine::run(
+        &repo,
+        &spec(None),
+        Mode::Replay { live: Vec::new() },
+        Some(&recorded),
+    )
+    .expect("replay should run to completion");
     assert!(
         report.faithful(),
         "an uninstrumented program should replay exactly: {:?}",
@@ -286,8 +291,13 @@ fn a_capture_gap_stops_the_recording_unless_it_is_allowed() {
 
     let mut replay = spec("unused", true);
     replay.name = None;
-    let report = engine::run(&repo, &replay, Mode::Replay, Some(&allowed))
-        .expect("replay should run to completion");
+    let report = engine::run(
+        &repo,
+        &replay,
+        Mode::Replay { live: Vec::new() },
+        Some(&allowed),
+    )
+    .expect("replay should run to completion");
     assert!(report.faithful(), "{:?}", report.divergences);
 
     let _ = fs::remove_dir_all(&dir);

--- a/crates/noidroid-core/tests/browser_slice.rs
+++ b/crates/noidroid-core/tests/browser_slice.rs
@@ -253,8 +253,13 @@ impl Fixture {
     fn replay(&self, t: &Trajectory) -> engine::Report {
         let mut spec = self.spec("unused", false);
         spec.name = None;
-        engine::run(&self.repo, &spec, Mode::Replay, Some(t))
-            .expect("replay should run to completion")
+        engine::run(
+            &self.repo,
+            &spec,
+            Mode::Replay { live: Vec::new() },
+            Some(t),
+        )
+        .expect("replay should run to completion")
     }
 
     /// Point the fixture at an agent written from the test rather than an example.

--- a/crates/noidroid-core/tests/environment_slice.rs
+++ b/crates/noidroid-core/tests/environment_slice.rs
@@ -80,8 +80,13 @@ impl Fixture {
     }
 
     fn replay(&self, t: &Trajectory) -> Report {
-        engine::run(&self.repo, &self.spec(None, false), Mode::Replay, Some(t))
-            .expect("replay runs to completion")
+        engine::run(
+            &self.repo,
+            &self.spec(None, false),
+            Mode::Replay { live: Vec::new() },
+            Some(t),
+        )
+        .expect("replay runs to completion")
     }
 
     fn branch(

--- a/crates/noidroid-core/tests/fence_slice.rs
+++ b/crates/noidroid-core/tests/fence_slice.rs
@@ -87,8 +87,13 @@ fn a_replay_that_reaches_the_network_is_caught_and_explained() {
 
     // Same program, now doing something nobody mediated. Before the fence this
     // reached the network and the replay still called itself faithful.
-    let report = engine::run(&f.repo, &f.spec(None, true), Mode::Replay, Some(&recorded))
-        .expect("replay should run to completion");
+    let report = engine::run(
+        &f.repo,
+        &f.spec(None, true),
+        Mode::Replay { live: Vec::new() },
+        Some(&recorded),
+    )
+    .expect("replay should run to completion");
 
     assert!(
         !report.faithful(),
@@ -113,8 +118,13 @@ fn the_fence_does_not_get_in_the_way_of_an_honest_replay() {
 
     // The engine's own socket is a Unix socket and loopback stays open, so a replay
     // that only talks to us is unaffected.
-    let report = engine::run(&f.repo, &f.spec(None, false), Mode::Replay, Some(&recorded))
-        .expect("replay should run to completion");
+    let report = engine::run(
+        &f.repo,
+        &f.spec(None, false),
+        Mode::Replay { live: Vec::new() },
+        Some(&recorded),
+    )
+    .expect("replay should run to completion");
     assert!(report.faithful(), "{:?}", report.divergences);
     assert!(report.last_words.is_none(), "nothing went wrong to report");
 }

--- a/crates/noidroid-core/tests/llm_slice.rs
+++ b/crates/noidroid-core/tests/llm_slice.rs
@@ -149,8 +149,13 @@ fn replaying_an_agent_never_calls_the_model() {
         .trajectory
         .unwrap();
 
-    let report = engine::run(&f.repo, &f.spec(None), Mode::Replay, Some(&recorded))
-        .expect("replay should run to completion");
+    let report = engine::run(
+        &f.repo,
+        &f.spec(None),
+        Mode::Replay { live: Vec::new() },
+        Some(&recorded),
+    )
+    .expect("replay should run to completion");
 
     assert!(report.faithful(), "{:?}", report.divergences);
     // Every step was served from the recording. Nothing was executed, so nothing was

--- a/crates/noidroid-core/tests/proxy_slice.rs
+++ b/crates/noidroid-core/tests/proxy_slice.rs
@@ -188,8 +188,13 @@ fn an_agent_that_knows_nothing_about_us_records_and_replays() {
     // Take the provider away.
     provider.stop();
 
-    let report = engine::run(&repo, &spec(None), Mode::Replay, Some(&recorded))
-        .expect("replay should run to completion");
+    let report = engine::run(
+        &repo,
+        &spec(None),
+        Mode::Replay { live: Vec::new() },
+        Some(&recorded),
+    )
+    .expect("replay should run to completion");
     assert!(report.faithful(), "{:?}", report.divergences);
     assert_eq!(
         report.delivery.get("executed").copied().unwrap_or(0),

--- a/crates/noidroid-core/tests/tolerance_slice.rs
+++ b/crates/noidroid-core/tests/tolerance_slice.rs
@@ -88,7 +88,13 @@ fn an_undeclared_clock_makes_every_replay_diverge() {
         .trajectory
         .unwrap();
 
-    let report = engine::run(&f.repo, &f.spec(None, false), Mode::Replay, Some(&recorded)).unwrap();
+    let report = engine::run(
+        &f.repo,
+        &f.spec(None, false),
+        Mode::Replay { live: Vec::new() },
+        Some(&recorded),
+    )
+    .unwrap();
 
     assert!(
         report
@@ -108,7 +114,13 @@ fn declaring_it_volatile_makes_the_replay_faithful() {
         .trajectory
         .unwrap();
 
-    let report = engine::run(&f.repo, &f.spec(None, true), Mode::Replay, Some(&recorded)).unwrap();
+    let report = engine::run(
+        &f.repo,
+        &f.spec(None, true),
+        Mode::Replay { live: Vec::new() },
+        Some(&recorded),
+    )
+    .unwrap();
 
     assert!(
         report.faithful(),

--- a/crates/noidroid-core/tests/vertical_slice.rs
+++ b/crates/noidroid-core/tests/vertical_slice.rs
@@ -132,8 +132,13 @@ impl Fixture {
     }
 
     fn replay(&self, t: &Trajectory, extra: &[(&str, &str)]) -> Report {
-        engine::run(&self.repo, &self.spec(None, extra), Mode::Replay, Some(t))
-            .expect("replay should run to completion")
+        engine::run(
+            &self.repo,
+            &self.spec(None, extra),
+            Mode::Replay { live: Vec::new() },
+            Some(t),
+        )
+        .expect("replay should run to completion")
     }
 
     fn witness_lines(&self) -> Vec<String> {
@@ -621,4 +626,62 @@ fn an_io_failure_says_what_it_was_doing() {
     );
 
     let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn a_live_replay_reruns_only_what_it_was_asked_to() {
+    let f = Fixture::new("hybrid");
+    let recorded = f.record();
+    let after_recording = f.witness_lines();
+    assert!(after_recording.contains(&"read".to_string()));
+    assert!(after_recording.contains(&"stage".to_string()));
+
+    // Re-run the read for real; everything else should still come from the recording.
+    // This is what keeps a recording useful once the thing you changed is upstream of
+    // it — the model, the prompt — without turning the whole run into a fresh one.
+    let mut spec = f.spec(Some("live-1"), &[]);
+    spec.name = Some("live-1".into());
+    let report = engine::run(
+        &f.repo,
+        &spec,
+        Mode::Replay {
+            live: vec!["world.read".into()],
+        },
+        Some(&recorded),
+    )
+    .expect("a live replay should run to completion");
+
+    let performed = f.witness_lines();
+    let extra: Vec<&String> = performed[after_recording.len()..].iter().collect();
+    assert_eq!(
+        extra,
+        vec![&"read".to_string()],
+        "only the target named --live may be executed again, got {extra:?}"
+    );
+
+    // The prefix before the live call still reproduced exactly.
+    assert!(
+        report.expected > 0 && report.reproduced == report.expected,
+        "the part before the first live call must still be verified: {:?}",
+        report.divergences
+    );
+
+    // And it is kept, because comparing it with the recording is the whole point.
+    let produced = report
+        .trajectory
+        .expect("a live replay produces a trajectory");
+    let chain = f.repo.chain(&produced).unwrap();
+    let live_step = chain
+        .iter()
+        .find(|(_, s)| matches!(&s.action, Action::Call { target, .. } if target == "world.read"))
+        .expect("the live call is a step");
+    assert_eq!(live_step.1.effects[0].provenance, Provenance::Live);
+    assert_eq!(
+        chain.last().unwrap().1.provenance,
+        Provenance::Live,
+        "live never improves back to real downstream"
+    );
+
+    // The recording it came from is untouched.
+    assert_eq!(f.repo.load_trajectory("run-1").unwrap(), recorded);
 }

--- a/crates/noidroid-core/tests/watch_slice.rs
+++ b/crates/noidroid-core/tests/watch_slice.rs
@@ -165,8 +165,13 @@ fn a_reconstruction_never_touches_the_watched_directory() {
 
     let mut spec = project.spec();
     spec.name = None;
-    let report = engine::run(&project.repo, &spec, Mode::Replay, Some(&recorded))
-        .expect("replay should run to completion");
+    let report = engine::run(
+        &project.repo,
+        &spec,
+        Mode::Replay { live: Vec::new() },
+        Some(&recorded),
+    )
+    .expect("replay should run to completion");
     assert!(report.faithful(), "{:?}", report.divergences);
 
     // A replay re-executes the program, which writes files. It must do that in its


### PR DESCRIPTION
Closes #24

A plain replay is the wrong instrument when the thing that changed sits upstream of
the recording — a prompt, a model, a system instruction. It is not a small
inaccuracy either: a published study forking live trajectories after a model swap
found 61–94% of post-fork actions rewritten and only about 3% of replayed states
still valid. Serving the old answers back would produce a confident comparison of
nothing.

So `--live <target>` names the part that should be new. `--live model` covers every
`model.*` call; the tools, the network and the clock still come from the recording,
which is what makes it a comparison rather than a fresh run — exactly one thing
changed.

Everything before the first live call still reproduces and is still verified by hash.
Everything after is marked `live`: really executed, in a world that did not happen.
And a call the run still makes in the same order is still served from the recording,
so the run keeps its grip for as long as it tracks the recording and only executes
what the recording genuinely cannot answer — degrading where it must rather than
everywhere at once, which is the shape Inngest arrived at for the same problem.

The result is kept as its own trajectory, because comparing it against the recording
it came from is the entire point, and it is never reported as faithful: part of it
was asked to be new, so what happened is a comparison, not a reproduction.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>