### PR TITLE
fix(error): say what an I/O failure was doing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ how the package version relates to `STEP_VERSION`, the on-disk object format.
 
 ### Fixed
 
+- An I/O failure now says what it was doing and on what path. `No such file or
+  directory` names none of the six operations that can produce it, which made a
+  real CI failure unreadable. (#42)
 - **Automatic capture failed open, and said it did not.** The README promised
   "`--auto` prints what it hooked; anything not listed was not recorded" — but the
   print was gated behind an environment variable nothing in the project ever set, so

--- a/crates/noidroid-core/src/engine.rs
+++ b/crates/noidroid-core/src/engine.rs
@@ -23,7 +23,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use serde_json::{json, Value};
 
-use crate::error::{Error, Result};
+use crate::error::{Doing, Error, Result};
 use crate::hash::Digest;
 use crate::model::{
     Action, Delivery, Effect, EffectKind, EffectOutcome, ForkPoint, Intervention, Outcome,
@@ -181,9 +181,10 @@ pub fn run(repo: &Repo, spec: &RunSpec, mode: Mode, source: Option<&Trajectory>)
     };
     if !watching {
         if workspace.exists() {
-            fs::remove_dir_all(&workspace)?;
+            fs::remove_dir_all(&workspace).doing(|| format!("clearing {}", workspace.display()))?;
         }
-        fs::create_dir_all(&workspace)?;
+        fs::create_dir_all(&workspace)
+            .doing(|| format!("creating the workspace {}", workspace.display()))?;
     }
     // A watched directory is somebody's project, so the parts that dwarf the source
     // are skipped. A sandbox holds only what the run put there, so nothing is.
@@ -200,8 +201,11 @@ pub fn run(repo: &Repo, spec: &RunSpec, mode: Mode, source: Option<&Trajectory>)
 
     let socket_path = unique_socket_path();
     let _ = fs::remove_file(&socket_path);
-    let listener = UnixListener::bind(&socket_path)?;
-    listener.set_nonblocking(true)?;
+    let listener = UnixListener::bind(&socket_path)
+        .doing(|| format!("binding the socket {}", socket_path.display()))?;
+    listener
+        .set_nonblocking(true)
+        .doing(|| "putting the socket in non-blocking mode")?;
 
     let stdout_path = repo.log_path(&run_label, "out");
     let stderr_path = repo.log_path(&run_label, "err");
@@ -1199,9 +1203,14 @@ fn spawn(
         .env("NOIDROID_MODE", mode.label())
         .env("NOIDROID_WORKSPACE", workspace)
         .stdin(Stdio::null())
-        .stdout(Stdio::from(fs::File::create(stdout_path)?))
-        .stderr(Stdio::from(fs::File::create(stderr_path)?))
-        .spawn()?;
+        .stdout(Stdio::from(fs::File::create(stdout_path).doing(|| {
+            format!("opening the stdout log {}", stdout_path.display())
+        })?))
+        .stderr(Stdio::from(fs::File::create(stderr_path).doing(|| {
+            format!("opening the stderr log {}", stderr_path.display())
+        })?))
+        .spawn()
+        .doing(|| format!("starting `{}` in {}", program, workspace.display()))?;
     Ok(child)
 }
 

--- a/crates/noidroid-core/src/error.rs
+++ b/crates/noidroid-core/src/error.rs
@@ -2,7 +2,13 @@ use std::fmt;
 
 #[derive(Debug)]
 pub enum Error {
-    Io(std::io::Error),
+    /// A filesystem or socket failure. `doing` says what was being attempted and on
+    /// what, because `No such file or directory` on its own names none of the six
+    /// operations that can produce it.
+    Io {
+        doing: String,
+        source: std::io::Error,
+    },
     Json(serde_json::Error),
     /// An object's stored bytes no longer hash to its name.
     Corrupt {
@@ -24,7 +30,8 @@ pub type Result<T> = std::result::Result<T, Error>;
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Error::Io(e) => write!(f, "io: {e}"),
+            Error::Io { doing, source } if doing.is_empty() => write!(f, "io: {source}"),
+            Error::Io { doing, source } => write!(f, "io: {doing}: {source}"),
             Error::Json(e) => write!(f, "json: {e}"),
             Error::Corrupt { digest, detail } => write!(f, "corrupt object {digest}: {detail}"),
             Error::Divergence(d) => write!(f, "{d}"),
@@ -39,12 +46,34 @@ impl std::error::Error for Error {}
 
 impl From<std::io::Error> for Error {
     fn from(e: std::io::Error) -> Self {
-        Error::Io(e)
+        Error::Io {
+            doing: String::new(),
+            source: e,
+        }
     }
 }
 
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Json(e)
+    }
+}
+
+/// Attaches what we were doing to an I/O failure.
+///
+/// `?` alone throws away everything except the operating system's verdict, and
+/// `NotFound` is the verdict for a missing program, a missing directory, a socket
+/// whose parent is gone, and a log file that cannot be opened. The message is built
+/// only when something actually failed.
+pub trait Doing<T> {
+    fn doing<D: fmt::Display>(self, what: impl FnOnce() -> D) -> Result<T>;
+}
+
+impl<T> Doing<T> for std::result::Result<T, std::io::Error> {
+    fn doing<D: fmt::Display>(self, what: impl FnOnce() -> D) -> Result<T> {
+        self.map_err(|source| Error::Io {
+            doing: what().to_string(),
+            source,
+        })
     }
 }

--- a/crates/noidroid-core/src/lib.rs
+++ b/crates/noidroid-core/src/lib.rs
@@ -19,6 +19,6 @@ pub mod repo;
 pub mod store;
 pub mod tree;
 
-pub use error::{Error, Result};
+pub use error::{Doing, Error, Result};
 pub use hash::Digest;
 pub use repo::Repo;

--- a/crates/noidroid-core/tests/vertical_slice.rs
+++ b/crates/noidroid-core/tests/vertical_slice.rs
@@ -587,3 +587,38 @@ fn a_branch_from_an_unreachable_checkpoint_leaves_nothing_behind() {
     // The parent is exactly as it was.
     assert_eq!(f.repo.load_trajectory("run-1").unwrap(), parent);
 }
+
+/// The tool's own failures should read as well as the ones it reports about others.
+/// `No such file or directory` names none of the operations that can produce it, so
+/// an I/O failure has to say what it was doing.
+#[test]
+fn an_io_failure_says_what_it_was_doing() {
+    let dir = std::env::temp_dir().join(format!(
+        "noidroid-ioctx-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    fs::create_dir_all(&dir).unwrap();
+    let repo = Repo::open(&dir).unwrap();
+
+    // A program that is not there: the failure is a bare ENOENT from the OS.
+    let spec = RunSpec {
+        command: vec!["definitely-not-a-real-program-9fd2".into()],
+        launch_dir: dir.clone(),
+        name: Some("nope".into()),
+        env: Vec::new(),
+        auto: false,
+        watch: None,
+    };
+    let err = engine::run(&repo, &spec, Mode::Record, None).expect_err("no such program");
+    let said = err.to_string();
+    assert!(
+        said.contains("starting `definitely-not-a-real-program-9fd2`"),
+        "an io failure must name the operation, said: {said}"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
Closes #42

## What this changes

`Error::Io` carried a bare `std::io::Error`. `No such file or directory` is the answer for a missing program, a missing workspace, a socket whose parent is gone, and a log file that cannot be opened — so the message named none of them. The variant now carries what was being attempted and on what path, formatted only when something actually failed.

This is not hypothetical: the macOS job on #28 fails with exactly `Io(Os { code: 2, kind: NotFound })` and nothing else, and the fix is what will identify it.

## How it was verified

`cargo test --all` — new test `an_io_failure_says_what_it_was_doing` runs a program that does not exist and asserts the error names the spawn rather than the errno. Browser tests fail locally on main as well (local Chromium, unrelated); CI covers them.