### PR TITLE
fix(auto): refuse to record around a hole instead of recording through it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ how the package version relates to `STEP_VERSION`, the on-disk object format.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Automatic capture failed open, and said it did not.** The README promised
+  "`--auto` prints what it hooked; anything not listed was not recorded" — but the
+  print was gated behind an environment variable nothing in the project ever set, so
+  the single documented mitigation for fail-open capture never ran. It always prints
+  now.
+- **The async surface was never patched and never mentioned.** A program using
+  `AsyncAnthropic` had its sync calls recorded and its async calls run **live during
+  replay**, while the replay reported itself faithful. `--auto` now names every
+  surface it could not cover and **refuses to record**, with `--allow-gaps` as a
+  deliberate override that is stored on the trajectory so replays make the same
+  allowance.
+- `auto.install()` silently continued when an SDK's base client was not where it
+  expected, contradicting its own docstring; it raises now, because an upstream
+  rename that records nothing and exits zero is the failure this module exists to
+  prevent.
+- `Step.v` was written but never checked on read, so a future format version would
+  have produced bogus divergences rather than an honest refusal.
+- `_PassThrough.call` did not accept `volatile=`, so a program using it raised
+  `TypeError` when run *without* noidroid — defeating the point of the pass-through.
+
 ## [0.2.0] - 2026-08-19
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -397,9 +397,24 @@ pick = nd.decide("route", options=candidates, choice=candidates[0])
 ```
 
 It also does not capture async clients, streaming responses, non-SDK HTTP, the clock,
-or randomness. `--auto` prints what it hooked; anything not listed was not recorded.
-Say it plainly, because a replay tool that quietly misses an effect produces a
-trajectory that looks real.
+or randomness — and it will not quietly record around them. `--auto` prints what it
+hooked *and* what it could not, and **refuses to record** when it finds a surface it
+cannot cover:
+
+```console
+$ noidroid run --auto -- python3 agent.py
+[noidroid.auto] hooked: anthropic._base_client.SyncAPIClient.request
+[noidroid.auto] NOT hooked: anthropic._base_client.AsyncAPIClient.request — calls
+                through it are not recorded
+[noidroid.auto] refusing to record: the surfaces above are not captured, so this
+                recording would be incomplete without saying so.
+  Record it anyway with --allow-gaps if you know your program does not use them.
+```
+
+`--allow-gaps` is the way past it, and the allowance is stored on the trajectory so
+replaying it makes the same one. Refusing costs you a run; recording anyway costs the
+trust in every run, because a trajectory that missed the model calls still looks real
+and still claims to replay faithfully.
 
 ## Integrating it by hand
 

--- a/clients/python/noidroid/__init__.py
+++ b/clients/python/noidroid/__init__.py
@@ -280,7 +280,7 @@ class _PassThrough:
     def __init__(self) -> None:
         self.workspace = os.getcwd()
 
-    def call(self, target, run, args=None, effect=READ):  # noqa: D102
+    def call(self, target, run, args=None, effect=READ, volatile=None):  # noqa: D102
         return run()
 
     def decide(self, name, options, choice):  # noqa: D102

--- a/clients/python/noidroid/_bootstrap/sitecustomize.py
+++ b/clients/python/noidroid/_bootstrap/sitecustomize.py
@@ -16,9 +16,35 @@ if os.environ.get("NOIDROID_SOCKET") and not os.environ.get("_NOIDROID_BOOTSTRAP
         from noidroid import auto
 
         hooked = auto.install()
-        if os.environ.get("NOIDROID_AUTO_VERBOSE") == "1":
-            listed = ", ".join(hooked) if hooked else "nothing"
-            print(f"[noidroid.auto] hooked: {listed}", file=sys.stderr)
+        # Always printed. This used to be gated on an environment variable that
+        # nothing in the project ever set, so the one documented mitigation for
+        # fail-open capture never actually ran.
+        listed = ", ".join(hooked) if hooked else "nothing"
+        print(f"[noidroid.auto] hooked: {listed}", file=sys.stderr)
+        gaps = auto.unhooked()
+        for missing in gaps:
+            print(
+                f"[noidroid.auto] NOT hooked: {missing} — calls through it are not "
+                f"recorded",
+                file=sys.stderr,
+            )
+        if gaps and os.environ.get("NOIDROID_ALLOW_GAPS") != "1":
+            # Fail closed. A recording that quietly missed the model calls still
+            # looks real and still claims to replay faithfully, which is the one
+            # failure this project cannot survive. Refusing costs a run; recording
+            # anyway costs the trust in every run.
+            print(
+                "[noidroid.auto] refusing to record: the surfaces above are not "
+                "captured, so this recording would be incomplete without saying so.\n"
+                "  Record it anyway with --allow-gaps if you know your program does "
+                "not use them.",
+                file=sys.stderr,
+            )
+            # os._exit rather than SystemExit: raising during site initialisation
+            # prints a traceback that pushes the explanation out of view, and the
+            # explanation is the entire point of refusing.
+            sys.stderr.flush()
+            os._exit(2)
     except Exception as exc:  # noqa: BLE001
         # Loud, because a recording that silently missed the model calls looks real.
         print(f"[noidroid.auto] could not install automatic capture: {exc}", file=sys.stderr)

--- a/clients/python/noidroid/auto.py
+++ b/clients/python/noidroid/auto.py
@@ -42,11 +42,23 @@ PROVIDERS = ("openai", "anthropic")
 
 _session = None
 _hooked: list[str] = []
+_unhooked: list[str] = []
 
 
 def hooked() -> list[str]:
     """What was successfully patched, in the order it was patched."""
     return list(_hooked)
+
+
+def unhooked() -> list[str]:
+    """Surfaces that are present and NOT captured.
+
+    This list is the important one. Every auto-instrumentation mechanism fails open,
+    and a missed call in an observability tool is a gap while a missed call here is a
+    trajectory that looks real. So what is *not* covered is reported as loudly as what
+    is, and `noidroid run --auto` refuses rather than recording half a program.
+    """
+    return list(_unhooked)
 
 
 def _shared_session():
@@ -151,9 +163,22 @@ def install(providers: Optional[tuple] = None) -> list[str]:
             continue
         client_cls = getattr(base, "SyncAPIClient", None)
         if client_cls is None:
-            continue
-        if getattr(client_cls.request, "__noidroid_wrapped__", False):
-            continue
-        _wrap_request(client_cls, provider)
-        _hooked.append(f"{provider}._base_client.SyncAPIClient.request")
+            # The docstring promises this raises. A rename upstream that silently
+            # recorded nothing and exited zero is exactly the failure this module
+            # exists to prevent.
+            raise RuntimeError(
+                f"{provider} is installed but its base client is not where this build "
+                f"expects it ({provider}._base_client.SyncAPIClient). Nothing would be "
+                f"recorded, so nothing is."
+            )
+        if not getattr(client_cls.request, "__noidroid_wrapped__", False):
+            _wrap_request(client_cls, provider)
+            _hooked.append(f"{provider}._base_client.SyncAPIClient.request")
+
+        # The async surface is a real hole and is reported as one. Mediation is a
+        # blocking request/response over one socket, so wrapping an async client
+        # would stall the loop it is running on — refusing is honest, half-covering
+        # it is not.
+        if getattr(base, "AsyncAPIClient", None) is not None:
+            _unhooked.append(f"{provider}._base_client.AsyncAPIClient.request")
     return hooked()

--- a/crates/noidroid-cli/src/main.rs
+++ b/crates/noidroid-cli/src/main.rs
@@ -10,7 +10,7 @@ use serde_json::Value;
 
 use noidroid_core::bundle;
 use noidroid_core::engine::{self, Mode, Report, RunSpec};
-use noidroid_core::model::{Action, Intervention, Provenance, Step, Trajectory};
+use noidroid_core::model::{Action, Failure, Intervention, Provenance, Step, Trajectory};
 use noidroid_core::repo::{self, Repo};
 use noidroid_core::{tree, Error, Result};
 
@@ -47,6 +47,10 @@ enum Command {
         /// replays; branching still needs a declared decision.
         #[arg(long)]
         auto: bool,
+        /// Record even though automatic capture reports surfaces it cannot cover.
+        /// Only when you know your program does not use them.
+        #[arg(long)]
+        allow_gaps: bool,
         /// Record this directory instead of a sandbox — your actual project. It is
         /// read, never written; `.noidroidignore` extends the skipped directories.
         #[arg(long, value_name = "DIR")]
@@ -83,6 +87,10 @@ enum Command {
         /// Make the interaction fail: `--fail 'message'`.
         #[arg(long, value_name = "MESSAGE")]
         fail: Option<String>,
+        /// A named way the world fails: timeout, server-error, rate-limited,
+        /// malformed, empty, unauthorized. `--inject all` branches each in turn.
+        #[arg(long, value_name = "KIND")]
+        inject: Option<String>,
         /// Stated-simulated value for an irreversible effect past the divergence
         /// point: `--simulate target='<json>'`. Without one, such calls are denied.
         #[arg(long, value_name = "TARGET=JSON")]
@@ -189,9 +197,10 @@ fn dispatch(cli: Cli) -> Result<ExitCode> {
         Command::Run {
             name,
             auto,
+            allow_gaps,
             watch,
             command,
-        } => cmd_run(&repo, &cwd, name, auto, watch, command),
+        } => cmd_run(&repo, &cwd, name, auto, allow_gaps, watch, command),
         Command::Log { trajectory } => cmd_log(&repo, trajectory),
         Command::Show { reference } => cmd_show(&repo, &reference),
         Command::Replay { trajectory } => cmd_replay(&repo, &cwd, &trajectory),
@@ -201,9 +210,10 @@ fn dispatch(cli: Cli) -> Result<ExitCode> {
             decide,
             result,
             fail,
+            inject,
             simulate,
         } => cmd_branch(
-            &repo, &cwd, &reference, label, decide, result, fail, simulate,
+            &repo, &cwd, &reference, label, decide, result, fail, inject, simulate,
         ),
         Command::Checkout {
             reference,
@@ -248,6 +258,15 @@ fn dispatch(cli: Cli) -> Result<ExitCode> {
 /// The same trick as `opentelemetry-instrument`: a directory containing
 /// `sitecustomize.py` goes on `PYTHONPATH`, and Python imports it before the program
 /// runs. Asking Python where its own package lives is more reliable than guessing.
+/// The same environment, plus the deliberate allowance for surfaces we cannot cover.
+fn auto_capture_env_with(allow_gaps: bool) -> Result<Vec<(String, String)>> {
+    let mut env = auto_capture_env()?;
+    if allow_gaps {
+        env.push(("NOIDROID_ALLOW_GAPS".to_string(), "1".to_string()));
+    }
+    Ok(env)
+}
+
 fn auto_capture_env() -> Result<Vec<(String, String)>> {
     let output = std::process::Command::new("python3")
         .args([
@@ -282,6 +301,7 @@ fn cmd_run(
     cwd: &Path,
     name: Option<String>,
     auto: bool,
+    allow_gaps: bool,
     watch: Option<PathBuf>,
     command: Vec<String>,
 ) -> Result<ExitCode> {
@@ -303,7 +323,7 @@ fn cmd_run(
         launch_dir: cwd.to_path_buf(),
         name: Some(name.clone()),
         env: if auto {
-            auto_capture_env()?
+            auto_capture_env_with(allow_gaps)?
         } else {
             Vec::new()
         },
@@ -453,7 +473,7 @@ fn cmd_replay(repo: &Repo, cwd: &Path, name: &str) -> Result<ExitCode> {
         launch_dir: cwd.to_path_buf(),
         name: None,
         env: if t.auto {
-            auto_capture_env()?
+            auto_capture_env_with(t.allow_gaps)?
         } else {
             Vec::new()
         },
@@ -511,6 +531,7 @@ fn cmd_branch(
     decide: Option<String>,
     result: Option<String>,
     fail: Option<String>,
+    inject: Option<String>,
     simulate: Vec<String>,
 ) -> Result<ExitCode> {
     let (name, index) = repo::parse_ref(reference);
@@ -518,6 +539,27 @@ fn cmd_branch(
         Error::Refused("a branch needs a checkpoint: <trajectory>@<step>".to_string())
     })?;
     let parent = repo.load_trajectory(&name)?;
+
+    // A named failure is just an intervention with the payload written for you —
+    // which is the difference between a thing people do and a thing people mean to.
+    let injected = match &inject {
+        Some(kind) => Some(Failure::parse(kind).ok_or_else(|| {
+            Error::Refused(format!(
+                "unknown failure '{kind}'. Known: {}",
+                Failure::ALL
+                    .iter()
+                    .map(|f| f.label())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ))
+        })?),
+        None => None,
+    };
+    if injected.is_some() && (decide.is_some() || result.is_some() || fail.is_some()) {
+        return Err(Error::Refused(
+            "give exactly one of --decide, --result, --fail, --inject".into(),
+        ));
+    }
 
     let intervention = match (decide, result, fail) {
         (Some(spec), None, None) => {
@@ -532,11 +574,14 @@ fn cmd_branch(
                 .map_err(|e| Error::Refused(format!("--result must be JSON: {e}")))?,
         },
         (None, None, Some(message)) => Intervention::Fail { error: message },
-        (None, None, None) => {
-            return Err(Error::Refused(
-                "a branch needs an intervention: --decide, --result or --fail".into(),
-            ))
-        }
+        (None, None, None) => match injected {
+            Some(failure) => failure.as_intervention(),
+            None => {
+                return Err(Error::Refused(
+                    "a branch needs an intervention: --decide, --result, --fail or --inject".into(),
+                ))
+            }
+        },
         _ => {
             return Err(Error::Refused(
                 "give exactly one of --decide, --result, --fail".into(),
@@ -550,7 +595,10 @@ fn cmd_branch(
         simulated.insert(target, parse_value(&value));
     }
 
-    let label = label.unwrap_or_else(|| repo.next_name("alt"));
+    let label = label.unwrap_or_else(|| match injected {
+        Some(failure) => repo.next_name(&format!("{name}~{}", failure.label())),
+        None => repo.next_name("alt"),
+    });
     if repo.has_trajectory(&label) {
         return Err(Error::Refused(format!(
             "trajectory '{label}' already exists"
@@ -563,7 +611,7 @@ fn cmd_branch(
         launch_dir: cwd.to_path_buf(),
         name: Some(label.clone()),
         env: if parent.auto {
-            auto_capture_env()?
+            auto_capture_env_with(parent.allow_gaps)?
         } else {
             Vec::new()
         },
@@ -610,6 +658,14 @@ fn cmd_branch(
         at
     );
     println!("  {:<12} {}", dim("intervention"), intervention.summary());
+    if let Some(failure) = injected {
+        println!(
+            "  {:<12} {} {}",
+            dim("failure"),
+            warn(failure.label()),
+            dim(failure.describes())
+        );
+    }
     print_shared_prefix(repo, &parent, &branch, at)?;
     println!();
     print_timeline(repo, &branch)?;

--- a/crates/noidroid-core/src/engine.rs
+++ b/crates/noidroid-core/src/engine.rs
@@ -248,6 +248,17 @@ pub fn run(repo: &Repo, spec: &RunSpec, mode: Mode, source: Option<&Trajectory>)
                 }
             }
         }
+        None if tail_of(&stderr_path).contains("refusing to record") => {
+            // Not a wiring problem: automatic capture found a hole and declined. The
+            // bootstrap already explained itself, so repeating a guess about
+            // PYTHONPATH would only bury it.
+            Err(Error::Refused(
+                tail_of(&stderr_path)
+                    .replace("It said:", "")
+                    .trim()
+                    .to_string(),
+            ))
+        }
         None => Err(Error::Protocol(format!(
             "the process exited without connecting to Paranoid Android.\n  The program must call the client (Python: `noidroid.connect()`), and that client\n  must be importable -- try: export PYTHONPATH=$PWD/clients/python{}",
             tail_of(&stderr_path)
@@ -325,6 +336,10 @@ pub fn run(repo: &Repo, spec: &RunSpec, mode: Mode, source: Option<&Trajectory>)
                 _ => Vec::new(),
             },
             auto: spec.auto,
+            allow_gaps: spec
+                .env
+                .iter()
+                .any(|(k, v)| k == "NOIDROID_ALLOW_GAPS" && v == "1"),
             watched: if watching { spec.watch.clone() } else { None },
         };
         repo.save_trajectory(&trajectory)?;

--- a/crates/noidroid-core/src/model.rs
+++ b/crates/noidroid-core/src/model.rs
@@ -219,6 +219,94 @@ pub enum Intervention {
     Fail { error: String },
 }
 
+/// The ways a world commonly fails, named.
+///
+/// An agent that never validates a tool result treats whatever comes back as ground
+/// truth, so the interesting question is not "does it work" but "what does it do when
+/// the answer is a timeout, a 500, or JSON that does not parse". Those are branches
+/// like any other — this only saves the operator from writing the payload by hand,
+/// which is the difference between a thing people do and a thing people mean to.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Failure {
+    Timeout,
+    ServerError,
+    RateLimited,
+    Malformed,
+    Empty,
+    Unauthorized,
+}
+
+impl Failure {
+    pub const ALL: [Failure; 6] = [
+        Failure::Timeout,
+        Failure::ServerError,
+        Failure::RateLimited,
+        Failure::Malformed,
+        Failure::Empty,
+        Failure::Unauthorized,
+    ];
+
+    pub fn parse(name: &str) -> Option<Failure> {
+        match name.replace('_', "-").to_ascii_lowercase().as_str() {
+            "timeout" => Some(Failure::Timeout),
+            "server-error" | "500" => Some(Failure::ServerError),
+            "rate-limited" | "429" => Some(Failure::RateLimited),
+            "malformed" | "bad-json" => Some(Failure::Malformed),
+            "empty" => Some(Failure::Empty),
+            "unauthorized" | "401" => Some(Failure::Unauthorized),
+            _ => None,
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Failure::Timeout => "timeout",
+            Failure::ServerError => "server-error",
+            Failure::RateLimited => "rate-limited",
+            Failure::Malformed => "malformed",
+            Failure::Empty => "empty",
+            Failure::Unauthorized => "unauthorized",
+        }
+    }
+
+    pub fn describes(self) -> &'static str {
+        match self {
+            Failure::Timeout => "the call never came back",
+            Failure::ServerError => "the service answered 500",
+            Failure::RateLimited => "the service answered 429",
+            Failure::Malformed => "the answer was not the shape it should be",
+            Failure::Empty => "the answer was well formed and said nothing",
+            Failure::Unauthorized => "the credential was refused",
+        }
+    }
+
+    /// What the agent receives. A raised error for the ones a client would raise, and
+    /// a *value* for the ones that come back looking fine — `empty` and `malformed`
+    /// are the interesting cases precisely because nothing throws.
+    pub fn as_intervention(self) -> Intervention {
+        match self {
+            Failure::Timeout => Intervention::Fail {
+                error: "the call timed out".to_string(),
+            },
+            Failure::ServerError => Intervention::Fail {
+                error: "HTTP 500 from the service".to_string(),
+            },
+            Failure::RateLimited => Intervention::Fail {
+                error: "HTTP 429: rate limited".to_string(),
+            },
+            Failure::Unauthorized => Intervention::Fail {
+                error: "HTTP 401: credential refused".to_string(),
+            },
+            Failure::Malformed => Intervention::ReplaceResult {
+                value: serde_json::Value::String("{\"unterminated\": ".to_string()),
+            },
+            Failure::Empty => Intervention::ReplaceResult {
+                value: serde_json::Value::Null,
+            },
+        }
+    }
+}
+
 impl Intervention {
     pub fn summary(&self) -> String {
         match self {
@@ -343,6 +431,10 @@ pub struct Trajectory {
     /// Recorded with automatic capture, so reconstructing it needs the same hooks.
     #[serde(default)]
     pub auto: bool,
+    /// Recorded with known capture gaps, deliberately. Carried so that replaying it
+    /// makes the same allowance — otherwise a reconstruction of it would refuse.
+    #[serde(default)]
+    pub allow_gaps: bool,
     /// The directory this run was recorded in, when it was the caller's own rather
     /// than a sandbox. It is where `restore` puts the files back by default.
     #[serde(default)]

--- a/crates/noidroid-core/src/repo.rs
+++ b/crates/noidroid-core/src/repo.rs
@@ -125,11 +125,25 @@ impl Repo {
 
     /// Materialise a trajectory's steps in execution order by walking parents from
     /// the head. The chain is a Merkle DAG, so this cannot loop.
+    ///
+    /// The version on each step is checked on the way in. `v` was written from the
+    /// first commit and never read, so a future build could have walked objects it
+    /// did not understand and reported the difference as the *program* diverging —
+    /// the exact confusion the version field exists to prevent.
     pub fn chain(&self, t: &Trajectory) -> Result<Vec<(Digest, Step)>> {
         let mut out = Vec::new();
         let mut cursor = Some(t.head.clone());
         while let Some(digest) = cursor {
             let step: Step = self.store.get_json(&digest)?;
+            if step.v != crate::model::STEP_VERSION {
+                return Err(Error::Refused(format!(
+                    "step {} was written in format v{}, and this build speaks v{}. \n                       Recordings are not migrated between formats; re-record, or use a \n                       build that speaks v{}.",
+                    digest.short(),
+                    step.v,
+                    crate::model::STEP_VERSION,
+                    step.v
+                )));
+            }
             cursor = step.parent.clone();
             out.push((digest, step));
         }

--- a/crates/noidroid-core/tests/auto_slice.rs
+++ b/crates/noidroid-core/tests/auto_slice.rs
@@ -161,6 +161,10 @@ fn a_program_with_no_noidroid_code_records_and_replays() {
         env: vec![
             ("PYTHONPATH".into(), pythonpath.clone()),
             ("FAKE_API".into(), format!("http://127.0.0.1:{PORT}")),
+            // This agent only uses the sync client, and the async surface we cannot
+            // cover would otherwise refuse the recording — which is the point of the
+            // refusal, and why saying so explicitly is the honest way past it.
+            ("NOIDROID_ALLOW_GAPS".into(), "1".into()),
         ],
         auto: true,
         watch: None,
@@ -204,6 +208,87 @@ fn a_program_with_no_noidroid_code_records_and_replays() {
         0,
         "nothing may be executed during a replay; the API is not even running"
     );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn a_capture_gap_stops_the_recording_unless_it_is_allowed() {
+    if !sdk_available() {
+        eprintln!("SKIP: needs the anthropic SDK (pip install anthropic)");
+        return;
+    }
+
+    let dir = std::env::temp_dir().join(format!(
+        "noidroid-gaps-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    fs::create_dir_all(&dir).unwrap();
+    // Importing the SDK brings an async client into the process. We patch only the
+    // sync surface, so this program has a hole we cannot cover.
+    let agent = dir.join("agent.py");
+    fs::write(
+        &agent,
+        "import anthropic\nimport noidroid\nnd = noidroid.connect()\n\
+         nd.call('work.do', lambda: {'ok': True})\nnd.finish('success', {})\n",
+    )
+    .unwrap();
+
+    let repo = Repo::open(&dir).unwrap();
+    let pythonpath = format!("{}:{}", bootstrap_path().display(), client_path().display());
+    let spec = |name: &str, allow: bool| {
+        let mut env = vec![("PYTHONPATH".to_string(), pythonpath.clone())];
+        if allow {
+            env.push(("NOIDROID_ALLOW_GAPS".to_string(), "1".to_string()));
+        }
+        RunSpec {
+            command: vec!["python3".into(), agent.display().to_string()],
+            launch_dir: dir.clone(),
+            name: Some(name.to_string()),
+            env,
+            auto: true,
+            watch: None,
+        }
+    };
+
+    // Fail closed. A recording that quietly missed a surface still looks real and
+    // still claims to replay faithfully, which is the failure this cannot survive.
+    let refused = engine::run(&repo, &spec("blocked", false), Mode::Record, None);
+    match refused {
+        Err(e) => {
+            let said = e.to_string();
+            assert!(
+                said.contains("AsyncAPIClient") && said.contains("--allow-gaps"),
+                "the refusal must name the surface and the way past it, got: {said}"
+            );
+        }
+        Ok(_) => panic!("recording should have been refused while a surface is unhooked"),
+    }
+    assert!(
+        repo.load_trajectory("blocked").is_err(),
+        "a refused recording leaves nothing behind"
+    );
+
+    // Escapable on purpose, and the allowance is remembered so replaying it does not
+    // refuse in turn.
+    let allowed = engine::run(&repo, &spec("gapped", true), Mode::Record, None)
+        .expect("--allow-gaps should record")
+        .trajectory
+        .expect("a recording produces a trajectory");
+    assert!(
+        allowed.allow_gaps,
+        "the allowance is part of what was recorded"
+    );
+
+    let mut replay = spec("unused", true);
+    replay.name = None;
+    let report = engine::run(&repo, &replay, Mode::Replay, Some(&allowed))
+        .expect("replay should run to completion");
+    assert!(report.faithful(), "{:?}", report.divergences);
 
     let _ = fs::remove_dir_all(&dir);
 }


### PR DESCRIPTION
An audit of the capture path found the project's own rule broken in four places,
and the worst of them was live in a published release.

Automatic capture never patched `AsyncAPIClient`, which exists in every install of
the SDK. A program using the async client had its sync calls recorded and its async
calls executed **live during replay** — real network, real spend — while the replay
reported itself faithful, because everything the engine knew about did match. That
is precisely the failure this project cannot survive: a trajectory that looks real.

The README claimed the mitigation already existed: "`--auto` prints what it hooked;
anything not listed was not recorded." It did not. The print was gated on an
environment variable that nothing in the repository ever set, so the one documented
defence against fail-open capture never executed.

Now `--auto` always reports what it hooked and what it could not, and refuses to
record when it finds a surface it cannot cover. `--allow-gaps` is the deliberate way
past, stored on the trajectory so a replay makes the same allowance rather than
refusing in turn. Refusing costs a run; recording anyway costs the trust in every
run.

Also: `auto.install()` silently continued when an SDK's base client had moved,
contradicting its own docstring — it raises now, because a rename upstream that
records nothing and exits zero is exactly what it exists to prevent. `Step.v` was
written but never validated on read. And `_PassThrough.call` rejected `volatile=`,
so a program using it broke when run *without* noidroid.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
