### PR TITLE
fix(fence): refuse to leave the machine during a replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ how the package version relates to `STEP_VERSION`, the on-disk object format.
 
 ### Added
 
-- **The egress fence.** During a replay, an outbound socket to anything but loopback
-  is refused. A reconstruction is supposed to serve every mediated input from the
+- **The egress fence.** During a replay or a branch, an outbound socket to anything
+  but loopback is refused. A reconstruction is supposed to serve every mediated input from the
   recording and touch nothing, but that was only enforced for calls that went
   *through* the protocol — anything a program did behind our back still reached the
   network, and nothing said so. The replay finished and reported itself faithful. That

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ how the package version relates to `STEP_VERSION`, the on-disk object format.
 
 ## [Unreleased]
 
+### Added
+
+- **The egress fence.** During a replay, an outbound socket to anything but loopback
+  is refused. A reconstruction is supposed to serve every mediated input from the
+  recording and touch nothing, but that was only enforced for calls that went
+  *through* the protocol — anything a program did behind our back still reached the
+  network, and nothing said so. The replay finished and reported itself faithful. That
+  was the worst failure mode here, because it was the silent one. Loopback stays open
+  for our own socket, the proxy and local stand-ins; recordings are never fenced,
+  since reaching the world is what they are recording.
+  Blind spots, stated rather than hidden: subprocesses do not inherit the patch, C
+  extensions can bypass Python's socket module, and connections opened before the
+  client loads escape it.
+- A run that dies mid-way now reports **what the program said on the way out**.
+  "Truncated" is true and explains nothing; the traceback usually is the explanation.
+
 ### Fixed
 
 - An I/O failure now says what it was doing and on what path. `No such file or

--- a/README.md
+++ b/README.md
@@ -411,6 +411,13 @@ $ noidroid run --auto -- python3 agent.py
   Record it anyway with --allow-gaps if you know your program does not use them.
 ```
 
+And during a replay the network is fenced: an outbound socket to anything but
+loopback is refused, because a reconstruction is supposed to serve every input from
+the recording and touch nothing. A blocked connection is not an inconvenience — it is
+proof that something was never recorded, and the report says which address tried to
+leave. It cannot see subprocesses, C extensions that bypass Python's socket module, or
+connections opened before the client loaded.
+
 `--allow-gaps` is the way past it, and the allowance is stored on the trajectory so
 replaying it makes the same one. Refusing costs you a run; recording anyway costs the
 trust in every run, because a trajectory that missed the model calls still looks real

--- a/clients/python/noidroid/__init__.py
+++ b/clients/python/noidroid/__init__.py
@@ -304,4 +304,10 @@ def connect():
     path = os.environ.get("NOIDROID_SOCKET")
     if not path:
         return _PassThrough()
+    # During a reconstruction nothing should reach the network: everything is served
+    # from the recording. Anything that still tries was never recorded, and saying so
+    # loudly is the whole point.
+    from . import fence
+
+    fence.install_for_mode()
     return Session(path)

--- a/clients/python/noidroid/_bootstrap/sitecustomize.py
+++ b/clients/python/noidroid/_bootstrap/sitecustomize.py
@@ -13,7 +13,11 @@ import sys
 if os.environ.get("NOIDROID_SOCKET") and not os.environ.get("_NOIDROID_BOOTSTRAPPED"):
     os.environ["_NOIDROID_BOOTSTRAPPED"] = "1"
     try:
-        from noidroid import auto
+        from noidroid import auto, fence
+
+        # Up as early as possible: a module-level request at import time would
+        # otherwise escape before the program ever reaches connect().
+        fence.install_for_mode()
 
         hooked = auto.install()
         # Always printed. This used to be gated on an environment variable that

--- a/clients/python/noidroid/fence.py
+++ b/clients/python/noidroid/fence.py
@@ -30,6 +30,9 @@ __all__ = ["install", "blocked", "Escaped"]
 _blocked: list[str] = []
 _installed = False
 
+#: The modes that are reconstructions rather than recordings.
+_RECONSTRUCTIONS = {"replay", "branch"}
+
 #: Loopback is allowed: the engine's socket, the recording proxy, local stand-ins.
 _LOCAL = {"127.0.0.1", "::1", "localhost", "0.0.0.0"}
 
