### PR TITLE
fix(fence): allow exactly what the engine authorised

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,13 @@ how the package version relates to `STEP_VERSION`, the on-disk object format.
   failure reading, writing, listing or pruning now names the operation and the path,
   so a `NotFound` in CI says which file it could not find. This is what made the macOS
   failure in #44 unreadable for two runs. (#44)
-
+- **The fence blocked calls the engine had authorised.** Egress is now permitted for
+  the body of a call the engine answered `execute` to — and nowhere else, on the
+  thread that call runs on. A plain replay authorises nothing, so the window never
+  opens; a branch performs its post-fork calls, which are recorded and were never the
+  silent egress the fence exists to catch. Without this, `--live` would have been
+  fenced out of the one call it exists to make, and CI would not have noticed:
+  its stand-in is on loopback, which was allowed all along. (#46)
 
 ## [0.3.0] - 2026-08-19
 

--- a/clients/python/noidroid/__init__.py
+++ b/clients/python/noidroid/__init__.py
@@ -213,7 +213,13 @@ class Session:
         directive = response.get("directive")
         if directive == "execute":
             try:
-                value = run()
+                # The engine authorised this one, so the fence stands aside for its
+                # body and closes again immediately after. Everywhere else in a
+                # reconstruction, an outbound socket is something nobody recorded.
+                from . import fence
+
+                with fence.authorised():
+                    value = run()
             except Exception as exc:  # the world failed; record that it did
                 self._rpc(
                     {

--- a/clients/python/noidroid/fence.py
+++ b/clients/python/noidroid/fence.py
@@ -14,6 +14,12 @@ recorded.
 Local addresses stay open on purpose: our own Unix socket, and loopback, which is
 where the recording proxy and local stand-ins live.
 
+One thing is allowed through, and only in the smallest window that works: a call the
+engine told us to execute. A plain replay authorises nothing, so the window never
+opens; a live replay authorises the targets it was asked for, and nothing else. That
+is what keeps `--live model` from being fenced out of the one call it exists to make
+without lowering the fence for the rest of the program.
+
 What it cannot see: subprocesses (a child does not inherit the patch), C extensions
 that bypass Python's socket module, and anything already connected before the fence
 went up.
@@ -21,14 +27,21 @@ went up.
 
 from __future__ import annotations
 
+import contextlib
 import os
 import socket
+import threading
 from typing import Optional
 
-__all__ = ["install", "blocked", "Escaped"]
+__all__ = ["install", "blocked", "authorised", "Escaped"]
 
 _blocked: list[str] = []
 _installed = False
+
+#: Per-thread: are we inside a call the engine told us to execute? Thread-local
+#: because the proxy serves on one thread per request, and one authorised call must
+#: not open the fence for every other thread in the process.
+_window = threading.local()
 
 #: The modes that are reconstructions rather than recordings.
 _RECONSTRUCTIONS = {"replay", "branch"}
@@ -44,6 +57,28 @@ class Escaped(RuntimeError):
 def blocked() -> list[str]:
     """Addresses this run tried to reach and was not allowed to."""
     return list(_blocked)
+
+
+@contextlib.contextmanager
+def authorised():
+    """Open the fence for the body of a call the engine asked us to execute.
+
+    The engine says `execute` for exactly the interactions that are meant to touch
+    the world — none at all during a plain replay, and only the named targets during
+    a live one. Reaching the network anywhere else is the silent failure this module
+    exists to catch, so the window is as small as the authorisation is: this thread,
+    this call, and closed again the moment it returns.
+    """
+    depth = getattr(_window, "depth", 0)
+    _window.depth = depth + 1
+    try:
+        yield
+    finally:
+        _window.depth = depth
+
+
+def _inside_authorised_call() -> bool:
+    return getattr(_window, "depth", 0) > 0
 
 
 def _describe(address) -> str:
@@ -78,26 +113,34 @@ def install(strict: bool = True) -> None:
     def guard(self, address):
         if self.family == socket.AF_UNIX or _is_local(address):
             return None
+        if _inside_authorised_call():
+            return None  # the engine asked for this one
         where = _describe(address)
         _blocked.append(where)
+        what = os.environ.get("NOIDROID_MODE", "reconstruction")
         raise Escaped(
-            f"this replay tried to reach {where}, which means something it did was "
-            f"never recorded — so the replay is not a reproduction. Record the run "
-            f"again with that interaction mediated, or route it through the proxy."
+            f"this {what} tried to reach {where} outside any mediated call, which "
+            f"means nothing recorded it — so what it produced is not a "
+            f"reconstruction. Wrap that interaction in nd.call(), or route it "
+            f"through the proxy."
         )
+
+    def _noted(self, address) -> None:
+        if not (self.family == socket.AF_UNIX or _is_local(address)):
+            _blocked.append(_describe(address))
 
     def connect(self, address):
         if strict:
             guard(self, address)
-        elif not (self.family == socket.AF_UNIX or _is_local(address)):
-            _blocked.append(_describe(address))
+        else:
+            _noted(self, address)
         return original_connect(self, address)
 
     def connect_ex(self, address):
         if strict:
             guard(self, address)
-        elif not (self.family == socket.AF_UNIX or _is_local(address)):
-            _blocked.append(_describe(address))
+        else:
+            _noted(self, address)
         return original_connect_ex(self, address)
 
     connect.__noidroid_fenced__ = True

--- a/crates/noidroid-core/tests/fence_slice.rs
+++ b/crates/noidroid-core/tests/fence_slice.rs
@@ -29,6 +29,29 @@ if os.environ.get("SNEAK") == "1":
 nd.finish("success", {})
 "#;
 
+/// Reaches for the network *inside* a mediated call — the one place the engine can
+/// authorise. Where it ends up is recorded either way, so the failure message is the
+/// evidence: the fence names itself, a real network failure does not.
+const MEDIATED_AGENT: &str = r#"
+import socket
+import noidroid
+
+nd = noidroid.connect()
+nd.call("work.do", lambda: {"ok": True})
+
+def reach():
+    s = socket.socket()
+    s.settimeout(2)
+    s.connect(("203.0.113.1", 80))   # TEST-NET-3: routable nowhere
+    return {"reached": True}
+
+try:
+    nd.call("net.fetch", reach)
+    nd.finish("success", {"why": "reached"})
+except Exception as exc:
+    nd.finish("failure", {"why": str(exc)})
+"#;
+
 struct Fixture {
     dir: PathBuf,
     repo: Repo,
@@ -37,6 +60,10 @@ struct Fixture {
 
 impl Fixture {
     fn new(tag: &str) -> Fixture {
+        Fixture::of(tag, AGENT)
+    }
+
+    fn of(tag: &str, program: &str) -> Fixture {
         let dir = std::env::temp_dir().join(format!(
             "noidroid-fence-{tag}-{}-{}",
             std::process::id(),
@@ -47,7 +74,7 @@ impl Fixture {
         ));
         fs::create_dir_all(&dir).unwrap();
         let agent = dir.join("agent.py");
-        fs::write(&agent, AGENT).unwrap();
+        fs::write(&agent, program).unwrap();
         let repo = Repo::open(&dir).unwrap();
         Fixture { dir, repo, agent }
     }
@@ -177,5 +204,47 @@ fn a_branch_is_fenced_the_same_as_a_replay() {
     assert!(
         said.contains("93.184.216.34") && said.contains("never recorded"),
         "a branch must be fenced like a replay, got: {said}"
+    );
+}
+
+/// The fence stands aside for exactly what the engine authorised, and nothing else.
+///
+/// A branch executes its post-fork calls for real — that is what a branch is — and
+/// those calls are recorded, so they are not the silent egress this fence exists to
+/// catch. Blocking them would have made the fence refuse the very interactions the
+/// operator asked for, which is how a safety measure becomes a bug.
+#[test]
+fn the_fence_stands_aside_for_a_call_the_engine_asked_for() {
+    let f = Fixture::of("authorised", MEDIATED_AGENT);
+    let recorded = engine::run(&f.repo, &f.spec(Some("run-1"), false), Mode::Record, None)
+        .expect("recording should succeed")
+        .trajectory
+        .expect("a recording produces a trajectory");
+
+    // Branch before the network call, so it is re-performed past the fork rather
+    // than served back from the recording.
+    let branch = engine::run(
+        &f.repo,
+        &f.spec(Some("alt-1"), false),
+        Mode::Branch {
+            at: 1,
+            intervention: Intervention::ReplaceResult {
+                value: serde_json::json!({"ok": false}),
+            },
+            simulate: BTreeMap::new(),
+        },
+        Some(&recorded),
+    )
+    .expect("the branch should run to completion")
+    .trajectory
+    .expect("a branch produces a trajectory");
+
+    // TEST-NET-3 routes nowhere, so the call fails either way. *How* it failed is
+    // the evidence: the fence names itself, a network that is simply not there
+    // does not.
+    let why = branch.outcome.result["why"].as_str().unwrap_or("").to_string();
+    assert!(
+        !why.contains("never recorded"),
+        "the fence blocked a call the engine authorised: {why}"
     );
 }

--- a/crates/noidroid-core/tests/fence_slice.rs
+++ b/crates/noidroid-core/tests/fence_slice.rs
@@ -130,7 +130,7 @@ fn a_replay_that_reaches_the_network_is_caught_and_explained() {
         .last_words
         .expect("a run that died mid-way should report why");
     assert!(
-        said.contains("93.184.216.34") && said.contains("never recorded"),
+        said.contains("93.184.216.34") && said.contains("nothing recorded it"),
         "the report must name what tried to leave and why it matters, got: {said}"
     );
 }
@@ -167,7 +167,7 @@ fn recording_is_never_fenced() {
     // the fence refusing it.
     if let Some(said) = &report.last_words {
         assert!(
-            !said.contains("never recorded"),
+            !said.contains("nothing recorded it"),
             "the fence must not fire while recording, got: {said}"
         );
     }
@@ -202,7 +202,7 @@ fn a_branch_is_fenced_the_same_as_a_replay() {
         .last_words
         .expect("the branch left the machine, so it should have died saying so");
     assert!(
-        said.contains("93.184.216.34") && said.contains("never recorded"),
+        said.contains("93.184.216.34") && said.contains("nothing recorded it"),
         "a branch must be fenced like a replay, got: {said}"
     );
 }
@@ -242,9 +242,12 @@ fn the_fence_stands_aside_for_a_call_the_engine_asked_for() {
     // TEST-NET-3 routes nowhere, so the call fails either way. *How* it failed is
     // the evidence: the fence names itself, a network that is simply not there
     // does not.
-    let why = branch.outcome.result["why"].as_str().unwrap_or("").to_string();
+    let why = branch.outcome.result["why"]
+        .as_str()
+        .unwrap_or("")
+        .to_string();
     assert!(
-        !why.contains("never recorded"),
+        !why.contains("nothing recorded it"),
         "the fence blocked a call the engine authorised: {why}"
     );
 }


### PR DESCRIPTION
Closes #46

## What this changes

The fence blocked every non-loopback connect during a replay or a branch. Too blunt in one direction, and wrong in the other once `--live` (#24) lands:

- A **branch executes its post-fork calls for real** — that is what a branch is — and those calls are recorded, so they were never the silent egress this fence exists to catch. Blocking them made a safety measure refuse the interactions the operator asked for.
- A **live replay is still mode `replay`**, so the fence would have blocked the model call the flag exists to make. CI would not have caught it: the test stand-in is on loopback, which was allowed all along. A test that passes for a reason unrelated to what it tests is how a project earns a false claim.

The engine already knows what may touch the world — it answers `execute`, and only then. The client now opens the fence for that call's body and closes it again: this thread, this call. Thread-local, because the proxy serves one thread per request and one authorised call must not open the fence for the whole process.

Net effect is a **smaller** hole than before, not a larger one: the blast radius goes from "the whole process during a replay" to "the body of a call the engine asked for", and a plain replay authorises nothing at all.

## How it was verified

New test `the_fence_stands_aside_for_a_call_the_engine_asked_for`: branches past a mediated network call and asserts the failure is the network's, not the fence's. Confirmed it **fails** with the window disabled before accepting that it passes with it. Existing fence tests unchanged and still passing, including the one that catches unmediated egress in a branch.