@@ -105,11 +108,16 @@ def install(strict: bool = True) -> None:
 def install_for_mode(mode: Optional[str] = None) -> bool:
     """Put the fence up when the run is a reconstruction. Returns whether it went up.
 
-    Only during a replay. A recording is *supposed* to reach the world — that is what
-    it is recording — so fencing it would block the very traffic being captured.
+    A replay and a branch both are one. A branch re-derives a recorded prefix and
+    then deliberately does something else, and unmediated traffic is exactly as
+    unrecorded on either side of that point — so fencing only the replay would leave
+    the mode people actually run wide open.
+
+    A recording is *supposed* to reach the world — that is what it is recording — so
+    fencing it would block the very traffic being captured.
     """
     mode = mode or os.environ.get("NOIDROID_MODE", "")
-    if mode != "replay" or os.environ.get("NOIDROID_NO_FENCE") == "1":
+    if mode not in _RECONSTRUCTIONS or os.environ.get("NOIDROID_NO_FENCE") == "1":
         return False
     install(strict=True)
     return True

--- a/clients/python/noidroid/fence.py
+++ b/clients/python/noidroid/fence.py
@@ -1,0 +1,115 @@
+"""The egress fence.
+
+A replay is supposed to serve every mediated input back from the recording and touch
+nothing. That is enforced structurally at the protocol — the engine never says
+`execute` while reconstructing — but only for calls that *went through* the protocol.
+Anything the program does behind our back still reaches the network, and nothing says
+so: the replay finishes, reports itself faithful, and the trajectory looks real.
+
+That is the worst failure this project has, because it is the silent one. So during a
+replay the fence blocks outbound sockets and names what tried to leave. A blocked
+connection is not an inconvenience — it is the proof that something was never
+recorded.
+
+Local addresses stay open on purpose: our own Unix socket, and loopback, which is
+where the recording proxy and local stand-ins live.
+
+What it cannot see: subprocesses (a child does not inherit the patch), C extensions
+that bypass Python's socket module, and anything already connected before the fence
+went up.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+from typing import Optional
+
+__all__ = ["install", "blocked", "Escaped"]
+
+_blocked: list[str] = []
+_installed = False
+
+#: Loopback is allowed: the engine's socket, the recording proxy, local stand-ins.
+_LOCAL = {"127.0.0.1", "::1", "localhost", "0.0.0.0"}
+
+
+class Escaped(RuntimeError):
+    """A replay tried to reach the network, so something was never recorded."""
+
+
+def blocked() -> list[str]:
+    """Addresses this run tried to reach and was not allowed to."""
+    return list(_blocked)
+
+
+def _describe(address) -> str:
+    if isinstance(address, tuple) and address:
+        host = address[0]
+        port = address[1] if len(address) > 1 else "?"
+        return f"{host}:{port}"
+    return str(address)
+
+
+def _is_local(address) -> bool:
+    if not isinstance(address, tuple) or not address:
+        return True  # AF_UNIX and friends carry a path, not a host
+    host = str(address[0])
+    return host in _LOCAL or host.startswith("127.")
+
+
+def install(strict: bool = True) -> None:
+    """Patch outbound connects. `strict` raises; otherwise it only records.
+
+    Idempotent, because a program that imports the client twice should not end up
+    with two layers of patch.
+    """
+    global _installed
+    if _installed:
+        return
+    _installed = True
+
+    original_connect = socket.socket.connect
+    original_connect_ex = socket.socket.connect_ex
+
+    def guard(self, address):
+        if self.family == socket.AF_UNIX or _is_local(address):
+            return None
+        where = _describe(address)
+        _blocked.append(where)
+        raise Escaped(
+            f"this replay tried to reach {where}, which means something it did was "
+            f"never recorded — so the replay is not a reproduction. Record the run "
+            f"again with that interaction mediated, or route it through the proxy."
+        )
+
+    def connect(self, address):
+        if strict:
+            guard(self, address)
+        elif not (self.family == socket.AF_UNIX or _is_local(address)):
+            _blocked.append(_describe(address))
+        return original_connect(self, address)
+
+    def connect_ex(self, address):
+        if strict:
+            guard(self, address)
+        elif not (self.family == socket.AF_UNIX or _is_local(address)):
+            _blocked.append(_describe(address))
+        return original_connect_ex(self, address)
+
+    connect.__noidroid_fenced__ = True
+    socket.socket.connect = connect
+    socket.socket.connect_ex = connect_ex
+
+
+def install_for_mode(mode: Optional[str] = None) -> bool:
+    """Put the fence up when the run is a reconstruction. Returns whether it went up.
+
+    Only during a replay. A recording is *supposed* to reach the world — that is what
+    it is recording — so fencing it would block the very traffic being captured.
+    """
+    mode = mode or os.environ.get("NOIDROID_MODE", "")
+    if mode != "replay" or os.environ.get("NOIDROID_NO_FENCE") == "1":
+        return False
+    install(strict=True)
+    return True

--- a/crates/noidroid-cli/src/main.rs
+++ b/crates/noidroid-cli/src/main.rs
@@ -518,6 +518,14 @@ fn cmd_replay(repo: &Repo, cwd: &Path, name: &str) -> Result<ExitCode> {
         for d in &report.divergences {
             println!("    @{} {} — {}", d.index, warn(d.kind.label()), d.detail);
         }
+        // A run that died halfway reports as truncated, which is true and explains
+        // nothing. What it said on the way out usually is the explanation.
+        if let Some(said) = &report.last_words {
+            println!("\n  {}", dim("the program's last words:"));
+            for line in said.lines() {
+                println!("    {}", line.trim());
+            }
+        }
         Ok(ExitCode::from(1))
     }
 }

--- a/crates/noidroid-core/src/engine.rs
+++ b/crates/noidroid-core/src/engine.rs
@@ -124,6 +124,9 @@ pub struct Report {
     pub delivery: BTreeMap<&'static str, u64>,
     pub denied: Vec<String>,
     pub exit_code: Option<i32>,
+    /// The last thing the program said, when it ended badly. A run that died
+    /// halfway reports as `truncated`, which is true and says nothing about why.
+    pub last_words: Option<String>,
     pub stdout_path: Option<PathBuf>,
     pub stderr_path: Option<PathBuf>,
     pub workspace: Option<PathBuf>,
@@ -274,6 +277,13 @@ pub fn run(repo: &Repo, spec: &RunSpec, mode: Mode, source: Option<&Trajectory>)
 
     let mut report = session.report;
     report.exit_code = status.code();
+    if !status.success() {
+        let said = tail_of(&stderr_path).replace("It said:", "");
+        let said = said.trim();
+        if !said.is_empty() {
+            report.last_words = Some(said.to_string());
+        }
+    }
 
     // Anything the recording still had to offer that we never reached.
     if !recorded.is_empty() && (session.index as usize) < recorded.len() {

--- a/crates/noidroid-core/tests/fence_slice.rs
+++ b/crates/noidroid-core/tests/fence_slice.rs
@@ -1,0 +1,135 @@
+//! The egress fence.
+//!
+//! A replay serves every mediated input from the recording and touches nothing — but
+//! that is only enforced for calls that went *through* the protocol. Anything the
+//! program does behind our back still reaches the network, and until this fence
+//! nothing said so: the replay finished, reported itself faithful, and the trajectory
+//! looked real. That is the worst failure this project has, because it is silent.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use noidroid_core::engine::{self, Mode, RunSpec};
+use noidroid_core::Repo;
+
+/// Reaches for the network only when told to — and by IP, so a blocked attempt needs
+/// no DNS and no reachable host to prove the point.
+const AGENT: &str = r#"
+import os, socket
+import noidroid
+
+nd = noidroid.connect()
+nd.call("work.do", lambda: {"ok": True})
+if os.environ.get("SNEAK") == "1":
+    s = socket.socket()
+    s.settimeout(2)
+    s.connect(("93.184.216.34", 80))
+nd.finish("success", {})
+"#;
+
+struct Fixture {
+    dir: PathBuf,
+    repo: Repo,
+    agent: PathBuf,
+}
+
+impl Fixture {
+    fn new(tag: &str) -> Fixture {
+        let dir = std::env::temp_dir().join(format!(
+            "noidroid-fence-{tag}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        let agent = dir.join("agent.py");
+        fs::write(&agent, AGENT).unwrap();
+        let repo = Repo::open(&dir).unwrap();
+        Fixture { dir, repo, agent }
+    }
+
+    fn spec(&self, name: Option<&str>, sneak: bool) -> RunSpec {
+        let client = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../clients/python")
+            .canonicalize()
+            .unwrap();
+        RunSpec {
+            command: vec!["python3".into(), self.agent.display().to_string()],
+            launch_dir: self.dir.clone(),
+            name: name.map(str::to_string),
+            env: vec![
+                ("PYTHONPATH".into(), client.display().to_string()),
+                ("SNEAK".into(), if sneak { "1".into() } else { "0".into() }),
+            ],
+            auto: false,
+            watch: None,
+        }
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.dir);
+    }
+}
+
+#[test]
+fn a_replay_that_reaches_the_network_is_caught_and_explained() {
+    let f = Fixture::new("caught");
+    let recorded = engine::run(&f.repo, &f.spec(Some("run-1"), false), Mode::Record, None)
+        .expect("recording should succeed")
+        .trajectory
+        .expect("a recording produces a trajectory");
+
+    // Same program, now doing something nobody mediated. Before the fence this
+    // reached the network and the replay still called itself faithful.
+    let report = engine::run(&f.repo, &f.spec(None, true), Mode::Replay, Some(&recorded))
+        .expect("replay should run to completion");
+
+    assert!(
+        !report.faithful(),
+        "a replay that left the machine is not a reproduction"
+    );
+    let said = report
+        .last_words
+        .expect("a run that died mid-way should report why");
+    assert!(
+        said.contains("93.184.216.34") && said.contains("never recorded"),
+        "the report must name what tried to leave and why it matters, got: {said}"
+    );
+}
+
+#[test]
+fn the_fence_does_not_get_in_the_way_of_an_honest_replay() {
+    let f = Fixture::new("honest");
+    let recorded = engine::run(&f.repo, &f.spec(Some("run-1"), false), Mode::Record, None)
+        .unwrap()
+        .trajectory
+        .unwrap();
+
+    // The engine's own socket is a Unix socket and loopback stays open, so a replay
+    // that only talks to us is unaffected.
+    let report = engine::run(&f.repo, &f.spec(None, false), Mode::Replay, Some(&recorded))
+        .expect("replay should run to completion");
+    assert!(report.faithful(), "{:?}", report.divergences);
+    assert!(report.last_words.is_none(), "nothing went wrong to report");
+}
+
+#[test]
+fn recording_is_never_fenced() {
+    // A recording is supposed to reach the world — that is what it is recording.
+    // Fencing it would block the very traffic being captured.
+    let f = Fixture::new("recording");
+    let report = engine::run(&f.repo, &f.spec(Some("run-1"), true), Mode::Record, None)
+        .expect("recording should run");
+    // The connect either succeeds or fails on its own merits; what must not happen is
+    // the fence refusing it.
+    if let Some(said) = &report.last_words {
+        assert!(
+            !said.contains("never recorded"),
+            "the fence must not fire while recording, got: {said}"
+        );
+    }
+}

--- a/crates/noidroid-core/tests/fence_slice.rs
+++ b/crates/noidroid-core/tests/fence_slice.rs
@@ -6,10 +6,12 @@
 //! nothing said so: the replay finished, reported itself faithful, and the trajectory
 //! looked real. That is the worst failure this project has, because it is silent.
 
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
 use noidroid_core::engine::{self, Mode, RunSpec};
+use noidroid_core::model::Intervention;
 use noidroid_core::Repo;
 
 /// Reaches for the network only when told to — and by IP, so a blocked attempt needs
@@ -132,4 +134,38 @@ fn recording_is_never_fenced() {
             "the fence must not fire while recording, got: {said}"
         );
     }
+}
+
+/// A branch is a reconstruction too — it re-derives a recorded prefix and only then
+/// does something else. Traffic nobody mediated is exactly as unrecorded on either
+/// side of that point, and the branch is the mode people actually run.
+#[test]
+fn a_branch_is_fenced_the_same_as_a_replay() {
+    let f = Fixture::new("branched");
+    let recorded = engine::run(&f.repo, &f.spec(Some("run-1"), false), Mode::Record, None)
+        .expect("recording should succeed")
+        .trajectory
+        .expect("a recording produces a trajectory");
+
+    let report = engine::run(
+        &f.repo,
+        &f.spec(Some("alt-1"), true),
+        Mode::Branch {
+            at: 1,
+            intervention: Intervention::ReplaceResult {
+                value: serde_json::json!({"ok": false}),
+            },
+            simulate: BTreeMap::new(),
+        },
+        Some(&recorded),
+    )
+    .expect("the branch should run to completion");
+
+    let said = report
+        .last_words
+        .expect("the branch left the machine, so it should have died saying so");
+    assert!(
+        said.contains("93.184.216.34") && said.contains("never recorded"),
+        "a branch must be fenced like a replay, got: {said}"
+    );
 }


### PR DESCRIPTION
Closes #25

## What this changes

During a replay, an outbound socket to anything but loopback is refused. Until now that invariant was only enforced for calls that went through the protocol, so anything a program did behind our back reached the network while the replay still reported itself faithful.

Recordings are never fenced — reaching the world is what they are recording.

Also surfaces the program's last words when a run dies mid-way, since `truncated` explains nothing on its own.

## How it was verified

`cargo test --test fence_slice` — three tests: a sneaking replay is caught and the report names the address; an honest replay is unaffected; and a *recording* is never fenced (fencing the wrong phase would block the traffic being captured).

Full suite green, clippy clean with `-D warnings`.

## Known blind spots, documented not hidden

Subprocesses do not inherit the patch, C extensions can bypass Python's socket module, and connections opened before the client loads escape it.