### PR TITLE
feat(env): the laws of the Stand — an explicit environment contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,29 @@ jobs:
           noidroid verify | tee verify.txt
           grep -q "intact:" verify.txt
 
+          # The reference environment: a world that can be re-driven and can never be
+          # put back. The release's central claim is that this reconstructs exactly,
+          # that a branch reaches a different outcome, and that a checkpoint sitting
+          # after an irreversible effect is refused rather than attempted.
+          noidroid run --name shift -- python3 examples/reference/agent.py || true
+          noidroid replay shift | tee shift-replay.txt
+          grep -q "faithful:" shift-replay.txt
+
+          noidroid show shift@8 | tee shift-show.txt
+          grep -q "witnessed" shift-show.txt
+          grep -q "WHAT THIS CHECKPOINT GUARANTEES" shift-show.txt
+
+          noidroid branch shift@8 --decide move=insert --label saved
+          noidroid diff shift saved | tee shift-diff.txt
+          grep -q "failure → success" shift-diff.txt
+          grep -q "the same objects, not copies" shift-diff.txt
+
+          last=$(python3 -c "import json;print(json.load(open('.noidroid/trajectories/shift.json'))['steps']-1)")
+          if noidroid branch "shift@$last" --fail x --label nope 2>refused.txt; then
+            echo "branching past an irreversible effect must be refused"; exit 1
+          fi
+          grep -q "irreversible" refused.txt
+
           # The Stand profile is pure output, so it either prints or it does not.
           noidroid stand | tee stand.txt
           grep -q "PARANOID ANDROID" stand.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,91 @@ how the package version relates to `STEP_VERSION`, the on-disk object format.
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-08-19
+
+*The laws of the Stand.* This release adds almost no functionality. It makes the
+execution model coherent, so that adding robotics, RL environments or a laboratory
+later is an adapter rather than a redesign. The contract is
+[`docs/environment-model.md`](docs/environment-model.md).
+
+### Added
+
+- **The environment contract.** An environment is not something we can save and load;
+  it is something that can be asked, told, and asked what it knows about its own state.
+  Three methods — `manifest`, `observe`, `restore` — and two of them are allowed to say
+  no. Three implementations, because there are three distinct answers: `Workspace` (the
+  directory we own), `Reported` (a world only the program can see), and `Situation`
+  (the two together). Anything not written in Rust declares its world over the wire
+  instead, with the new `observe` protocol message.
+- **Grip: what a state reference is worth.** `state_root` used to be the Merkle root of
+  a directory, full stop — one answer to "what is the state here", and the wrong one for
+  every environment this project is aimed at. A step now records a `grip` beside it:
+  `captured` (we hold the bytes and can put the world back), `witnessed` (we hold a
+  fingerprint, so a reconstruction that lands elsewhere is detected and can never be
+  repaired), `opaque` (nothing was captured, so re-execution still works and cannot be
+  shown to have worked). Grip joins like provenance: the weakest part decides.
+- **A checkpoint answers three questions.** `noidroid show` now prints *reach* (can I
+  get back here: `rebuild`, `rebuild+restore`, `unreachable`), *evidence* (will I know
+  if I got it wrong) and *grounding* (is what I get back to a claim about reality). None
+  collapses into another, and none of them is a percentage. A robot checkpoint reads
+  `rebuild / none / real`; a checkpoint inside a branch reads
+  `rebuild / captured / simulated`.
+- **Branching from an unreachable checkpoint is refused before the program is spawned.**
+  If the prefix performed an irreversible effect in a world we cannot put back, the only
+  route back through it is to perform it again. The refusal names the step and the
+  target. Discovering this halfway through is the version that re-submits the form in
+  order to find out it should not have.
+- **The reference environment** (`examples/reference/`): a deterministic reactor and an
+  operator whose policy is reasonable and wrong. About a hundred lines that record,
+  reconstruct, branch, intervene and compare — original melts down, branch survives —
+  in a world that can be re-driven and can never be put back. It is the environment
+  contract made runnable, and it is what `environment_slice` tests against.
+- `Trajectory.worlds` records which worlds a run declared and how well it could see
+  them, so `noidroid log` can say what it would take to return to a recording.
+
+### Changed
+
+- **The browser adapter declares its page as a world.** It was already re-driving and
+  comparing page digests, in its own private vocabulary, with nothing in the core aware
+  that a page existed. The page is now a `witnessed` world like any other: the
+  fingerprint lands in the recorded state at `.world/browser.json`, `noidroid show`
+  prints it, `noidroid diff` shows when it changed, and the checkpoint analysis knows
+  the difference between the workspace and the page.
+- **`bisect` no longer counts a probe that established nothing as a flip.** A branch
+  that could not be re-entered, could not be reconstructed, or died without reaching a
+  verdict reads as `unknown`. Reporting it as "changed the outcome" was inventing the
+  one answer the command exists to find.
+- `EffectKind::Write` is documented as what it always meant: *reversible under
+  reconstruction*, not "touches a disk". A browser navigation is a `write` because
+  re-driving rebuilds the page; an actuator command is `irreversible` because nothing
+  rebuilds the world.
+
+### Fixed
+
+- **A reconstruction claimed to have restored a world it had not.** When a
+  `write`/`irreversible` effect was deliberately not re-executed, the engine restored
+  the recorded tree and counted the step as `state_restored`. For a directory that is
+  true. For a browser it filed a page nobody restored under the address of the page the
+  recording saw. Restoration now reports the grip it actually achieved, and anything
+  short of `captured` is *checked* instead of asserted.
+- **The browser tests could not tell a missing browser from a broken one.** The guard
+  looked for a Chromium on disk, so a host with the download but not its shared
+  libraries failed three tests with an agent that "aborted" for no stated reason. It
+  launches a browser now — and the first version of that probe was itself the same bug
+  one level down: `cargo fmt` joined its multi-line string literal and kept the source
+  indentation, turning the script into an `IndentationError` that exited in thirteen
+  milliseconds and read as "no browser here", on the CI job whose entire purpose is to
+  run the browser tests. One-line script now, and the skip says which shared library is
+  missing.
+
+### Compatibility
+
+`STEP_VERSION` stays at **1**. `grip` defaults to `captured` and is skipped when
+serialising, so a step recorded before this release reads back as exactly what it was,
+and a workspace-only step recorded after it serialises to the same bytes and the same
+address as before. Existing trajectories replay, branch, export and import unchanged.
+No migration.
+
 ### Added
 
 - **The egress fence.** During a replay or a branch, an outbound socket to anything
@@ -244,6 +329,7 @@ only the sandboxed workspace is captured, the ambient environment is not capture
 branch is not a prediction, browser reconstruction is bounded by the recorded page
 set, and no scale work.
 
-[Unreleased]: https://github.com/swalla02/noidroid/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/swalla02/noidroid/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/swalla02/noidroid/releases/tag/v0.3.0
 [0.2.0]: https://github.com/swalla02/noidroid/releases/tag/v0.2.0
 [0.1.0]: https://github.com/swalla02/noidroid/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "noidroid-cli"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "clap",
  "noidroid-core",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "noidroid-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "blake3",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/noidroid-core", "crates/noidroid-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/swalla02/noidroid"

--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ to you, the tool is unaffected.
 instrumented Python programs and for real browser sessions — and it is explicit
 about where its knowledge stops. See [Limitations](#limitations).
 
+What it means for an environment to participate — what it must be able to do, what it
+may decline, and how a checkpoint says which — is the contract in
+[`docs/environment-model.md`](docs/environment-model.md).
+[`examples/reference/`](examples/reference/README.md) is that document made runnable:
+a hundred lines that record, reconstruct, branch and compare, in a world that can be
+re-driven and can never be put back.
+
 ---
 
 ## The example, end to end
@@ -80,13 +87,24 @@ CHECKPOINT run-1@2
   action       decide pick_flight = "FL-101"
   options      ["FL-101","FL-203","FL-311"]
   provenance   real
-  state        1 file(s) root 367c26441d
+  state        1 file(s) root 367c26441d · captured
                · notes/candidates.json
+
+  WHAT THIS CHECKPOINT GUARANTEES
+    reach        rebuild    re-execute the prefix; every input comes from the recording
+    evidence     captured   re-derived addresses are compared byte for byte
+    grounding    real
 
   EXPLORE FROM HERE
     noidroid branch run-1@2 --decide pick_flight=FL-203
     → what if it had chosen differently?
 ```
+
+Three separate questions, and a checkpoint answers them separately: **can I get back
+here**, **will I know if I got it wrong**, and **is what I get back to a claim about
+reality**. A Python program in a sandbox gets the strongest answer to all three. A
+browser page or a robot arm does not, and says so instead of rounding up — see
+[`docs/environment-model.md`](docs/environment-model.md).
 
 Take the other path:
 
@@ -466,6 +484,7 @@ nd.finish("success", {"picked": pick})
 | `call(target, run, effect=…)` | recorded, replayed instead of re-executed, and branchable |
 | `decide(name, options, choice)` | the *choice* becomes branchable |
 | `finish(status, result)` | the trajectory has an outcome worth comparing |
+| `observe(name, state)` | for the rare environment that carries state *between* steps — a page, a simulator, a reactor — and which almost nothing needs. See [`docs/environment-model.md`](docs/environment-model.md) §4.2 |
 
 `run` is invoked **only** when the engine says so, and during replay it never does.
 That is why a replay cannot touch the world: the guarantee lives in the protocol, not
@@ -523,10 +542,20 @@ faithful replay re-derives *the same objects*. `noidroid replay` reports
 (`key_mismatch`, `state_mismatch`, `unexpected_call`, `truncated`).
 
 **Branching is the data model, not a feature.** A step is
-`(parent, action, effects, state_root, provenance)`, addressed by its hash. A branch
+`(parent, action, effects, state, provenance)`, addressed by its hash. A branch
 is a step whose parent belongs to another trajectory. Immutable history, shared
 prefixes and copy-on-write all fall out of that; identical files and tool responses
 are stored once.
+
+**A state reference says what it is worth.** Most environments are not a directory, so
+a step records a *grip* alongside its state: `captured` (we hold the bytes and can put
+the world back), `witnessed` (we hold a fingerprint, so a reconstruction that lands
+elsewhere is detected and cannot be repaired), or `opaque` (nothing was captured, so
+re-execution still works and cannot be shown to have worked). Grip joins like
+provenance — the weakest part decides — and `noidroid show` answers three separate
+questions at a checkpoint: can I get back here, will I know if I got it wrong, and is
+what I get back to a claim about reality. The contract is
+[`docs/environment-model.md`](docs/environment-model.md).
 
 **Two kinds of honesty are tracked separately.** *Provenance* is a property of
 content and is part of the hash — `real` ⊑ `live` ⊑ `simulated` ⊑ `unknown`, joined
@@ -539,7 +568,10 @@ performed only during an original recording. Every replay and every branch refus
 unless you explicitly supply a stated-simulated value, which then poisons the
 provenance of everything downstream.
 
-Design reasoning, and where this disagrees with the manifesto, is in
+The environment contract — what an environment must satisfy to participate, what it
+may decline, and how the difference is represented rather than papered over — is
+[`docs/environment-model.md`](docs/environment-model.md). Design reasoning, and where
+this disagrees with the manifesto, is in
 [`docs/technical-proposal.md`](docs/technical-proposal.md).
 
 ---
@@ -556,7 +588,9 @@ cannot be vague about its own boundaries.
 - **Sequential programs only.** Threads, async races and concurrent interleavings are
   out of scope. A non-deterministic program will be reported as divergent, not
   silently mis-replayed.
-- **Only the sandboxed workspace is captured.** Unmediated writes *inside* it are
+- **Only the sandboxed workspace is *captured*.** Anything else an environment tells us
+  about is `witnessed` at best: comparable, never restorable. A world nobody reports is
+  `opaque`, and reported as such. Unmediated writes *inside* the workspace are
   detected by hash. Writes outside it — networks, databases, other directories — are
   neither captured nor detected.
 - **The ambient environment is not captured.** Environment variables, installed
@@ -624,9 +658,11 @@ because an object's name *is* the hash of its bytes.
 crates/noidroid-core/   objects, store, workspace trees, the record/replay/branch engine
 crates/noidroid-cli/    the `noidroid` binary, the palette, the viewer, the Stand
 clients/python/         the client (stdlib only) and the browser adapter
+examples/reference/     the reference environment: the whole lifecycle in 100 lines
 examples/flight_agent/  the example above
 examples/browser_agent/ the same idea driving real Chromium
-docs/                   technical proposal
+docs/                   the environment contract, the technical proposal, the direction
+research/               the scout's knowledge base: discoveries, landscape, recommendations
 manifesto.md            the product vision this is built toward
 ```
 

--- a/clients/python/noidroid/__init__.py
+++ b/clients/python/noidroid/__init__.py
@@ -29,6 +29,11 @@ Typical use::
 
     nd.finish("success", {"booked": pick})
 
+Those three -- ``call``, ``decide``, ``finish`` -- are the whole mandatory contract.
+There is a fourth, ``observe``, which almost nothing should use: it is for an
+environment carrying state *between* steps that the recorded effects do not capture,
+such as a browser page or a simulator. See ``docs/environment-model.md`` §4.2.
+
 Running the same script without ``noidroid run`` is fine: ``connect()`` returns a
 pass-through session that simply executes everything and records nothing.
 """
@@ -60,10 +65,13 @@ PROTOCOL_VERSION = 1
 
 #: Observes; repeating it changes nothing.
 READ = "read"
-#: Mutates the sandboxed workspace; reversible because the sandbox belongs to Paranoid Android.
+#: Mutates a world we can put back -- the sandboxed workspace, or an environment that
+#: re-driving rebuilds. It is a claim about *reversibility under reconstruction*, not
+#: about touching a disk: a browser navigation is a write because re-driving the
+#: recorded actions rebuilds the page.
 WRITE = "write"
-#: Leaves the sandbox -- payments, mail, production writes, physical actuation.
-#: Never performed during replay, denied by default while branching.
+#: Leaves a mark we cannot take back -- payments, mail, production writes, physical
+#: actuation. Never performed during replay, denied by default while branching.
 IRREVERSIBLE = "irreversible"
 
 
@@ -169,7 +177,7 @@ class Session:
             raise NoidroidError(detail)
         return response
 
-    # -- the three things an application declares ---------------------------
+    # -- what an application declares ---------------------------------------
 
     def call(
         self,
@@ -248,6 +256,39 @@ class Session:
         )
         return response.get("value", choice)
 
+    def observe(self, of: str, state: Any = None, restorable: bool = False) -> None:
+        """Report what the world you can see looks like now.
+
+        Paranoid Android cannot look at a browser page, a simulator or an instrument.
+        This is how you tell it what is true out there, and how much that testimony is
+        worth. The observation is recorded at ``.world/<of>.json`` inside the step's
+        state, so it is content-addressed, inspectable and compared automatically on
+        every reconstruction.
+
+        ``state=None`` declares the world and says plainly that you are *not* observing
+        it. That is ``opaque``: reconstruction is still possible and simply cannot be
+        shown to have worked. It is a legitimate answer and a fabricated fingerprint is
+        not.
+
+        **Most programs should never call this.** Declare a world only when state
+        persists inside the environment across steps *and* is not carried by the
+        recorded effects. A model provider needs no world -- every call is independent
+        and its answer is recorded. A browser does: the page persists and is read
+        later. See ``docs/environment-model.md`` §4.2.
+
+        Report what must be true for a reconstruction to count, not everything that is
+        true. A fingerprint containing a clock makes every reconstruction diverge,
+        which is accurate and useless.
+        """
+        self._rpc(
+            {
+                "op": "observe",
+                "of": of,
+                "state": state,
+                "restorable": restorable,
+            }
+        )
+
     def finish(self, status: str, result: Any = None) -> None:
         """Record the application's own verdict on how the execution went."""
         self._rpc({"op": "finish", "status": status, "result": result})
@@ -285,6 +326,9 @@ class _PassThrough:
 
     def decide(self, name, options, choice):  # noqa: D102
         return choice
+
+    def observe(self, of, state=None, restorable=False):  # noqa: D102
+        return None
 
     def finish(self, status, result=None):  # noqa: D102
         return None

--- a/clients/python/noidroid/browser.py
+++ b/clients/python/noidroid/browser.py
@@ -16,6 +16,12 @@ mediated through Paranoid Android and become branchable steps. HTTP *responses* 
 alongside them and replayed into the browser, which is what makes re-driving
 deterministic.
 
+The page itself is declared to the core as a **world** with a `witnessed` grip: a
+fingerprint we can compare and can never put back. That is not decoration. It is what
+makes `noidroid show` say `evidence: witnessed` at a browser checkpoint instead of
+implying the byte-level proof it has over the workspace, and what makes the core refuse
+to re-enter a checkpoint sitting after an irreversible browser action.
+
 Three things follow, and they are the honest boundaries of this adapter:
 
 1. The browser is launched lazily -- only when the engine actually says `execute`.
@@ -176,11 +182,37 @@ class Browser:
             observation["reconstruction"] = self._reconstruction
             self._reconstruction = None
         self._append_action(target, args, observation)
+        self._report_world(observation)
         if self._ungrounded:
             # The browser was never put back into the recorded state, so nothing it
             # tells us from here on is evidence about the original execution.
             return Ungrounded(observation)
         return observation
+
+    def _report_world(self, observation: dict) -> None:
+        """Tell the core what the page looks like now.
+
+        The page is a *world* in the sense of ``docs/environment-model.md`` §4.2: state
+        that persists between steps and that no recorded return value carries forward.
+        Declaring it is what makes the core mark these steps `witnessed` -- reachable by
+        re-driving, checkable by fingerprint, and never restorable -- instead of
+        implying the `captured` grip it has over the workspace.
+
+        What goes in the fingerprint is a judgement call, and the rule is *report what
+        must be true for a reconstruction to count, not everything that is true*. The
+        URL, the title and the page digest are what this adapter already compares when
+        it re-drives a prefix, so they are what it reports. Adding a timestamp would be
+        just as accurate and would make every reconstruction diverge.
+        """
+        self._nd.observe(
+            "browser",
+            {
+                "url": observation["url"],
+                "title": observation["title"],
+                "digest": observation["digest"],
+            },
+            restorable=False,
+        )
 
     def _reconstruction_note(self) -> str:
         if self._reconstruction is None:

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "noidroid"
-version = "0.2.0"
+version = "0.3.0"
 description = "Python client for the Paranoid Android trajectory engine."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/crates/noidroid-cli/Cargo.toml
+++ b/crates/noidroid-cli/Cargo.toml
@@ -12,7 +12,7 @@ name = "noidroid"
 path = "src/main.rs"
 
 [dependencies]
-noidroid-core = { path = "../noidroid-core", version = "0.2.0" }
+noidroid-core = { path = "../noidroid-core", version = "0.3.0" }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 ratatui = "0.30.2"

--- a/crates/noidroid-cli/src/main.rs
+++ b/crates/noidroid-cli/src/main.rs
@@ -9,6 +9,7 @@ use clap::{Parser, Subcommand};
 use serde_json::Value;
 
 use noidroid_core::bundle;
+use noidroid_core::checkpoint;
 use noidroid_core::engine::{self, Mode, Report, RunSpec};
 use noidroid_core::model::{Action, Failure, Intervention, Provenance, Step, Trajectory};
 use noidroid_core::repo::{self, Repo};
@@ -471,10 +472,62 @@ fn cmd_show(repo: &Repo, reference: &str) -> Result<ExitCode> {
         "  {:<12} {} file(s) {}",
         dim("state"),
         workspace.entries.len(),
-        dim(&format!("root {}", step.state_root.short()))
+        dim(&format!(
+            "root {} · {}",
+            step.state_root.short(),
+            step.grip.label()
+        ))
     );
     for entry in workspace.entries.iter().take(8) {
         println!("               {} {}", dim("·"), entry.path);
+    }
+
+    // Three independent questions, and none of them collapses into another: can I get
+    // back here, will I know if I got it wrong, and is what I get back to a claim
+    // about reality. See docs/environment-model.md §6.
+    let point = checkpoint::at(&chain, index).expect("the step was just read");
+    println!("\n  {}", shell("WHAT THIS CHECKPOINT GUARANTEES"));
+    println!(
+        "    {:<12} {} {}",
+        dim("reach"),
+        if point.reach.is_reachable() {
+            ok(point.reach.label())
+        } else {
+            bad(point.reach.label())
+        },
+        dim(match point.reach {
+            checkpoint::Reach::Rebuild =>
+                "re-execute the prefix; every input comes from the recording",
+            checkpoint::Reach::RebuildAndRestore =>
+                "re-execute the prefix, restoring around effects we will not re-perform",
+            checkpoint::Reach::Unreachable { .. } => "",
+        })
+        .trim_end()
+    );
+    if let Some(why) = point.reach.why() {
+        for line in why.lines() {
+            println!("                 {}", warn(line.trim()));
+        }
+    }
+    println!(
+        "    {:<12} {} {}",
+        dim("evidence"),
+        point.evidence.label(),
+        dim(point.evidence.evidence())
+    );
+    println!(
+        "    {:<12} {}",
+        dim("grounding"),
+        provenance_text(point.grounding)
+    );
+
+    if !point.reach.is_reachable() {
+        println!("\n  {}", shell("EXPLORE FROM HERE"));
+        println!(
+            "    {}",
+            dim("nothing can be explored from here; pick an earlier step with `noidroid log`")
+        );
+        return Ok(ExitCode::SUCCESS);
     }
 
     println!("\n  {}", shell("EXPLORE FROM HERE"));
@@ -924,7 +977,7 @@ fn cmd_bisect(
             auto: parent.auto,
             watch: None,
         };
-        let report = engine::run(
+        let attempt = engine::run(
             repo,
             &spec,
             Mode::Branch {
@@ -936,16 +989,26 @@ fn cmd_bisect(
                 simulate: simulated.clone(),
             },
             Some(&parent),
-        )?;
+        );
 
-        let outcome = match &report.trajectory {
-            Some(branch) => branch.outcome.status.clone(),
-            None => "unreachable".to_string(),
+        // A probe that could not be re-entered, could not be reconstructed, or died
+        // without reaching a verdict has established *nothing*. Counting it as
+        // "changed the outcome" would be inventing the one answer this command
+        // exists to find, so it reads as `unknown` and never flips.
+        let outcome = match &attempt {
+            Err(Error::Refused(_)) => "unreachable".to_string(),
+            Err(e) => return Err(Error::Protocol(format!("probing {name}@{at}: {e}"))),
+            Ok(report) => match &report.trajectory {
+                Some(branch) => branch.outcome.status.clone(),
+                None => "unreachable".to_string(),
+            },
         };
-        let flips = match &goal {
-            Some(wanted) => &outcome == wanted,
-            None => outcome != original && outcome != "unreachable",
-        };
+        let established = !matches!(outcome.as_str(), "unreachable" | "aborted" | "unknown");
+        let flips = established
+            && match &goal {
+                Some(wanted) => &outcome == wanted,
+                None => outcome != original,
+            };
         println!(
             "  @{at} {} = {:<18} {}{}",
             dim(&decision),
@@ -953,6 +1016,8 @@ fn cmd_bisect(
             status_text(&outcome),
             if flips {
                 format!("  {}", ok("← flips it"))
+            } else if !established {
+                format!("  {}", warn("← unknown, nothing was established"))
             } else {
                 String::new()
             }
@@ -1219,6 +1284,20 @@ fn print_header(t: &Trajectory) {
         status_text(&t.outcome.status),
         origin
     );
+    // What it would take to return to this run: which worlds the program declared it
+    // could see, and how well. Silent for the ordinary case, where the workspace is
+    // the whole of the recorded world.
+    if !t.worlds.is_empty() {
+        println!(
+            "  {} {}",
+            dim("world"),
+            t.worlds
+                .iter()
+                .map(|w| format!("{} ({})", w.name, w.grip.label()))
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    }
 }
 
 fn print_timeline(repo: &Repo, t: &Trajectory) -> Result<()> {

--- a/crates/noidroid-cli/src/tui.rs
+++ b/crates/noidroid-cli/src/tui.rs
@@ -634,7 +634,13 @@ fn draw_checkpoint(f: &mut Frame, area: Rect, app: &App) {
                 ),
             ]));
         }
-        lines.push(field("state", step.state_root.short()));
+        // The address, and what holding it is worth. A viewer that shows a state root
+        // without its grip invites the reader to assume `captured`, which for a page
+        // or a reactor is the one thing it is not.
+        lines.push(field(
+            "state",
+            &format!("{} · {}", step.state_root.short(), step.grip.label()),
+        ));
         if let Action::Decide { options, .. } = &step.action {
             lines.push(Line::raw(""));
             lines.push(Line::from(Span::styled(

--- a/crates/noidroid-core/src/checkpoint.rs
+++ b/crates/noidroid-core/src/checkpoint.rs
@@ -75,8 +75,6 @@ pub struct Checkpoint {
     pub evidence: Grip,
     /// This step's own provenance, already joined along the chain.
     pub grounding: Provenance,
-    /// Whether this step is one an intervention can be applied to at all.
-    pub branchable: bool,
 }
 
 /// Read the chain at `index`.
@@ -116,7 +114,6 @@ pub fn at(chain: &[(Digest, Step)], index: u64) -> Option<Checkpoint> {
                             },
                             evidence: evidence_over(chain, index),
                             grounding: step.provenance,
-                            branchable: branchable(&step.action),
                         });
                     }
                     reach = Reach::RebuildAndRestore;
@@ -131,17 +128,7 @@ pub fn at(chain: &[(Digest, Step)], index: u64) -> Option<Checkpoint> {
         reach,
         evidence: evidence_over(chain, index),
         grounding: step.provenance,
-        branchable: branchable(&step.action),
     })
-}
-
-/// Every checkpoint in a trajectory. Used by anything that reasons across steps —
-/// `bisect` most of all, which must not report an unreachable probe as "did not flip
-/// the outcome".
-pub fn all(chain: &[(Digest, Step)]) -> Vec<Checkpoint> {
-    (0..chain.len() as u64)
-        .filter_map(|i| at(chain, i))
-        .collect()
 }
 
 /// The weakest grip anywhere in `0..=index`: what a reconstruction of that prefix
@@ -151,10 +138,6 @@ fn evidence_over(chain: &[(Digest, Step)], index: u64) -> Grip {
         .iter()
         .take(index as usize + 1)
         .fold(Grip::Captured, |acc, (_, s)| acc.join(s.grip))
-}
-
-fn branchable(action: &Action) -> bool {
-    matches!(action, Action::Call { .. } | Action::Decide { .. })
 }
 
 fn target_of(action: &Action) -> String {

--- a/crates/noidroid-core/src/checkpoint.rs
+++ b/crates/noidroid-core/src/checkpoint.rs
@@ -1,0 +1,271 @@
+//! What a checkpoint guarantees.
+//!
+//! A checkpoint is not an object and is not a saved world. It is a *reading* of the
+//! step chain that answers three independent questions about a point in an execution:
+//!
+//! ```text
+//! reach      can I get back here?
+//! evidence   will I know if I got it wrong?
+//! grounding  is what I get back to a claim about reality?
+//! ```
+//!
+//! None of the three collapses into another. A robot checkpoint reads
+//! `rebuild / none / real` — reachable, unverifiable, and grounded in an execution
+//! that really happened. A checkpoint inside a branch reads
+//! `rebuild / captured / simulated` — reachable, provable, and counterfactual. Both
+//! are useful and neither is a percentage.
+//!
+//! Everything here is a pure function of the recorded chain. Nothing runs.
+
+use crate::env::Grip;
+use crate::hash::Digest;
+use crate::model::{Action, EffectKind, EffectOutcome, Provenance, Step};
+
+/// The procedure that gets back to a point, if there is one.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum Reach {
+    /// Re-execute the prefix with every mediated input served from the recording.
+    /// Nothing in it has to be re-performed.
+    Rebuild,
+    /// The same, plus: at each step whose `write` or `irreversible` effect we refuse
+    /// to re-perform, the recorded state is put back instead.
+    RebuildAndRestore,
+    /// The prefix performed something we will not perform again and cannot restore
+    /// around, because the world at that step is not one we hold.
+    Unreachable { index: u64, target: String },
+}
+
+impl Reach {
+    pub fn label(&self) -> &'static str {
+        match self {
+            Reach::Rebuild => "rebuild",
+            Reach::RebuildAndRestore => "rebuild+restore",
+            Reach::Unreachable { .. } => "unreachable",
+        }
+    }
+
+    pub fn is_reachable(&self) -> bool {
+        !matches!(self, Reach::Unreachable { .. })
+    }
+
+    /// The sentence a refusal should carry. Names the step and the target, because
+    /// "unreachable" on its own tells nobody what to do about it.
+    pub fn why(&self) -> Option<String> {
+        match self {
+            Reach::Unreachable { index, target } => Some(format!(
+                "step {index} performed '{target}', which is declared irreversible, in a world \
+                 this run cannot put back.\n  Re-entering this checkpoint would mean performing \
+                 it again. Branch at or before step {index} instead."
+            )),
+            _ => None,
+        }
+    }
+}
+
+/// A point in a trajectory, read as a place you might return to.
+#[derive(Clone, PartialEq, Debug)]
+pub struct Checkpoint {
+    pub index: u64,
+    pub step: Digest,
+    /// How to get back to just before this step — the prefix `0..index`. Exclusive,
+    /// because `index` is the step a branch replaces.
+    pub reach: Reach,
+    /// What a reconstruction of `0..=index` would be able to prove: the weakest grip
+    /// anywhere in it.
+    pub evidence: Grip,
+    /// This step's own provenance, already joined along the chain.
+    pub grounding: Provenance,
+    /// Whether this step is one an intervention can be applied to at all.
+    pub branchable: bool,
+}
+
+/// Read the chain at `index`.
+///
+/// Returns `None` if the chain has no such step.
+pub fn at(chain: &[(Digest, Step)], index: u64) -> Option<Checkpoint> {
+    let (digest, step) = chain.get(index as usize)?;
+
+    let mut reach = Reach::Rebuild;
+    for (_, prior) in chain.iter().take(index as usize) {
+        for effect in &prior.effects {
+            // An effect that did not produce a value never happened: a denial or an
+            // error leaves nothing behind to re-perform or restore around.
+            if effect.outcome != EffectOutcome::Value {
+                continue;
+            }
+            match effect.effect {
+                EffectKind::Read => {}
+                EffectKind::Write => {
+                    if reach == Reach::Rebuild {
+                        reach = Reach::RebuildAndRestore;
+                    }
+                }
+                EffectKind::Irreversible => {
+                    // A world we hold can be put back around an irreversible effect:
+                    // we do not re-perform it, we restore the state it left. A world
+                    // we merely witness cannot, because the only way back through it
+                    // is to re-drive the actions that produced it -- which would
+                    // perform the irreversible one again.
+                    if !prior.grip.is_captured() {
+                        return Some(Checkpoint {
+                            index,
+                            step: digest.clone(),
+                            reach: Reach::Unreachable {
+                                index: prior.index,
+                                target: target_of(&prior.action),
+                            },
+                            evidence: evidence_over(chain, index),
+                            grounding: step.provenance,
+                            branchable: branchable(&step.action),
+                        });
+                    }
+                    reach = Reach::RebuildAndRestore;
+                }
+            }
+        }
+    }
+
+    Some(Checkpoint {
+        index,
+        step: digest.clone(),
+        reach,
+        evidence: evidence_over(chain, index),
+        grounding: step.provenance,
+        branchable: branchable(&step.action),
+    })
+}
+
+/// Every checkpoint in a trajectory. Used by anything that reasons across steps —
+/// `bisect` most of all, which must not report an unreachable probe as "did not flip
+/// the outcome".
+pub fn all(chain: &[(Digest, Step)]) -> Vec<Checkpoint> {
+    (0..chain.len() as u64)
+        .filter_map(|i| at(chain, i))
+        .collect()
+}
+
+/// The weakest grip anywhere in `0..=index`: what a reconstruction of that prefix
+/// could prove at its weakest point, which is what it can prove.
+fn evidence_over(chain: &[(Digest, Step)], index: u64) -> Grip {
+    chain
+        .iter()
+        .take(index as usize + 1)
+        .fold(Grip::Captured, |acc, (_, s)| acc.join(s.grip))
+}
+
+fn branchable(action: &Action) -> bool {
+    matches!(action, Action::Call { .. } | Action::Decide { .. })
+}
+
+fn target_of(action: &Action) -> String {
+    match action {
+        Action::Call { target, .. } => target.clone(),
+        Action::Decide { name, .. } => name.clone(),
+        Action::Genesis { .. } => "genesis".to_string(),
+        Action::Finish { .. } => "finish".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{Effect, Step};
+    use serde_json::json;
+
+    fn chain_of(steps: Vec<Step>) -> Vec<(Digest, Step)> {
+        steps
+            .into_iter()
+            .map(|s| (Digest::of(format!("{s:?}").as_bytes()), s))
+            .collect()
+    }
+
+    fn step(index: u64, effects: Vec<Effect>, grip: Grip) -> Step {
+        let mut s = Step::new(
+            None,
+            index,
+            Action::Call {
+                target: "t".into(),
+                args: json!({}),
+                effect: EffectKind::Read,
+            },
+            effects,
+            Digest::of(b""),
+            Provenance::Real,
+            Provenance::Real,
+            None,
+        );
+        s.grip = grip;
+        s
+    }
+
+    fn effect(kind: EffectKind) -> Effect {
+        Effect {
+            key: "k".into(),
+            value: Digest::of(b"v"),
+            effect: kind,
+            provenance: Provenance::Real,
+            outcome: EffectOutcome::Value,
+        }
+    }
+
+    #[test]
+    fn a_read_only_prefix_is_reached_by_rebuilding_alone() {
+        let chain = chain_of(vec![
+            step(0, vec![effect(EffectKind::Read)], Grip::Captured),
+            step(1, vec![effect(EffectKind::Read)], Grip::Captured),
+        ]);
+        assert_eq!(at(&chain, 1).unwrap().reach, Reach::Rebuild);
+    }
+
+    #[test]
+    fn a_written_prefix_has_to_be_restored_around() {
+        let chain = chain_of(vec![
+            step(0, vec![effect(EffectKind::Write)], Grip::Captured),
+            step(1, vec![effect(EffectKind::Read)], Grip::Captured),
+        ]);
+        assert_eq!(at(&chain, 1).unwrap().reach, Reach::RebuildAndRestore);
+    }
+
+    #[test]
+    fn an_irreversible_effect_is_survivable_only_in_a_world_we_hold() {
+        let held = chain_of(vec![
+            step(0, vec![effect(EffectKind::Irreversible)], Grip::Captured),
+            step(1, vec![], Grip::Captured),
+        ]);
+        assert_eq!(at(&held, 1).unwrap().reach, Reach::RebuildAndRestore);
+
+        let witnessed = chain_of(vec![
+            step(0, vec![effect(EffectKind::Irreversible)], Grip::Witnessed),
+            step(1, vec![], Grip::Witnessed),
+        ]);
+        assert_eq!(
+            at(&witnessed, 1).unwrap().reach,
+            Reach::Unreachable {
+                index: 0,
+                target: "t".into()
+            }
+        );
+    }
+
+    #[test]
+    fn a_denied_irreversible_effect_never_happened_and_blocks_nothing() {
+        let mut denied = effect(EffectKind::Irreversible);
+        denied.outcome = EffectOutcome::Denied;
+        let chain = chain_of(vec![
+            step(0, vec![denied], Grip::Witnessed),
+            step(1, vec![], Grip::Witnessed),
+        ]);
+        assert_eq!(at(&chain, 1).unwrap().reach, Reach::Rebuild);
+    }
+
+    #[test]
+    fn evidence_is_the_weakest_grip_in_the_prefix_not_the_grip_here() {
+        let chain = chain_of(vec![
+            step(0, vec![], Grip::Captured),
+            step(1, vec![], Grip::Opaque),
+            step(2, vec![], Grip::Captured),
+        ]);
+        assert_eq!(at(&chain, 0).unwrap().evidence, Grip::Captured);
+        assert_eq!(at(&chain, 2).unwrap().evidence, Grip::Opaque);
+    }
+}

--- a/crates/noidroid-core/src/engine.rs
+++ b/crates/noidroid-core/src/engine.rs
@@ -10,6 +10,12 @@
 //! same objects as the recording, the reconstruction is faithful with respect to
 //! everything we captured. If it does not, we say exactly where it stopped matching
 //! and refuse to pretend otherwise.
+//!
+//! What "everything we captured" covers is the environment's business, not this
+//! module's. The engine asks a [`Situation`] to address the world and to say what that
+//! address is worth. Where the workspace is the whole world the answer is `captured`
+//! and nothing about the old behaviour changes; where it is not -- a browser page, a
+//! simulator, a reactor -- the weaker answer is recorded rather than rounded up.
 
 use std::collections::BTreeMap;
 use std::fmt;
@@ -23,6 +29,8 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use serde_json::{json, Value};
 
+use crate::checkpoint;
+use crate::env::{Environment, Grip, Situation, State, Workspace};
 use crate::error::{Doing, Error, Result};
 use crate::hash::Digest;
 use crate::model::{
@@ -119,6 +127,9 @@ pub struct Report {
     /// Workspace snapshots restored from the recording because the mediated effect
     /// that produced them was deliberately not re-executed.
     pub state_restored: u64,
+    /// The weakest grip anywhere in this run: what it could prove at its weakest
+    /// point, which is what it can prove.
+    pub grip: Grip,
     pub divergences: Vec<Divergence>,
     pub provenance: BTreeMap<&'static str, u64>,
     pub delivery: BTreeMap<&'static str, u64>,
@@ -164,6 +175,16 @@ pub fn run(repo: &Repo, spec: &RunSpec, mode: Mode, source: Option<&Trajectory>)
         None => Vec::new(),
     };
 
+    // Whether a checkpoint can be re-entered is a property of the recording, so it is
+    // answered before anything is spawned. The version of this that finds out halfway
+    // through is the version that re-drives a browser into a form it already
+    // submitted, in order to discover that it should not have.
+    if let Mode::Branch { at, .. } = &mode {
+        if let Some(why) = checkpoint::at(&recorded, *at).and_then(|c| c.reach.why()) {
+            return Err(Error::Refused(why));
+        }
+    }
+
     let run_label = spec.name.clone().unwrap_or_else(|| {
         format!(
             "replay-{}",
@@ -196,10 +217,20 @@ pub fn run(repo: &Repo, spec: &RunSpec, mode: Mode, source: Option<&Trajectory>)
     } else {
         tree::Ignores::none()
     };
-    // Reconstruction starts from the world the recording started from.
+    // The world starts as the one part of it the engine owns outright. Anything else
+    // is added when the program says it can see it.
+    let mut situation = Situation::new(Workspace::new(&workspace, ignores));
+    // Reconstruction starts from the world the recording started from -- as much of it
+    // as this environment can put back, which the environment itself decides.
     if let Some(t) = source {
         let genesis: Step = repo.store.get_json(&t.genesis)?;
-        tree::materialize(&genesis.state_root, &repo.store, &workspace)?;
+        situation.restore(
+            &State {
+                root: genesis.state_root.clone(),
+                grip: genesis.grip,
+            },
+            &repo.store,
+        )?;
     }
 
     let socket_path = unique_socket_path();
@@ -225,8 +256,7 @@ pub fn run(repo: &Repo, spec: &RunSpec, mode: Mode, source: Option<&Trajectory>)
         repo,
         mode: &mode,
         recorded: &recorded,
-        workspace: workspace.clone(),
-        ignores,
+        env: situation,
         parent: None,
         parent_provenance: Provenance::Real,
         index: 0,
@@ -355,6 +385,7 @@ pub fn run(repo: &Repo, spec: &RunSpec, mode: Mode, source: Option<&Trajectory>)
                 .iter()
                 .any(|(k, v)| k == "NOIDROID_ALLOW_GAPS" && v == "1"),
             watched: if watching { spec.watch.clone() } else { None },
+            worlds: session.env.manifests(),
         };
         repo.save_trajectory(&trajectory)?;
         repo.save_notes(&name, &session.notes)?;
@@ -369,8 +400,8 @@ struct Session<'a> {
     repo: &'a Repo,
     mode: &'a Mode,
     recorded: &'a [(Digest, Step)],
-    workspace: PathBuf,
-    ignores: tree::Ignores,
+    /// The world, in parts. Everything this module knows about state goes through it.
+    env: Situation,
     parent: Option<Digest>,
     parent_provenance: Provenance,
     index: u64,
@@ -459,6 +490,16 @@ impl<'a> Session<'a> {
                     };
                 }
                 self.on_result(json!({ "error": message, "type": kind }))
+            }
+            Request::Observe {
+                of,
+                state,
+                restorable,
+            } => {
+                let observed = if state.is_null() { None } else { Some(&state) };
+                self.env
+                    .report(&of, observed, restorable, &self.repo.store)?;
+                Ok(Response::ack())
             }
             Request::Finish { status, result } => {
                 let action = Action::Finish {
@@ -920,39 +961,90 @@ impl<'a> Session<'a> {
         suppressed_side_effect: bool,
     ) -> Result<()> {
         let started = Instant::now();
-        let actual_root = tree::snapshot_with(&self.workspace, &self.repo.store, &self.ignores)?;
         let expected = self.recorded.get(self.index as usize).cloned();
+        // While reconstructing, the program is not touching the world -- every value
+        // it asked for was served from the recording -- so it has nothing new to say
+        // about it, and the honest source for "what did it look like here" is the
+        // recording. Testimony obeys the recorded-input oracle like everything else.
+        // A program that *did* re-drive its world has already reported, and its report
+        // wins: that is the case where the comparison means something.
+        if matches!(self.phase(), Phase::Reconstructing) {
+            if let Some((_, rec)) = &expected {
+                let tree = tree::read(&rec.state_root, &self.repo.store)?;
+                for (name, seen) in Situation::worlds_in(&tree) {
+                    self.env.adopt(&name, seen);
+                }
+            }
+        }
+        let observed = self.env.observe(&self.repo.store)?;
+        self.report.grip = self.report.grip.join(observed.grip);
 
         let state_root = match (&expected, suppressed_side_effect) {
             // The mediated effect that produced this state was deliberately not
-            // re-executed, so the workspace is restored from the recording instead.
-            // Counted as restored, never as verified: we did not prove this one.
+            // re-executed, so the recorded state is put back instead -- as far as the
+            // environment can put it back, which for anything but the workspace is
+            // not at all.
+            (Some((_, rec)), true) if observed.root == rec.state_root => {
+                // Already where the recording says it should be, with nothing put
+                // back to get there. That is the strongest thing we could have said,
+                // and it is checked rather than asserted.
+                self.report.state_verified += 1;
+                observed.root
+            }
             (Some((_, rec)), true) => {
-                if actual_root != rec.state_root {
-                    tree::materialize(&rec.state_root, &self.repo.store, &self.workspace)?;
+                let achieved = self.env.restore(
+                    &State {
+                        root: rec.state_root.clone(),
+                        grip: rec.grip,
+                    },
+                    &self.repo.store,
+                )?;
+                if achieved.is_captured() {
+                    // Counted as restored, never as verified: we did not prove this
+                    // one, we asserted it from the recording.
+                    self.report.state_restored += 1;
+                    rec.state_root.clone()
+                } else {
+                    // The environment could not put its world back, so asserting the
+                    // recorded address here would file a page nobody restored under
+                    // the address of the page the recording saw. Look again instead,
+                    // and record what is actually there.
+                    let after = self.env.observe(&self.repo.store)?;
+                    if matches!(self.phase(), Phase::Reconstructing | Phase::Diverging) {
+                        self.report.divergences.push(Divergence {
+                            index: self.index,
+                            kind: DivergenceKind::StateMismatch,
+                            detail: format!(
+                                "the world hashes to {} but the recording says {}; \
+                                 this environment reports it as {} and cannot put it back",
+                                after.root.short(),
+                                rec.state_root.short(),
+                                achieved.label()
+                            ),
+                        });
+                    }
+                    after.root
                 }
-                self.report.state_restored += 1;
-                rec.state_root.clone()
             }
             (Some((_, rec)), false)
                 if matches!(self.phase(), Phase::Reconstructing | Phase::Diverging) =>
             {
-                if actual_root == rec.state_root {
+                if observed.root == rec.state_root {
                     self.report.state_verified += 1;
                 } else {
                     self.report.divergences.push(Divergence {
                         index: self.index,
                         kind: DivergenceKind::StateMismatch,
                         detail: format!(
-                            "workspace hashes to {} but the recording says {}",
-                            actual_root.short(),
+                            "the world hashes to {} but the recording says {}",
+                            observed.root.short(),
                             rec.state_root.short()
                         ),
                     });
                 }
-                actual_root
+                observed.root
             }
-            _ => actual_root,
+            _ => observed.root,
         };
 
         let step = Step::new(
@@ -964,7 +1056,8 @@ impl<'a> Session<'a> {
             self.parent_provenance,
             own,
             intervention,
-        );
+        )
+        .with_grip(observed.grip);
         for e in &step.effects {
             *self
                 .report
@@ -1002,6 +1095,7 @@ impl<'a> Session<'a> {
             wall_ms: now_ms(),
             duration_ms: started.elapsed().as_millis() as u64,
         });
+        self.env.settle();
         self.parent_provenance = step.provenance;
         self.parent = Some(digest);
         self.index += 1;

--- a/crates/noidroid-core/src/env.rs
+++ b/crates/noidroid-core/src/env.rs
@@ -1,0 +1,485 @@
+//! The environment contract.
+//!
+//! An environment is *not* something Paranoid Android can save and load. It is
+//! something that can be asked, told, and — crucially — asked what it knows about its
+//! own state. See [`docs/environment-model.md`](../../../docs/environment-model.md);
+//! this module is that document in code.
+//!
+//! Three methods, and two of them are allowed to say no:
+//!
+//! ```text
+//! manifest()  what am I, and what is the best I can ever offer
+//! observe()   address the world as it is now, and say what that address is worth
+//! restore()   put it back, and say how much of it you actually put back
+//! ```
+//!
+//! Three implementations, which between them cover every environment in the
+//! conformance table:
+//!
+//! * [`Workspace`] — the sandboxed directory. The one world the engine owns outright,
+//!   so the only one it can genuinely put back.
+//! * [`Reported`] — a world only the program can see: a browser page, a simulator, an
+//!   instrument. It reports a fingerprint, or admits it is not looking.
+//! * [`Situation`] — the two together. The grip on the whole is the weakest grip of
+//!   any part, which is the same law provenance obeys and for the same reason.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::error::Result;
+use crate::hash::Digest;
+use crate::model::{Tree, TreeEntry};
+use crate::store::Store;
+use crate::tree;
+
+/// Where a reported observation lands inside the recorded tree.
+///
+/// Never snapshotted from the filesystem and never written back onto it: it is
+/// evidence *about* a world, not any part of one, and the moment it can be read as a
+/// file it has become an input nobody declared.
+pub const WORLD_DIR: &str = ".world";
+
+/// What holding a recorded state reference entitles you to do.
+///
+/// This is the distinction the whole release turns on. A state root is an address, and
+/// an address is worth something quite different depending on what is behind it.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Grip {
+    /// The store holds the bytes. `restore` reproduces the world exactly.
+    ///
+    /// The default, because it is what every recording made before this release had:
+    /// a sandboxed workspace and nothing else.
+    #[default]
+    Captured,
+    /// The store holds a fingerprint. A reconstruction that lands somewhere else is
+    /// *detected*; it cannot be *repaired*.
+    Witnessed,
+    /// Nothing was captured. Re-execution may well reconstruct this perfectly, and we
+    /// have no way to say that it did. Reported as such rather than implied to be a
+    /// check that passed.
+    Opaque,
+}
+
+impl Grip {
+    pub fn rank(self) -> u8 {
+        match self {
+            Grip::Captured => 0,
+            Grip::Witnessed => 1,
+            Grip::Opaque => 2,
+        }
+    }
+
+    /// The weakest of the two. A claim about a whole is never stronger than the
+    /// weakest claim it rests on.
+    pub fn join(self, other: Grip) -> Grip {
+        if self.rank() >= other.rank() {
+            self
+        } else {
+            other
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Grip::Captured => "captured",
+            Grip::Witnessed => "witnessed",
+            Grip::Opaque => "opaque",
+        }
+    }
+
+    /// What a reconstruction can prove when this is the grip it had.
+    pub fn evidence(self) -> &'static str {
+        match self {
+            Grip::Captured => "re-derived addresses are compared byte for byte",
+            Grip::Witnessed => "reported fingerprints are compared; the world cannot be corrected",
+            Grip::Opaque => {
+                "nothing is compared; a faithful reconstruction cannot be shown to be one"
+            }
+        }
+    }
+
+    /// Serde: the default grip is skipped, which is what keeps the step format at v1.
+    pub fn is_captured(&self) -> bool {
+        matches!(self, Grip::Captured)
+    }
+}
+
+/// A state reference, and what it is worth.
+#[derive(Clone, PartialEq, Debug)]
+pub struct State {
+    pub root: Digest,
+    pub grip: Grip,
+}
+
+/// What an environment is and the best it can ever offer. Recorded on the trajectory
+/// so a reader knows what was needed to make the recording, and what it would take to
+/// return to it.
+#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
+pub struct Manifest {
+    pub name: String,
+    pub grip: Grip,
+}
+
+/// The contract an environment satisfies to participate.
+///
+/// Implementing this is *optional*. An environment whose every input arrives through
+/// the mediation protocol has no world to declare, and gets recording, replay,
+/// branching, diff and bisect without a line of Rust.
+pub trait Environment {
+    /// Name, and the best grip this environment can ever offer.
+    fn manifest(&self) -> Manifest;
+
+    /// Address the world as it is now.
+    fn observe(&mut self, store: &Store) -> Result<State>;
+
+    /// Put the world back to `state`, and report the grip actually achieved:
+    /// `Captured` if it is genuinely back, `Witnessed` if we can only tell whether it
+    /// is, `Opaque` if we cannot even do that.
+    fn restore(&mut self, state: &State, store: &Store) -> Result<Grip>;
+}
+
+/// The sandboxed directory: the one part of the world the engine owns.
+pub struct Workspace {
+    dir: PathBuf,
+    ignores: tree::Ignores,
+}
+
+impl Workspace {
+    /// `ignores` names what is not ours to record — the dependency and VCS
+    /// directories of a watched project. [`WORLD_DIR`] is always added: a reported
+    /// observation is not a file.
+    pub fn new(dir: impl Into<PathBuf>, mut ignores: tree::Ignores) -> Workspace {
+        ignores.add(WORLD_DIR);
+        Workspace {
+            dir: dir.into(),
+            ignores,
+        }
+    }
+
+    pub fn dir(&self) -> &Path {
+        &self.dir
+    }
+
+    pub fn ignores(&self) -> &tree::Ignores {
+        &self.ignores
+    }
+}
+
+impl Environment for Workspace {
+    fn manifest(&self) -> Manifest {
+        Manifest {
+            name: "workspace".to_string(),
+            grip: Grip::Captured,
+        }
+    }
+
+    fn observe(&mut self, store: &Store) -> Result<State> {
+        Ok(State {
+            root: tree::snapshot_with(&self.dir, store, &self.ignores)?,
+            grip: Grip::Captured,
+        })
+    }
+
+    fn restore(&mut self, state: &State, store: &Store) -> Result<Grip> {
+        tree::materialize_with(&state.root, store, &self.dir, &self.ignores)?;
+        Ok(Grip::Captured)
+    }
+}
+
+/// A world only the program can see.
+///
+/// The engine cannot look at a browser page, a simulator or an instrument. What it can
+/// do is record what the program says about them, and be precise about the fact that
+/// this is testimony rather than possession.
+pub struct Reported {
+    name: String,
+    /// The last observation, stored. `None` means the program declared this world and
+    /// told us it is not observing it — which is `Opaque`, and is a legitimate answer.
+    seen: Option<Digest>,
+    /// The program claims it can put this world back. Nothing in-tree does; the flag
+    /// exists so that an environment which genuinely can is not forced to lie
+    /// downwards.
+    restorable: bool,
+}
+
+impl Reported {
+    pub fn new(name: impl Into<String>, restorable: bool) -> Reported {
+        Reported {
+            name: name.into(),
+            seen: None,
+            restorable,
+        }
+    }
+
+    /// Record what the program says the world looks like now.
+    pub fn report(&mut self, state: &Value, store: &Store) -> Result<()> {
+        self.seen = Some(store.put_json(state)?);
+        Ok(())
+    }
+
+    /// Declared, and deliberately not observed.
+    pub fn unobserved(&mut self) {
+        self.seen = None;
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn grip(&self) -> Grip {
+        match (&self.seen, self.restorable) {
+            (None, _) => Grip::Opaque,
+            (Some(_), true) => Grip::Captured,
+            (Some(_), false) => Grip::Witnessed,
+        }
+    }
+
+    fn path(&self) -> String {
+        format!("{WORLD_DIR}/{}.json", self.name)
+    }
+}
+
+impl Environment for Reported {
+    fn manifest(&self) -> Manifest {
+        Manifest {
+            name: self.name.clone(),
+            grip: self.grip(),
+        }
+    }
+
+    fn observe(&mut self, store: &Store) -> Result<State> {
+        let entries = match &self.seen {
+            Some(blob) => vec![TreeEntry {
+                path: self.path(),
+                blob: blob.clone(),
+                mode: 0o644,
+            }],
+            None => Vec::new(),
+        };
+        Ok(State {
+            root: store.put_json(&Tree::new(entries))?,
+            grip: self.grip(),
+        })
+    }
+
+    fn restore(&mut self, _state: &State, _store: &Store) -> Result<Grip> {
+        // Nothing here can put a page, a simulator or a reactor back. Saying so is the
+        // point: the caller uses this to decide whether a checkpoint is reachable at
+        // all, and a cheerful `Ok(())` here would be the exact lie the project exists
+        // to avoid.
+        Ok(match self.seen {
+            Some(_) => Grip::Witnessed,
+            None => Grip::Opaque,
+        })
+    }
+}
+
+/// The world, in parts: the workspace the engine owns plus whatever the program
+/// declared it can see.
+///
+/// A run with no declared world is a `Situation` with no reported parts, and hashes
+/// exactly as it did before this module existed.
+pub struct Situation {
+    workspace: Workspace,
+    worlds: BTreeMap<String, Reported>,
+    /// Worlds the program has spoken about since the last [`Situation::observe`].
+    /// Anything not in here during a reconstruction is served from the recording
+    /// instead, exactly as every other input is.
+    fresh: BTreeSet<String>,
+}
+
+impl Situation {
+    pub fn new(workspace: Workspace) -> Situation {
+        Situation {
+            workspace,
+            worlds: BTreeMap::new(),
+            fresh: BTreeSet::new(),
+        }
+    }
+
+    pub fn workspace(&self) -> &Workspace {
+        &self.workspace
+    }
+
+    /// Record an observation of a declared world, declaring it if this is the first
+    /// time we have heard of it. `state` of `None` is a declaration that the program
+    /// has this world and is *not* looking at it.
+    pub fn report(
+        &mut self,
+        name: &str,
+        state: Option<&Value>,
+        restorable: bool,
+        store: &Store,
+    ) -> Result<()> {
+        let world = self
+            .worlds
+            .entry(name.to_string())
+            .or_insert_with(|| Reported::new(name, restorable));
+        match state {
+            Some(value) => world.report(value, store)?,
+            None => world.unobserved(),
+        }
+        self.fresh.insert(name.to_string());
+        Ok(())
+    }
+
+    /// Take a recorded observation as this step's, for a world the program has not
+    /// spoken about since the last observation.
+    ///
+    /// This is the recorded-input oracle applied to testimony. During a reconstruction
+    /// the program is not touching the world -- the engine is serving it every value
+    /// it asks for -- so it has nothing new to say about it, and the honest source for
+    /// "what did the page look like here" is the recording. A program that *did*
+    /// re-drive its world reports, and its report wins: that is the case where the
+    /// comparison means something.
+    pub fn adopt(&mut self, name: &str, seen: Digest) {
+        if self.fresh.contains(name) {
+            return;
+        }
+        self.worlds
+            .entry(name.to_string())
+            .or_insert_with(|| Reported::new(name, false))
+            .seen = Some(seen);
+    }
+
+    /// The observations recorded in a tree, by world name.
+    pub fn worlds_in(tree: &Tree) -> Vec<(String, Digest)> {
+        tree.entries
+            .iter()
+            .filter_map(|e| {
+                let rest = e.path.strip_prefix(WORLD_DIR)?.strip_prefix('/')?;
+                Some((rest.strip_suffix(".json")?.to_string(), e.blob.clone()))
+            })
+            .collect()
+    }
+
+    /// A step has been committed: whatever the program said about the world belonged
+    /// to that step, not to the next one.
+    pub fn settle(&mut self) {
+        self.fresh.clear();
+    }
+
+    /// The declared worlds, weakest first — which is the order a reader cares about.
+    pub fn manifests(&self) -> Vec<Manifest> {
+        let mut out: Vec<Manifest> = self.worlds.values().map(|w| w.manifest()).collect();
+        out.sort_by_key(|m| (std::cmp::Reverse(m.grip.rank()), m.name.clone()));
+        out
+    }
+
+    pub fn has_worlds(&self) -> bool {
+        !self.worlds.is_empty()
+    }
+}
+
+impl Environment for Situation {
+    fn manifest(&self) -> Manifest {
+        let mut name = vec![self.workspace.manifest().name];
+        name.extend(self.worlds.keys().cloned());
+        Manifest {
+            name: name.join("+"),
+            grip: self
+                .worlds
+                .values()
+                .fold(Grip::Captured, |acc, w| acc.join(w.grip())),
+        }
+    }
+
+    /// Hash each part, merge the entries, and take the weakest grip.
+    ///
+    /// Merging entries rather than nesting trees is what keeps every existing tool
+    /// working: the result is an ordinary tree, so `checkout`, `diff`, `export` and
+    /// the state comparison need no idea that a world was ever declared.
+    fn observe(&mut self, store: &Store) -> Result<State> {
+        let mut entries: Vec<TreeEntry> =
+            tree::entries_of(self.workspace.dir(), store, self.workspace.ignores())?;
+        let mut grip = Grip::Captured;
+        for world in self.worlds.values_mut() {
+            let part = world.observe(store)?;
+            grip = grip.join(part.grip);
+            entries.extend(tree::read(&part.root, store)?.entries);
+        }
+        Ok(State {
+            root: store.put_json(&Tree::new(entries))?,
+            grip,
+        })
+    }
+
+    /// The workspace goes back; the reported worlds say what they are worth. The
+    /// merged root carries `.world/` entries, which `materialize_with` filters out.
+    fn restore(&mut self, state: &State, store: &Store) -> Result<Grip> {
+        let mut grip = self.workspace.restore(state, store)?;
+        for world in self.worlds.values_mut() {
+            grip = grip.join(world.restore(state, store)?);
+        }
+        Ok(grip)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn grip_join_is_commutative_and_never_improves() {
+        let all = [Grip::Captured, Grip::Witnessed, Grip::Opaque];
+        for a in all {
+            for b in all {
+                assert_eq!(a.join(b), b.join(a));
+                assert!(a.join(b).rank() >= a.rank());
+                assert!(a.join(b).rank() >= b.rank());
+            }
+        }
+        assert_eq!(Grip::Captured.join(Grip::Witnessed), Grip::Witnessed);
+        assert_eq!(Grip::Witnessed.join(Grip::Opaque), Grip::Opaque);
+    }
+
+    #[test]
+    fn a_declared_but_unobserved_world_is_opaque_not_captured() {
+        let mut world = Reported::new("reactor", false);
+        assert_eq!(world.manifest().grip, Grip::Opaque);
+        let dir = std::env::temp_dir().join(format!("nd-env-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let store = Store::open(dir.join("objects")).unwrap();
+        world
+            .report(&serde_json::json!({"temp": 20}), &store)
+            .unwrap();
+        assert_eq!(world.manifest().grip, Grip::Witnessed);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn a_situation_with_no_declared_world_is_captured() {
+        let dir = std::env::temp_dir().join(format!("nd-env-plain-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let store = Store::open(dir.join("objects")).unwrap();
+        let work = dir.join("work");
+        std::fs::create_dir_all(&work).unwrap();
+        std::fs::write(work.join("a.txt"), b"hello").unwrap();
+
+        let mut plain = Situation::new(Workspace::new(&work, tree::Ignores::none()));
+        let bare = plain.observe(&store).unwrap();
+        assert_eq!(bare.grip, Grip::Captured);
+
+        // The same files plus a witnessed world: a different address, and a weaker
+        // grip. Both halves matter -- the state genuinely differs, and what we can say
+        // about it genuinely got worse.
+        let mut witnessed = Situation::new(Workspace::new(&work, tree::Ignores::none()));
+        witnessed
+            .report(
+                "page",
+                Some(&serde_json::json!({"url": "/a"})),
+                false,
+                &store,
+            )
+            .unwrap();
+        let seen = witnessed.observe(&store).unwrap();
+        assert_eq!(seen.grip, Grip::Witnessed);
+        assert_ne!(seen.root, bare.root);
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/crates/noidroid-core/src/env.rs
+++ b/crates/noidroid-core/src/env.rs
@@ -301,10 +301,6 @@ impl Situation {
         }
     }
 
-    pub fn workspace(&self) -> &Workspace {
-        &self.workspace
-    }
-
     /// Record an observation of a declared world, declaring it if this is the first
     /// time we have heard of it. `state` of `None` is a declaration that the program
     /// has this world and is *not* looking at it.
@@ -368,10 +364,6 @@ impl Situation {
         let mut out: Vec<Manifest> = self.worlds.values().map(|w| w.manifest()).collect();
         out.sort_by_key(|m| (std::cmp::Reverse(m.grip.rank()), m.name.clone()));
         out
-    }
-
-    pub fn has_worlds(&self) -> bool {
-        !self.worlds.is_empty()
     }
 }
 

--- a/crates/noidroid-core/src/lib.rs
+++ b/crates/noidroid-core/src/lib.rs
@@ -7,10 +7,14 @@
 //! than being features layered on top.
 //!
 //! The core knows nothing about flights, browsers, robots or laboratories. It knows
-//! `call`, `decide`, `result` and `finish` — see [`proto`].
+//! `call`, `decide`, `result` and `finish` — see [`proto`] — and it knows how much it
+//! can honestly say about the world those happen in — see [`env`] and [`checkpoint`],
+//! which are `docs/environment-model.md` in code.
 
 pub mod bundle;
+pub mod checkpoint;
 pub mod engine;
+pub mod env;
 pub mod error;
 pub mod hash;
 pub mod model;
@@ -19,6 +23,7 @@ pub mod repo;
 pub mod store;
 pub mod tree;
 
+pub use env::{Environment, Grip};
 pub use error::{Doing, Error, Result};
 pub use hash::Digest;
 pub use repo::Repo;

--- a/crates/noidroid-core/src/model.rs
+++ b/crates/noidroid-core/src/model.rs
@@ -10,6 +10,7 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use crate::env::Grip;
 use crate::hash::Digest;
 
 pub const STEP_VERSION: u32 = 1;
@@ -96,15 +97,24 @@ impl Delivery {
 
 /// What re-performing an interaction would do to the world. Declared by the caller;
 /// it is the only thing that lets us fail safely around external side effects.
+///
+/// The axis is **reversibility under reconstruction**, not whether something touches a
+/// disk. That distinction is the one adapter authors get wrong: a browser navigation is
+/// a `Write` because re-driving the recorded actions rebuilds the page, while a robot's
+/// actuator command is `Irreversible` because nothing rebuilds the world.
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum EffectKind {
     /// Observes; repeating it changes nothing.
     Read,
-    /// Mutates the sandboxed workspace; reversible because the sandbox is ours.
+    /// Mutates a world we can put back — the sandboxed workspace, or an environment
+    /// that re-driving rebuilds. Not re-performed during a reconstruction: the
+    /// recorded state is restored instead, or the environment re-drives itself.
     Write,
-    /// Leaves the sandbox: payments, mail, production writes, physical actuation.
-    /// Never performed during replay, denied by default during branching.
+    /// Leaves a mark we cannot take back: payments, mail, production writes, physical
+    /// actuation. Never performed during replay, denied by default during branching,
+    /// and — in a world we only witness — enough to make every later checkpoint
+    /// unreachable. See [`crate::checkpoint::Reach`].
     Irreversible,
 }
 
@@ -334,11 +344,22 @@ pub struct Step {
     pub index: u64,
     pub action: Action,
     pub effects: Vec<Effect>,
-    /// Merkle root of the sandboxed workspace after this step.
+    /// Address of the situation after this step: the workspace, plus whatever world
+    /// the program declared it can see. See [`crate::env`].
     pub state_root: Digest,
     /// Join of this step's own grounding with its parent's and its effects'.
     pub provenance: Provenance,
     pub intervention: Option<Intervention>,
+    /// What `state_root` is *worth*: bytes we hold, a fingerprint we can only
+    /// compare, or nothing.
+    ///
+    /// Skipped when it is `captured`, which is what every recording made before the
+    /// environment model existed was. That is what keeps `STEP_VERSION` at 1: an old
+    /// step reads back as captured, which is exactly what it was, and a new
+    /// workspace-only step serialises to the same bytes and the same address as
+    /// before. Only a step with a declared, non-restorable world carries the field.
+    #[serde(default, skip_serializing_if = "Grip::is_captured")]
+    pub grip: Grip,
 }
 
 impl Step {
@@ -368,7 +389,15 @@ impl Step {
             state_root,
             provenance,
             intervention,
+            grip: Grip::Captured,
         }
+    }
+
+    /// Say what the recorded `state_root` is worth. Separate from [`Step::new`]
+    /// because a step's grip comes from the environment, not from the transition.
+    pub fn with_grip(mut self, grip: Grip) -> Step {
+        self.grip = grip;
+        self
     }
 }
 
@@ -439,6 +468,10 @@ pub struct Trajectory {
     /// than a sandbox. It is where `restore` puts the files back by default.
     #[serde(default)]
     pub watched: Option<std::path::PathBuf>,
+    /// Worlds the program declared it could see, weakest grip first. Empty for the
+    /// ordinary case, where the workspace is the whole of the recorded world.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub worlds: Vec<crate::env::Manifest>,
 }
 
 /// Per-run, non-content observations: how each step was delivered and how long it took.

--- a/crates/noidroid-core/src/proto.rs
+++ b/crates/noidroid-core/src/proto.rs
@@ -63,6 +63,28 @@ pub enum Request {
         options: Value,
         choice: Value,
     },
+    /// "Here is what the world I can see looks like now."
+    ///
+    /// The engine cannot look at a browser page, a simulator or an instrument. This is
+    /// how a program tells it what is true out there, and — through `restorable` —
+    /// how much that testimony is worth. `state` of `null` declares a world and says
+    /// plainly that the program is *not* observing it, which is `opaque` and is a
+    /// legitimate answer, unlike a fabricated one.
+    ///
+    /// Sending this is optional and most programs never should: declare a world only
+    /// when state persists inside the environment across steps and is not carried by
+    /// the recorded effects. See `docs/environment-model.md` §4.2.
+    Observe {
+        /// The world's name. Repeated observations of the same name update it.
+        of: String,
+        #[serde(default)]
+        state: Value,
+        /// The program claims it can put this world back where it found it. Almost
+        /// nothing can; the flag exists so an environment that genuinely can is not
+        /// forced to understate itself.
+        #[serde(default)]
+        restorable: bool,
+    },
     /// The application's own verdict.
     Finish {
         #[serde(default = "unknown_status")]

--- a/crates/noidroid-core/src/tree.rs
+++ b/crates/noidroid-core/src/tree.rs
@@ -76,6 +76,12 @@ impl Ignores {
         ignores
     }
 
+    /// Also leave this name out, wherever it appears.
+    pub fn add(&mut self, name: &str) -> &mut Ignores {
+        self.names.insert(name.trim_matches('/').to_string());
+        self
+    }
+
     fn skips(&self, name: &str) -> bool {
         self.names.contains(name)
     }
@@ -91,9 +97,18 @@ pub fn snapshot(dir: &Path, store: &Store) -> Result<Digest> {
 
 /// Hash a directory, leaving out what `ignores` names.
 pub fn snapshot_with(dir: &Path, store: &Store, ignores: &Ignores) -> Result<Digest> {
+    store.put_json(&Tree::new(entries_of(dir, store, ignores)?))
+}
+
+/// The entries a snapshot would contain, without sealing them into a tree.
+///
+/// An environment made of several parts hashes each part and merges the entries (see
+/// `env::Situation`), so the entry list has to be available separately from the tree
+/// it usually becomes.
+pub fn entries_of(dir: &Path, store: &Store, ignores: &Ignores) -> Result<Vec<TreeEntry>> {
     let mut entries = Vec::new();
     collect(dir, dir, store, ignores, &mut entries)?;
-    store.put_json(&Tree::new(entries))
+    Ok(entries)
 }
 
 fn collect(
@@ -169,10 +184,20 @@ pub fn materialize_with(
     let tree: Tree = store.get_json(digest)?;
     fs::create_dir_all(dir)?;
 
-    let wanted: BTreeSet<PathBuf> = tree.entries.iter().map(|e| dir.join(&e.path)).collect();
+    // `ignores` applies to the recorded entries as well as to what is already on
+    // disk. A tree can hold paths that are deliberately not files -- `.world/`, which
+    // is an environment's *report about* a world rather than any part of the
+    // workspace. Writing those out would let evidence become an input on the next run.
+    let entries: Vec<&TreeEntry> = tree
+        .entries
+        .iter()
+        .filter(|e| !e.path.split('/').any(|part| ignores.skips(part)))
+        .collect();
+
+    let wanted: BTreeSet<PathBuf> = entries.iter().map(|e| dir.join(&e.path)).collect();
     prune(dir, &wanted, ignores)?;
 
-    for entry in &tree.entries {
+    for entry in entries {
         let path = dir.join(&entry.path);
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)?;

--- a/crates/noidroid-core/tests/browser_slice.rs
+++ b/crates/noidroid-core/tests/browser_slice.rs
@@ -47,15 +47,56 @@ fn repo_root() -> PathBuf {
 /// and the tests below then fail with an agent that "aborted" for no stated reason.
 /// Skipping is the honest outcome; a green suite that never ran the browser is not.
 fn browser_available() -> bool {
+    match unavailable_because() {
+        None => true,
+        Some(why) => {
+            eprintln!("SKIP: browser adapter test — {why}");
+            false
+        }
+    }
+}
+
+/// One line on purpose. `cargo fmt` joins a multi-line string literal's continuations
+/// and keeps the source indentation, which turns an indented Python block into an
+/// `IndentationError` — a probe that fails in 13ms without ever launching anything and
+/// reports it as "no browser here".
+const LAUNCH_PROBE: &str = "from playwright.sync_api import sync_playwright as s; p = s().start(); p.chromium.launch().close(); p.stop()";
+
+/// `None` when a browser really did start. Otherwise the reason, verbatim, because a
+/// skip that does not say why is how a suite ends up quietly not running.
+fn unavailable_because() -> Option<String> {
     let probe = Command::new("python3")
-        .args([
-            "-c",
-            "from playwright.sync_api import sync_playwright\n             with sync_playwright() as p:\n             \x20   p.chromium.launch().close()",
-        ])
+        .args(["-c", LAUNCH_PROBE])
         .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status();
-    matches!(probe, Ok(s) if s.success())
+        .stderr(Stdio::piped())
+        .output();
+    match probe {
+        Err(e) => Some(format!("python3 would not start: {e}")),
+        Ok(out) if out.status.success() => None,
+        Ok(out) => {
+            // Playwright's failure is buried in pages of driver chatter, and the last
+            // line is usually "<gracefully close end>". The line that names the cause
+            // is the one worth putting in front of whoever has to fix it.
+            let said = String::from_utf8_lossy(&out.stderr);
+            let lines: Vec<&str> = said.lines().filter(|l| !l.trim().is_empty()).collect();
+            let last = lines
+                .iter()
+                // The host-level cause, when there is one: a missing shared library is
+                // what actually stops a downloaded Chromium, and it is the only line
+                // that tells anyone what to install.
+                .find(|l| l.contains("error while loading"))
+                // Otherwise the raised error, which comes after its traceback.
+                .or_else(|| lines.iter().rev().find(|l| l.contains("Error")))
+                .or_else(|| lines.last())
+                .unwrap_or(&"it said nothing")
+                .trim()
+                .to_string();
+            Some(format!(
+                "chromium would not launch ({last}). Install it with: \
+                 pip install playwright && playwright install --with-deps chromium"
+            ))
+        }
+    }
 }
 
 /// An agent that looks at a page which cannot be reproduced, then makes a decision.
@@ -245,10 +286,6 @@ impl Drop for Fixture {
 fn a_browser_session_reconstructs_from_recorded_responses_alone() {
     let _serial = one_at_a_time();
     if !browser_available() {
-        eprintln!(
-            "SKIP: browser adapter test needs playwright and chromium \
-             (pip install playwright && playwright install chromium)"
-        );
         return;
     }
 
@@ -347,7 +384,6 @@ fn a_browser_session_reconstructs_from_recorded_responses_alone() {
 fn a_browser_branch_can_reach_a_different_outcome() {
     let _serial = one_at_a_time();
     if !browser_available() {
-        eprintln!("SKIP: browser adapter test needs playwright and chromium");
         return;
     }
 
@@ -382,7 +418,6 @@ fn a_browser_branch_can_reach_a_different_outcome() {
 fn a_page_that_cannot_be_reproduced_makes_everything_after_it_unknown() {
     let _serial = one_at_a_time();
     if !browser_available() {
-        eprintln!("SKIP: browser adapter test needs playwright and chromium");
         return;
     }
 

--- a/crates/noidroid-core/tests/browser_slice.rs
+++ b/crates/noidroid-core/tests/browser_slice.rs
@@ -15,8 +15,9 @@ use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
 
 use noidroid_core::engine::{self, Mode, RunSpec};
+use noidroid_core::env::{Grip, Situation};
 use noidroid_core::model::{Intervention, Provenance, Trajectory};
-use noidroid_core::Repo;
+use noidroid_core::{tree, Repo};
 
 /// One browser at a time.
 ///
@@ -39,25 +40,22 @@ fn repo_root() -> PathBuf {
 }
 
 /// Chromium is a large optional dependency; say so rather than failing.
+///
+/// The probe launches a browser rather than looking for one. A downloaded Chromium
+/// that cannot start -- the usual cause is a host missing `libnspr4` and friends, which
+/// `playwright install` does not bring -- looks exactly like an installed one on disk,
+/// and the tests below then fail with an agent that "aborted" for no stated reason.
+/// Skipping is the honest outcome; a green suite that never ran the browser is not.
 fn browser_available() -> bool {
     let probe = Command::new("python3")
-        .args(["-c", "import playwright"])
+        .args([
+            "-c",
+            "from playwright.sync_api import sync_playwright\n             with sync_playwright() as p:\n             \x20   p.chromium.launch().close()",
+        ])
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status();
-    if !matches!(probe, Ok(s) if s.success()) {
-        return false;
-    }
-    let cache = std::env::var("HOME")
-        .map(|h| PathBuf::from(h).join(".cache/ms-playwright"))
-        .unwrap_or_default();
-    fs::read_dir(&cache)
-        .map(|entries| {
-            entries
-                .filter_map(|e| e.ok())
-                .any(|e| e.file_name().to_string_lossy().starts_with("chromium"))
-        })
-        .unwrap_or(false)
+    matches!(probe, Ok(s) if s.success())
 }
 
 /// An agent that looks at a page which cannot be reproduced, then makes a decision.
@@ -266,6 +264,32 @@ fn a_browser_session_reconstructs_from_recorded_responses_alone() {
         recorded.outcome.status, "failure",
         "the agent picks a sold-out flight"
     );
+
+    // The page is declared to the core as a world it can compare and can never put
+    // back. This is the whole reason the browser is the load-bearing example: the
+    // workspace holds the network log and the artifacts, and none of that is the page.
+    assert_eq!(
+        recorded
+            .worlds
+            .iter()
+            .map(|w| (w.name.as_str(), w.grip))
+            .collect::<Vec<_>>(),
+        vec![("browser", Grip::Witnessed)],
+        "a browser trajectory says what it would take to return to it"
+    );
+    let page_step = f
+        .repo
+        .chain(&recorded)
+        .unwrap()
+        .into_iter()
+        .find(|(_, s)| s.grip == Grip::Witnessed)
+        .expect("every step after the first action is witnessed");
+    assert!(
+        !Situation::worlds_in(&tree::read(&page_step.1.state_root, &f.repo.store).unwrap())
+            .is_empty(),
+        "and carries the page fingerprint in its recorded state"
+    );
+
     let at = f.decision_step(&recorded);
 
     // 2. Take the site away. Anything that still works from here is reconstruction,

--- a/crates/noidroid-core/tests/environment_slice.rs
+++ b/crates/noidroid-core/tests/environment_slice.rs
@@ -1,0 +1,408 @@
+//! The environment contract, end to end.
+//!
+//! `vertical_slice` covers the invariants of a run whose whole world is a directory.
+//! This file covers the ones that only appear once the world is *not* a directory: a
+//! reactor, a page, a simulator — something that can be re-driven and compared but
+//! never put back.
+//!
+//! The program under test is the reference environment in `examples/reference`,
+//! because a contract proved against a fixture written for the contract proves less
+//! than one proved against the thing people are told to copy.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use noidroid_core::checkpoint::{self, Reach};
+use noidroid_core::engine::{self, Mode, Report, RunSpec};
+use noidroid_core::env::{Grip, Situation};
+use noidroid_core::model::{EffectKind, Intervention, Provenance, Trajectory};
+use noidroid_core::{tree, Error, Repo};
+
+fn examples() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../examples/reference")
+        .canonicalize()
+        .expect("the reference environment is part of the repository")
+}
+
+struct Fixture {
+    dir: PathBuf,
+    repo: Repo,
+}
+
+impl Fixture {
+    fn new(tag: &str) -> Fixture {
+        let dir = std::env::temp_dir().join(format!(
+            "noidroid-env-{tag}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        let repo = Repo::open(&dir).unwrap();
+        Fixture { dir, repo }
+    }
+
+    fn spec(&self, name: Option<&str>, blind: bool) -> RunSpec {
+        let client = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../clients/python")
+            .canonicalize()
+            .expect("the python client is part of the repository");
+        let mut env = vec![("PYTHONPATH".to_string(), client.display().to_string())];
+        if blind {
+            env.push(("REFERENCE_BLIND".to_string(), "1".to_string()));
+        }
+        RunSpec {
+            command: vec![
+                "python3".into(),
+                examples().join("agent.py").display().to_string(),
+            ],
+            launch_dir: self.dir.clone(),
+            name: name.map(str::to_string),
+            env,
+            auto: false,
+            watch: None,
+        }
+    }
+
+    fn record(&self, name: &str, blind: bool) -> Trajectory {
+        engine::run(
+            &self.repo,
+            &self.spec(Some(name), blind),
+            Mode::Record,
+            None,
+        )
+        .expect("the reference environment records")
+        .trajectory
+        .expect("a recording produces a trajectory")
+    }
+
+    fn replay(&self, t: &Trajectory) -> Report {
+        engine::run(&self.repo, &self.spec(None, false), Mode::Replay, Some(t))
+            .expect("replay runs to completion")
+    }
+
+    fn branch(
+        &self,
+        t: &Trajectory,
+        at: u64,
+        label: &str,
+        choice: &str,
+    ) -> noidroid_core::Result<Report> {
+        engine::run(
+            &self.repo,
+            &self.spec(Some(label), false),
+            Mode::Branch {
+                at,
+                intervention: Intervention::ReplaceDecision {
+                    name: "move".into(),
+                    value: serde_json::json!(choice),
+                },
+                simulate: Default::default(),
+            },
+            Some(t),
+        )
+    }
+
+    /// Every object a trajectory reaches, by address and by bytes.
+    fn reachable(&self, t: &Trajectory) -> std::collections::BTreeMap<String, Vec<u8>> {
+        let mut out = std::collections::BTreeMap::new();
+        for (digest, step) in self.repo.chain(t).unwrap() {
+            out.insert(digest.to_string(), self.repo.store.get(&digest).unwrap());
+            out.insert(
+                step.state_root.to_string(),
+                self.repo.store.get(&step.state_root).unwrap(),
+            );
+        }
+        out
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.dir);
+    }
+}
+
+/// The index of the decision at tick `n`: genesis, then read/decide/act per tick.
+fn decision_at(tick: u64) -> u64 {
+    1 + tick * 3 + 1
+}
+
+#[test]
+fn a_declared_world_is_recorded_as_witnessed_and_its_fingerprint_is_stored() {
+    let f = Fixture::new("witnessed");
+    let t = f.record("shift", false);
+
+    assert_eq!(
+        t.worlds.iter().map(|w| w.name.as_str()).collect::<Vec<_>>(),
+        vec!["reactor"],
+        "the trajectory records what it would take to return to this run"
+    );
+    assert_eq!(t.worlds[0].grip, Grip::Witnessed);
+
+    let chain = f.repo.chain(&t).unwrap();
+    // Genesis is committed before the program has said anything about the reactor, so
+    // it is opaque; every step after the first action carries a fingerprint.
+    let acted = &chain[3].1;
+    assert_eq!(acted.grip, Grip::Witnessed);
+
+    let observed = tree::read(&acted.state_root, &f.repo.store).unwrap();
+    let worlds = Situation::worlds_in(&observed);
+    assert_eq!(worlds.len(), 1, "the reactor is in the recorded tree");
+    assert_eq!(worlds[0].0, "reactor");
+
+    let seen: serde_json::Value = f.repo.store.get_json(&worlds[0].1).unwrap();
+    assert_eq!(
+        seen["temp"], 61.0,
+        "the fingerprint is the reactor as it was after the first move, not a summary"
+    );
+}
+
+#[test]
+fn a_witnessed_world_replays_to_the_same_objects_without_being_touched() {
+    let f = Fixture::new("replay");
+    let t = f.record("shift", false);
+    let report = f.replay(&t);
+
+    assert!(
+        report.faithful(),
+        "a witnessed run reconstructs exactly: {:?}",
+        report.divergences
+    );
+    assert_eq!(report.reproduced, report.expected);
+    assert_eq!(
+        report.grip,
+        Grip::Witnessed,
+        "the run reports the weakest grip it had, not the best"
+    );
+    assert_eq!(
+        report.delivery.get("executed"),
+        None,
+        "a reconstruction executes nothing; the recorded observations are served, \
+         exactly as every other input is"
+    );
+}
+
+#[test]
+fn a_world_the_program_declines_to_observe_is_opaque_and_nothing_is_invented() {
+    let f = Fixture::new("opaque");
+    let t = f.record("blind", true);
+
+    assert_eq!(t.worlds[0].grip, Grip::Opaque);
+
+    let chain = f.repo.chain(&t).unwrap();
+    assert_eq!(
+        chain[0].1.grip,
+        Grip::Captured,
+        "genesis is committed at the handshake, before the program has declared \
+         anything: at that point the workspace really is the whole world"
+    );
+    for (_, step) in chain.iter().skip(1) {
+        assert_eq!(
+            step.grip,
+            Grip::Opaque,
+            "step {} claims a grip it has not",
+            step.index
+        );
+        let tree = tree::read(&step.state_root, &f.repo.store).unwrap();
+        assert!(
+            Situation::worlds_in(&tree).is_empty(),
+            "an unobserved world leaves no fingerprint; a fabricated one would be worse \
+             than none"
+        );
+    }
+
+    let point = checkpoint::at(&chain, decision_at(2)).unwrap();
+    assert_eq!(
+        point.evidence,
+        Grip::Opaque,
+        "the checkpoint says plainly that a reconstruction of it cannot be shown to \
+         have worked"
+    );
+    assert!(
+        point.reach.is_reachable(),
+        "unverifiable is not unreachable: re-execution still gets back here"
+    );
+}
+
+#[test]
+fn a_checkpoint_after_an_irreversible_effect_in_a_witnessed_world_is_unreachable() {
+    let f = Fixture::new("unreachable");
+    let t = f.record("shift", false);
+    let chain = f.repo.chain(&t).unwrap();
+
+    let scram = chain
+        .iter()
+        .find(|(_, s)| {
+            s.effects
+                .iter()
+                .any(|e| e.effect == EffectKind::Irreversible)
+        })
+        .map(|(_, s)| s.index)
+        .expect("the shift ends by firing the emergency dump");
+
+    assert!(
+        checkpoint::at(&chain, scram).unwrap().reach.is_reachable(),
+        "the checkpoint *at* the irreversible step is still reachable: it is the step \
+         a branch would replace"
+    );
+
+    let after = checkpoint::at(&chain, scram + 1).unwrap();
+    assert_eq!(
+        after.reach,
+        Reach::Unreachable {
+            index: scram,
+            target: "reactor.scram".into()
+        },
+        "getting back past it would mean firing it again"
+    );
+}
+
+#[test]
+fn an_unreachable_checkpoint_is_refused_before_anything_runs() {
+    let f = Fixture::new("refused");
+    let t = f.record("shift", false);
+    let before: Vec<String> = fs::read_dir(f.repo.root.join("workspaces"))
+        .map(|d| {
+            d.filter_map(|e| e.ok())
+                .map(|e| e.file_name().to_string_lossy().into())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let last = t.steps - 1;
+    let refused = f.branch(&t, last, "impossible", "insert");
+    match refused {
+        Err(Error::Refused(why)) => {
+            assert!(
+                why.contains("reactor.scram"),
+                "the refusal names the step: {why}"
+            );
+            assert!(why.contains("irreversible"), "and why it is one: {why}");
+        }
+        other => panic!("branching past an irreversible effect must be refused, got {other:?}"),
+    }
+
+    assert!(
+        !f.repo.has_trajectory("impossible"),
+        "a refused branch leaves no trajectory claiming an ancestry it does not have"
+    );
+    let after: Vec<String> = fs::read_dir(f.repo.root.join("workspaces"))
+        .map(|d| {
+            d.filter_map(|e| e.ok())
+                .map(|e| e.file_name().to_string_lossy().into())
+                .collect()
+        })
+        .unwrap_or_default();
+    assert_eq!(before, after, "and it does not spawn the program at all");
+}
+
+#[test]
+fn a_branch_shares_its_parents_history_and_diverges_only_after_the_branch_point() {
+    let f = Fixture::new("branch");
+    let parent = f.record("shift", false);
+    let before = f.reachable(&parent);
+
+    let at = decision_at(2);
+    let branch = f
+        .branch(&parent, at, "saved", "insert")
+        .expect("the checkpoint is reachable")
+        .trajectory
+        .expect("a reachable branch produces a trajectory");
+
+    let parent_chain = f.repo.chain(&parent).unwrap();
+    let branch_chain = f.repo.chain(&branch).unwrap();
+
+    for i in 0..at as usize {
+        assert_eq!(
+            parent_chain[i].0, branch_chain[i].0,
+            "step {i} is the same object in both, not a copy of it"
+        );
+    }
+    assert_ne!(
+        parent_chain[at as usize].0, branch_chain[at as usize].0,
+        "the branch point is the first step that differs"
+    );
+
+    assert_eq!(
+        branch.forked_from.as_ref().map(|f| f.step_hash.clone()),
+        Some(parent_chain[at as usize].0.clone()),
+        "the fork names the exact object it says it grew from"
+    );
+
+    // The parent, byte for byte, after somebody branched off it.
+    assert_eq!(
+        before,
+        f.reachable(&parent),
+        "branching wrote nothing the parent reaches"
+    );
+    let reloaded = f.repo.load_trajectory("shift").unwrap();
+    assert_eq!(reloaded, parent, "and did not move its ref");
+}
+
+#[test]
+fn a_branch_reaches_a_different_outcome_and_never_claims_to_be_real() {
+    let f = Fixture::new("outcome");
+    let parent = f.record("shift", false);
+    assert_eq!(parent.outcome.status, "failure");
+    assert_eq!(parent.outcome.result["reason"], "meltdown");
+
+    let at = decision_at(2);
+    let branch = f
+        .branch(&parent, at, "saved", "insert")
+        .expect("reachable")
+        .trajectory
+        .expect("a trajectory");
+
+    assert_eq!(
+        branch.outcome.status, "success",
+        "inserting one tick earlier survives the shift"
+    );
+
+    let chain = f.repo.chain(&branch).unwrap();
+    for (_, step) in chain.iter().take(at as usize) {
+        assert_eq!(
+            step.provenance,
+            Provenance::Real,
+            "the prefix is the parent's evidence and stays real"
+        );
+    }
+    for (_, step) in chain.iter().skip(at as usize) {
+        assert_eq!(
+            step.provenance,
+            Provenance::Simulated,
+            "nothing downstream of an intervention may claim to be real"
+        );
+    }
+}
+
+#[test]
+fn the_counterfactual_world_is_re_driven_rather_than_assumed() {
+    // The claim: the branch's reactor is genuinely at the recorded state when the
+    // counterfactual begins, not sitting at tick zero because the replayed prefix
+    // never touched it. If the re-drive were skipped, the moves after the branch
+    // point would be applied to a cold reactor and the run would still finish, still
+    // hash consistently, and still report `success` -- silently describing a physics
+    // that did not happen. The observable difference is which alternatives flip the
+    // outcome.
+    let f = Fixture::new("redrive");
+    let parent = f.record("shift", false);
+
+    let flips = |tick: u64, choice: &str, label: &str| -> String {
+        f.branch(&parent, decision_at(tick), label, choice)
+            .expect("reachable")
+            .trajectory
+            .map(|t| t.outcome.status)
+            .unwrap_or_else(|| "unreachable".into())
+    };
+
+    // Tick 0 and tick 2 are survivable; tick 1 is not. A cold reactor would make
+    // tick 1 survivable too, because it would be starting from 55 degrees instead
+    // of 79.
+    assert_eq!(flips(0, "insert", "b0"), "success");
+    assert_eq!(flips(1, "insert", "b1"), "failure");
+    assert_eq!(flips(2, "insert", "b2"), "success");
+}

--- a/docs/direction.md
+++ b/docs/direction.md
@@ -77,6 +77,19 @@ known at the time.
 - **"Replay costs zero tokens" is not the pitch.** It collapses for the change people
   make most often — swapping the prompt or the model. Lead with divergence
   localisation instead.
+- **A state reference carries a grip, and grip only ever gets weaker** (#48). The
+  workspace is `captured`; a page, a simulator or an instrument is `witnessed` at best;
+  a world nobody reports is `opaque`. Composition takes the weakest part, exactly as
+  provenance does. The alternative — one state model that assumes a filesystem — was
+  already producing a quiet lie: restoring `browser/actions.jsonl` is not restoring the
+  page. See [environment-model.md](environment-model.md).
+- **A checkpoint answers three questions, not one** (#48). Reach, evidence, grounding.
+  Collapsing them into a single "can I branch here" loses the two answers people
+  actually need, and inventing a confidence number for the gap is the failure mode this
+  project exists to avoid.
+- **Re-driving a witnessed world is the adapter's job, and the engine cannot check it.**
+  Stated as a limit rather than papered over: the only source of truth about a world the
+  engine cannot see is the program that can.
 
 ## What we are deliberately not building
 

--- a/docs/environment-model.md
+++ b/docs/environment-model.md
@@ -1,0 +1,516 @@
+# The environment model
+
+*The contract between Paranoid Android and a world it did not write.*
+
+This document answers one question:
+
+> What is the minimum an environment must satisfy for Paranoid Android to record an
+> execution, reconstruct a meaningful point in it, and explore a counterfactual from
+> there?
+
+It is a contract, not a tour. Where it says **must**, the engine enforces it or refuses.
+Where it says **may decline**, declining is a first-class answer and is represented in
+the recording rather than hidden.
+
+Read [direction.md](direction.md) first if you have not. The rule it states —
+*do not fake capabilities we do not have* — is the only reason this document is as
+complicated as it is, and the reason it is not more complicated than it is.
+
+---
+
+## 1. The loop
+
+Every environment Paranoid Android targets runs the same loop, whatever it is made of:
+
+```
+observation → decision → action → effect → observation → …
+```
+
+| Environment | observation | decision | action | effect |
+|---|---|---|---|---|
+| Python application | arguments, returned values | branch taken | function call | return value, files written |
+| Browser agent | rendered page | model's next move | click, fill, navigate | new page, network traffic |
+| RL environment | `obs` | policy output | `step(a)` | next `obs`, reward |
+| Robot | sensor frame | controller output | actuator command | new sensor frame, moved world |
+| Autonomous lab | instrument reading | experiment choice | run the protocol | consumed reagents, new reading |
+| Production service | request, config | application logic | outbound call | response, other people's state |
+
+These differ in latency, cost and reversibility by many orders of magnitude. They do
+not differ in shape. Paranoid Android records the loop, not the machinery.
+
+Two things follow immediately, and they are the whole design:
+
+1. **The recording is of the boundary, not of the machine.** We record what crossed
+   between the program and the world. We do not record the program's memory and we do
+   not record the world.
+2. **Returning to a point is re-execution, not restoration.** A checkpoint is
+   re-entered by re-running the prefix with every input served from the recording. The
+   program rebuilds its own state, which is the one thing it is guaranteed to be able
+   to do.
+
+## 2. Vocabulary
+
+| Term | Meaning |
+|---|---|
+| **program** | the process under recording. It declares its own boundary. |
+| **environment** | everything the program interacts with across that boundary. |
+| **world** | environment state that persists *between* steps and is not carried by the recorded effects. Most environments have none. See §6. |
+| **trajectory** | the recorded evidence of one execution: an immutable chain of steps. |
+| **step** | one node of that chain: `(parent, action, effects, state, provenance)`, addressed by the hash of its content. |
+| **checkpoint** | a step, considered as a place you might return to. Not a separate object. |
+| **branch** | a step whose parent belongs to another trajectory. |
+
+There is no `Checkpoint` object on disk, and no `Branch` object. Both are *readings* of
+the step chain. That is deliberate: a checkpoint you have to create is a checkpoint
+somebody forgot to create.
+
+## 3. What a trajectory records
+
+A trajectory is an ordered chain of steps. Each step records:
+
+- **`action`** — what the program said it was about to do. One of `genesis`, `call`,
+  `decide`, `finish`.
+- **`effects`** — what came back, stored by content address, each carrying its
+  `EffectKind` (what re-performing it would do to the world) and its `Provenance`
+  (how grounded it is).
+- **`state`** — a reference to the situation after the step, plus a **`grip`** saying
+  what that reference is worth (§5).
+- **`provenance`** — the join of the step's own grounding with its parent's and its
+  effects'.
+- **`intervention`** — the deliberate change, if this step is where a branch diverged.
+
+And what it does not record, ever:
+
+- the program's memory, stack or heap,
+- the world,
+- anything not declared at the boundary. Untracked inputs — an unmediated clock, an
+  unpatched socket, a subprocess — are *invisible*, and their absence shows up as a
+  divergence during reconstruction rather than as a silent wrong answer.
+
+A recording is therefore **evidence**, not a world. Every guarantee below is a
+statement about the evidence.
+
+### The step is the only primitive
+
+A trajectory is a chain of steps. A branch is a step whose parent belongs to another
+trajectory. Prefix sharing, immutability of history and copy-on-write are consequences
+of content addressing, not features layered on top: two runs that did the same thing
+produce byte-identical step objects and therefore the same addresses, and a step that
+exists cannot be edited because editing it changes its name.
+
+## 4. The environment contract
+
+An environment participates in Paranoid Android by satisfying two obligations. Only the
+first is mandatory.
+
+### 4.1 The boundary (mandatory, and it is data, not code)
+
+The program **must** route every interaction that crosses into the environment through
+the mediation protocol — `call` / `decide` / `result` / `error` / `finish`, newline
+JSON over a Unix socket (see [technical-proposal.md](technical-proposal.md) §protocol).
+For each `call` it declares:
+
+- a **target**: a stable name for *what kind of interaction this is* (`flights.search`,
+  `browser.click`, `reactor.act`). Position plus target plus arguments is the identity
+  of the interaction; reconstruction matches on it.
+- an **effect kind**, which is a claim about **reversibility under reconstruction**:
+
+  | kind | claim | consequence |
+  |---|---|---|
+  | `read` | re-performing it changes nothing | freely re-performed |
+  | `write` | it mutates a world we can put back — our sandbox, or an environment that re-driving rebuilds | not re-performed during reconstruction; the recorded state is restored instead |
+  | `irreversible` | it leaves a mark we cannot take back — a payment, an email, an actuator, a production write | never performed outside an original recording. Denied by default; explorable only with a stated-simulated value |
+
+  `write` is the interesting one, and it is routinely mislabelled. It does **not** mean
+  "touches the disk". It means *we have a way to put this back*. A browser navigation
+  is a `write` because re-driving the recorded actions rebuilds the page. A robot's
+  actuator command is `irreversible` because nothing rebuilds the world.
+
+An environment whose interactions are not declared is not participating. There is no
+discovery mechanism and there will not be one: a boundary you inferred is a boundary
+you will be wrong about, quietly.
+
+### 4.2 The world (optional, and it is code)
+
+Some environments carry state *between* steps that the recorded effects do not
+capture. A browser page is the canonical case: step 3 navigates, step 7 reads — and
+what step 7 reads depends on state that lives in the browser, not in the trajectory.
+
+For those, and **only** those, the environment supplies an implementation of:
+
+```rust
+pub trait Environment {
+    /// Name, and the best grip this environment can ever offer.
+    fn manifest(&self) -> Manifest;
+
+    /// Address the world as it is now. `State.grip` says what that address is worth.
+    fn observe(&mut self, store: &Store) -> Result<State>;
+
+    /// Put the world back to `state`. Returns the grip actually achieved:
+    /// `Captured` if it is genuinely back, `Witnessed` if we can only tell whether it
+    /// is, `Opaque` if we cannot even do that.
+    fn restore(&mut self, state: &State, store: &Store) -> Result<Grip>;
+}
+```
+
+Three methods. That is the whole interface, and two of the three are allowed to be
+honest about failing. `restore` returning a `Grip` rather than a `Result<()>` is the
+load-bearing detail: an environment that cannot put its world back says so in the same
+vocabulary everything else uses, and the caller's behaviour changes accordingly — it
+stops *asserting* the recorded state and starts *checking* it.
+
+The engine ships three implementations, and there are only three because that is how
+many distinct answers there are: `Workspace` (the directory it owns, `captured`),
+`Reported` (a world only the program can see, `witnessed` or `opaque`), and `Situation`
+(the two together, joined by §5.1). A Python program with no world uses the first and
+implements nothing.
+
+In-process environments do not have to be Rust. A world can be declared over the wire
+instead — `{"op":"observe","of":"browser","state":{…},"restorable":false}` — which is
+how the browser adapter does it and how anything not written in Rust will. The trait
+and the protocol message are the same contract from two sides.
+
+**When to declare a world.** Only when state persists inside the environment across
+steps *and* is not carried by the mediated effects. Test it with one question: *if the
+program branched here, what would the counterfactual inherit that the recording does
+not contain?*
+
+- A model provider: **no world.** Every call is independent and its answer is recorded.
+- A REST API you read and never mutate: **no world.**
+- A browser: **a world.** The page persists and is read later.
+- An RL environment or simulator: **a world.** `step()` depends on accumulated state.
+- A robot or a laboratory: **a world**, and a very weak grip on it (§5).
+- The sandboxed workspace: **a world**, and the strongest possible grip. It is
+  supplied by the engine, always present, and needs no adapter.
+
+Over-declaring is not harmless. A world with a weak grip weakens the grip on the whole
+situation (§5.1), which weakens the evidence a reconstruction can offer. Declare what
+must be true, not everything that is true.
+
+## 5. Grip: what a state reference is worth
+
+The single most important thing this release adds. `state` is not a snapshot; it is an
+address, and `grip` says what holding that address entitles you to do.
+
+| grip | we hold | can we detect the world differs? | can we put it back? |
+|---|---|---|---|
+| `captured` | the bytes | yes | **yes** |
+| `witnessed` | a fingerprint | yes | no |
+| `opaque` | nothing | no | no |
+
+- **`captured`** — the store holds the content and `restore` reproduces it exactly.
+  The sandboxed workspace. This is the only grip that supports restoration, and it is
+  the default, so every existing recording keeps its meaning unchanged.
+- **`witnessed`** — the recording holds a fingerprint the environment reported: a page
+  URL and structure hash, an instrument reading, an observation vector. A
+  reconstruction that lands somewhere else is *detected*. It cannot be *repaired*.
+- **`opaque`** — nothing was captured. Reconstruction by re-execution is still
+  possible; it is simply **unverifiable**, and the system says so rather than implying
+  a check it did not perform. A robot arm's position between commands is opaque. So is
+  a world an adapter declared and never observed.
+
+### 5.1 Grip joins like provenance
+
+A situation is usually made of parts — the workspace we own plus the page we can only
+look at. The grip on the whole is **the weakest grip of any part**:
+
+```
+captured ⊔ witnessed = witnessed
+witnessed ⊔ opaque   = opaque
+```
+
+Same law as `Provenance::join`, and for the same reason: a claim about a whole cannot
+be stronger than the weakest claim it rests on. This is why composition needs no
+framework — an environment that owns a page and delegates the files to the workspace
+just joins the two.
+
+### 5.2 Where an observation is stored
+
+A reported observation is stored as a blob and folded into the same tree as the files,
+at `.world/<name>.json`. Three consequences, all wanted:
+
+- every existing tool keeps working — `checkout`, `diff`, `export` and the state
+  comparison need no special case,
+- the fingerprint is **inspectable**: `noidroid show run-1@3` prints it,
+- the state comparison that verifies a reconstruction covers the reported world for
+  free, because it is part of the hashed tree.
+
+`.world/` is never snapshotted from the filesystem and never materialised onto it. It
+is evidence about the world, not the world, and it must not be able to become an input.
+
+## 6. What a checkpoint guarantees
+
+A checkpoint is not a saved world. It is the claim:
+
+> **There is a defined procedure that gets back here, and here is what will be checked
+> when it does.**
+
+`noidroid show <trajectory>@<k>` answers three independent questions about step *k*:
+
+### 6.1 Reach — can I get back here?
+
+Computed over the prefix `0..k` (exclusive: step *k* itself is the one you are about to
+intervene on).
+
+| reach | meaning |
+|---|---|
+| `rebuild` | re-execute `0..k` with every mediated input served from the recording. Nothing in the prefix has to be re-performed or put back. |
+| `rebuild+restore` | as above, and at each step whose `write`/`irreversible` effect we refuse to re-perform, the recorded state is restored as far as the environment can restore it. |
+| `unreachable` | the prefix performed an **irreversible** effect at step *j* in a world whose grip at *j* is not `captured`. |
+
+Only `irreversible` blocks, and only outside a `captured` world. The reasoning is worth
+stating because it is easy to get backwards:
+
+- A `write` never blocks. That is what `write` *means* — either we hold the bytes and
+  restore them, or the environment rebuilds itself by re-driving the recorded actions.
+- An `irreversible` effect in a `captured` world does not block either. We do not have
+  to un-send it; we have to *not send it again*, and we do not, because the value is
+  served from the recording and the workspace it left behind is restored.
+- An `irreversible` effect in a `witnessed` or `opaque` world does block, because the
+  only route back through it is to re-drive the actions that produced it — which sends
+  it again. There is no third option, so the answer is `unreachable`.
+
+That last case is the honest answer for a branch that would have to un-send an email,
+un-submit a form, or un-fire an emergency dump. Branching from such a checkpoint is
+**refused before the program is spawned**, naming the step and the target. It is not a
+warning and it is not best-effort: discovering it halfway through is the version that
+performs the irreversible effect a second time in order to find out it should not
+have.
+
+### 6.2 Evidence — will I know if I got it wrong?
+
+The join of the grips over `0..=k`.
+
+| evidence | on reconstruction |
+|---|---|
+| `captured` | the re-derived step addresses equal the recorded ones, or we say exactly where they stopped matching. Byte-level proof. |
+| `witnessed` | fingerprints are compared. A divergence is reported; the world cannot be corrected. |
+| `none` | nothing is compared. The reconstruction may be perfect and we cannot say so. |
+
+`none` is not an error. It is the truthful description of a robot, and printing it is
+worth more than any number we could invent instead.
+
+### 6.3 Grounding — is what I get back to a claim about reality?
+
+Step *k*'s own `provenance`: `real`, `live`, `simulated`, `unknown`. Already joined
+along the chain, so a checkpoint downstream of an intervention reports `simulated`
+however real the last few steps were.
+
+Three questions, three answers, none of them collapsible into the others. A robot
+checkpoint reads `rebuild / none / real` — reachable, unverifiable, and grounded in an
+execution that actually happened. A checkpoint inside a branch reads
+`rebuild / captured / simulated` — reachable, provable, and counterfactual. Both
+statements are useful; neither is a percentage.
+
+## 7. Reconstruction
+
+Reconstruction has two halves, and conflating them is the mistake this project exists
+to avoid.
+
+| what | how it comes back | if it cannot |
+|---|---|---|
+| the program's internal state | **only** by re-executing `0..k` with recorded inputs | there is no fallback. This is why the boundary must be complete. |
+| the world's state | `captured` → restored from the store; `witnessed`/`opaque` → **re-driven by the adapter** (§7.1) | if re-driving would re-perform an irreversible effect, the checkpoint is `unreachable` (§6.1) |
+
+We never snapshot memory. Not as an optimisation — a memory image is not portable, not
+comparable, not inspectable and not verifiable, and the moment a trajectory contains
+one, "the original is immutable" stops being checkable.
+
+**The check.** A reconstruction re-derives each step from scratch rather than copying
+it. If the re-derived object addresses equal the recorded ones, the reconstruction is
+faithful *with respect to everything captured* — hash equality is evidence, not
+bookkeeping. If they differ, the engine reports the first index where they stopped
+matching, the kind (`unexpected_call`, `key_mismatch`, `state_mismatch`, `truncated`)
+and the field-by-field difference. It never repairs and never rounds.
+
+### 7.1 Re-driving a world the engine does not own
+
+This obligation belongs to the adapter and cannot be moved. During a reconstruction the
+engine serves the program every value it asks for, so the program never touches its
+world — which means that when a branch crosses the divergence point, the world is
+sitting wherever it started, not where the recording left it.
+
+An adapter for a `witnessed` or `opaque` world must therefore, before the first action
+it really performs:
+
+1. re-perform the recorded actions of the prefix against a fresh world,
+2. compare the result with the fingerprint the recording holds,
+3. and if it does not match, mark what follows `Ungrounded` rather than continue as
+   though it did.
+
+Both in-tree adapters do exactly this: `Browser._reconstruct` re-drives the recorded
+actions into a fresh browser with the recorded network responses re-served, and
+`Shift._catch_up` in the reference environment re-drives the recorded moves. It is
+about fifteen lines in each case, and it is the difference between a counterfactual and
+a plausible-looking fiction.
+
+**The engine cannot check that you did it.** If an adapter skips the re-drive, the run
+still completes, still hashes consistently and still reports a clean outcome — while
+describing a physics that never happened. This is a real, structural limit: the only
+source of truth about a world the engine cannot see is the program that can. What the
+model does is make the obligation *explicit* (grip `witnessed` means "must be
+re-driven") and give the adapter the fingerprint to check itself against. A recording
+that fails to declare its world at all does not get even that.
+
+**Observations obey the recorded-input oracle.** During reconstruction the program is
+not touching the world, so it has nothing new to say about it, and the engine serves the
+recorded observation in its place — testimony is an input like any other. A program that
+*did* re-drive reports, its report wins, and the difference surfaces as a state
+mismatch. That is the only case in which comparing fingerprints tells you anything, and
+it is exactly the case worth comparing.
+
+**Reconstruction is bounded by capture.** A prefix containing an effect with provenance
+`unknown` re-derives correctly — the recording holds what the program saw — but every
+step downstream inherits `unknown`. The reconstruction is exact and the *claim* is
+weak, and those are different things, so they are recorded on different axes.
+
+## 8. Replay
+
+Replay is reconstruction of a whole trajectory, run for its own sake: *does this still
+do what it did?*
+
+The invariant, and it is structural rather than remembered: **during reconstruction the
+engine never issues `execute`.** The program cannot perform a mediated interaction it
+was not told to perform, so a replay cannot touch the world — not because the adapter
+is careful but because the directive never arrives. A replay that reaches the network
+anyway (an unmediated socket) is caught by the egress fence and reported, because a
+reconstruction that touched the world is not a reconstruction.
+
+The one deliberate exception is `--live <target>`: named targets are executed for real
+while everything else is served from the recording. This is how a recording stays
+useful when what changed is the prompt or the model. The engine does not pretend it is
+still a reproduction — from the first live call onward the run is marked
+counterfactual, its steps are `live`, and they are not compared against the recording.
+
+`replayed` is therefore a **delivery**, not a provenance. Serving a recorded value back
+does not make it less real; it makes it differently delivered. Keeping the two axes
+apart is what lets a branch share its parent's prefix object-for-object — if replay
+changed the content, a perfect reconstruction would produce different hashes than the
+run it reproduced, which is absurd.
+
+## 9. Intervention
+
+An intervention is the single deliberate difference that makes a branch a branch:
+
+| intervention | question |
+|---|---|
+| `replace_result` | what if the world had answered differently? |
+| `replace_decision` | what if it had chosen differently? (requires a declared `decide`) |
+| `fail` | what if this had failed? |
+
+Rules:
+
+1. **Exactly one, at exactly one step.** A branch with two differences explains
+   nothing.
+2. **An intervened step is `simulated`, always.** Nobody ran it. Provenance never
+   improves, so everything downstream is `simulated` or worse, permanently.
+3. **Past the divergence point the program really executes** — `read` and `write`
+   effects are performed for real and recorded as `live`: they happened, in a
+   counterfactual world. `irreversible` effects are **denied** unless the operator
+   supplies a stated-simulated value with `--simulate target=<json>`, which is recorded
+   as `simulated` and poisons everything after it.
+4. **A branch never writes back.** It gets its own workspace and its own trajectory.
+
+## 10. Branching
+
+```
+run-1   S0 → S1 → S2 → S3 → FAILURE
+                   │
+                   └── branch at @2
+                       ├── run-1~a  A → S4 → FAILURE
+                       └── run-1~b  B → S5 → SUCCESS
+```
+
+The invariants, each of which has a test:
+
+- **The parent is immutable.** Branching writes no object that the parent references
+  and never rewrites the parent's ref. Enforced by construction: objects are named by
+  their content, so a modified step is a different step.
+- **The branch shares historical identity with its parent.** For every `j < k` the
+  branch's step *j* has the *same address* as the parent's step *j*. Not a copy — the
+  same object, re-derived and found to be identical. This is what makes prefix sharing
+  free and what makes "same history" checkable rather than asserted.
+- **Divergence occurs only after the branch point.** Step *k* is the first step whose
+  address differs, and it is the step carrying the intervention.
+- **Provenance is preserved and joined.** The branch's prefix is `real` — it is the
+  parent's evidence. From *k* onward nothing may claim to be real.
+- **A refused branch leaves nothing behind.** If the prefix does not reconstruct, no
+  trajectory is written: a trajectory on disk claiming an ancestry it does not have is
+  worse than no trajectory.
+- **A branch is an ordinary trajectory.** It can be replayed, branched again,
+  exported, and compared with its parent.
+
+The branch's `forked_from` records `(trajectory, step, step_hash)`. The step hash is
+what makes the claim falsifiable: it names the exact object the branch says it grew
+from.
+
+## 11. Unknown
+
+`unknown` is a result, not an error path.
+
+It appears when:
+
+- an adapter could not obtain information at all (`Unavailable`) — the effect's outcome
+  is `unavailable` and its provenance is `unknown`,
+- an adapter produced a real value against an environment it could not put back into
+  the recorded state (`Ungrounded`) — the value is usable, its provenance is not,
+- an irreversible effect was **denied** — no value exists, and the program is told so,
+- a reported world was never observed — grip `opaque`, evidence `none`.
+
+In every case the join makes the rest of the trajectory `unknown` too. There is no
+mechanism to repair it, on purpose. The alternative — filling the hole with a plausible
+value — produces a trajectory that looks real, which is the one failure this project
+cannot survive.
+
+## 12. Conformance
+
+What an environment must do, in order:
+
+1. **Route its interactions through the protocol**, with a stable target and an honest
+   `EffectKind`. *Mandatory.* An environment that stops here gets recording, replay,
+   branching, diffing and bisect, with `captured` grip on the workspace.
+2. **Declare a world**, if and only if state persists inside the environment across
+   steps and is not carried by the effects (§4.2). *Optional.*
+3. **Observe it**, reporting whatever fingerprint must be true for a reconstruction to
+   count. *Optional; without it the world is `opaque` and evidence is `none`.*
+4. **Restore it**, if it genuinely can. *Optional; almost nothing can.*
+
+Against the six environments:
+
+| environment | boundary | world | best grip | restore | notes |
+|---|---|---|---|---|---|
+| Python application | function calls | workspace | `captured` | yes | the default. Nothing to implement. |
+| Browser agent | actions + network | the page | `witnessed` | no | reconstructed by re-driving; verified by fingerprint |
+| RL environment | `step`/`reset` | simulator state | `witnessed`, `captured` with save/load | sometimes | a seeded env with `save_state` is `captured` |
+| Robot | sensor/actuator | physical | `opaque` | no | reachable, unverifiable; actuation is `irreversible` |
+| Autonomous lab | instruments/protocols | physical + consumables | `opaque` | no | most checkpoints are `unreachable`: reagents do not come back |
+| Production service | outbound calls | other people's state | `opaque` | no | branch with `--simulate`; irreversible writes denied |
+
+Note what the table does **not** say: that these are the same. A laboratory
+checkpoint is usually unreachable and a Python one usually is not. The contract's job
+is to make that difference *explicit and computable*, not to hide it behind a uniform
+interface that lies about three of the six rows.
+
+## 13. Format and compatibility
+
+`STEP_VERSION` stays at **1**. `grip` is `captured` by default and is skipped when
+serialising, and `Trajectory.worlds` is omitted when empty, so:
+
+- a step recorded before this release deserialises as `captured`, which is exactly what
+  it was,
+- a workspace-only step recorded after this release serialises to the same bytes and
+  the same address as before,
+- only a step with a declared non-restorable world carries the field at all.
+
+Existing trajectories replay, branch, export and import unchanged. No migration.
+
+---
+
+## Appendix: the laws
+
+1. A trajectory is evidence, not a world.
+2. The boundary is declared, never inferred.
+3. A checkpoint is a claim about reachability plus evidence, not a snapshot.
+4. Grip and provenance only ever get weaker downstream.
+5. What cannot be grounded is `unknown`, and `unknown` is never repaired.
+6. The past is immutable; a branch is a new step whose parent is somebody else's.

--- a/docs/technical-proposal.md
+++ b/docs/technical-proposal.md
@@ -345,8 +345,14 @@ done, and the README says so.
 
 ## 9. Environment adapter strategy
 
+> **Superseded in part.** The contract this section sketches is now specified in
+> [`environment-model.md`](environment-model.md), which is normative where the two differ.
+> What is below remains accurate about *why* the wire protocol is the integration surface.
+
 The core knows nothing about flights, browsers, robots or laboratories. It knows `call`, `decide`,
-`result`, `finish`.
+`result`, `finish` — and `observe`, for the minority of environments carrying state *between* steps
+that the recorded effects do not capture. `observe` is what makes a step's state reference
+`witnessed` rather than `captured`: a fingerprint we can compare and can never put back.
 
 The adapter surface is **a wire protocol, not an SDK**. That is the anti-lock-in decision: the
 Python client is ~200 lines of stdlib and speaks NDJSON over `AF_UNIX`. Reimplementing it in Node,

--- a/examples/reference/README.md
+++ b/examples/reference/README.md
@@ -1,0 +1,181 @@
+# The reference environment
+
+A reactor with a temperature and three control rods, and an operator whose policy is
+reasonable and wrong.
+
+It exists to be the smallest thing that is genuinely an *environment* rather than a
+function, so that the whole lifecycle can be shown end to end in about a hundred lines:
+
+```
+record → checkpoint → reconstruct → branch → intervene → execute → compare
+```
+
+Read [`docs/environment-model.md`](../../docs/environment-model.md) alongside it. This
+directory is that document made runnable.
+
+## Why a reactor
+
+Four properties, and every one of them is load-bearing:
+
+| property | why it matters |
+|---|---|
+| state persists between steps | tick 4 depends on what tick 3 did, and no recorded return value carries the temperature forward into a counterfactual |
+| it is acted on, not just read | `insert` and `withdraw` change it; `read` does not |
+| it can be re-driven but not restored | the same moves from the same start reproduce it exactly, and nothing puts a running reactor back to how it was at 14:03 |
+| it has one irreversible action | `scram` fires the emergency dump. It happens once, to a real world, and no reconstruction gets to un-fire it |
+
+That is the shape of a browser, an RL environment, a robot and an autonomous
+laboratory, minus everything that would make it slow to run in a test. It is
+deterministic, has no dependencies and does no I/O, so it produces the same numbers on
+every machine.
+
+## Run it
+
+```bash
+export PYTHONPATH=$PWD/clients/python
+noidroid run --name shift -- python3 examples/reference/agent.py
+```
+
+The operator chases output while the core is cool and pulls back once it is nearly too
+late. It melts down on tick 4:
+
+```
+   0 ● genesis
+   1 ● call reactor.read()
+   2 ● decide move = "withdraw"
+   3 ● call reactor.act({"move":"withdraw"})
+   …
+  13 ● call reactor.scram()
+  14 ✘ finish failure
+```
+
+### What is known at a checkpoint
+
+```bash
+noidroid show shift@8
+```
+
+```
+  state        1 file(s) root 0da17bf5b3 · witnessed
+               · .world/reactor.json
+
+  WHAT THIS CHECKPOINT GUARANTEES
+    reach        rebuild+restore  re-execute the prefix, restoring around effects we will not re-perform
+    evidence     witnessed  reported fingerprints are compared; the world cannot be corrected
+    grounding    real
+```
+
+Three independent questions — can I get back, will I know if I got it wrong, is what I
+get back to a claim about reality — and none of them is a percentage.
+
+Ask about a checkpoint past the emergency dump and the answer is different:
+
+```bash
+noidroid show shift@14
+```
+
+```
+    reach        unreachable
+                 step 13 performed 'reactor.scram', which is declared irreversible,
+                 in a world this run cannot put back.
+```
+
+`noidroid branch shift@14 …` is then refused before the program is spawned. Discovering
+it halfway through would mean firing the dump a second time to find out we should not
+have.
+
+### Reconstruct it
+
+```bash
+noidroid replay shift
+```
+
+```
+  steps re-derived       15/15 identical objects
+  faithful: the reconstruction addresses the same objects as the recording
+```
+
+Nothing was executed. Every reading, every move and the reactor's own fingerprint came
+out of the recording.
+
+### Explore another future
+
+```bash
+noidroid branch shift@8 --decide move=insert --label saved
+noidroid diff shift saved
+```
+
+```
+  shared prefix    8 step(s) — the same objects, not copies
+  diverged at      @8 replace-decision move = "insert"
+  outcome          failure → success
+  provenance       real → simulated
+  workspace        ~ .world/reactor.json
+```
+
+Inserting one tick earlier survives the shift. The first eight steps are not copies of
+the original's — they are the *same objects*, found to be identical by re-derivation.
+
+### Ask which decision mattered
+
+```bash
+noidroid bisect shift
+```
+
+```
+  @2 move = "insert"           success  ← flips it
+  @2 move = "hold"             failure
+  @5 move = "insert"           failure
+  @5 move = "hold"             failure
+  @8 move = "insert"           success  ← flips it
+  @8 move = "withdraw"         failure
+  @11 move = "hold"            failure
+  @11 move = "withdraw"        failure
+```
+
+Two alternatives suffice, at different times, and six do not. Note that this is not
+monotone: `@5` fails between two that succeed. Bisect is a **scan**, not a binary
+search, because "which decision was sufficient to change the outcome" has no reason to
+be a threshold.
+
+## The two layers
+
+`agent.py` has a `Shift` class, and it is the part worth copying. The same shape appears
+in the browser adapter and would appear in a robotics one:
+
+1. **Readings, decisions and actions are mediated.** They become recorded, replayable,
+   branchable steps.
+2. **The reactor is re-driven.** The engine reconstructs the *program* by serving it
+   recorded inputs; nothing can put a reactor back, so `_catch_up()` re-performs the
+   recorded moves and checks the result against the recorded fingerprint.
+
+The second layer is not optional and it is not the engine's job. That is precisely what
+grip `witnessed` means. Delete `_catch_up()` and the branch still runs, still hashes
+consistently and still reports `success` — while describing a physics that never
+happened. `the_counterfactual_world_is_re_driven_rather_than_assumed` in
+`crates/noidroid-core/tests/environment_slice.rs` is the test that catches it, and the
+only reason it can is that it knows which alternatives *should* flip.
+
+## Seeing an opaque world
+
+```bash
+REFERENCE_BLIND=1 noidroid run --name blind -- python3 examples/reference/agent.py
+noidroid show blind@8
+```
+
+The agent declares the reactor and tells Paranoid Android it is not looking at it:
+
+```
+    evidence     opaque  nothing is compared; a faithful reconstruction cannot be shown to be one
+```
+
+The recording still replays and still branches. It simply cannot be shown to have
+landed in the same place — which is the truth about a robot, and worth more than a
+number invented to fill the gap.
+
+## Files
+
+```
+world.py   the environment: 100 lines, deterministic, knows nothing about noidroid
+agent.py   the program: the policy, the mediated boundary, and the re-drive layer
+```

--- a/examples/reference/agent.py
+++ b/examples/reference/agent.py
@@ -1,0 +1,194 @@
+"""The reference agent: six ticks of a shift, one policy, one bad habit.
+
+This is the smallest program that exercises the entire lifecycle:
+
+    record -> checkpoint -> reconstruct -> branch -> intervene -> execute -> compare
+
+Run it::
+
+    export PYTHONPATH=$PWD/clients/python
+    noidroid run --name shift -- python examples/reference/agent.py
+
+    noidroid log shift                 # the timeline, and where it went wrong
+    noidroid show shift@8              # what is known at a checkpoint, and what is not
+    noidroid replay shift              # re-derive it; the world is never touched
+    noidroid branch shift@8 --decide move=insert --label saved
+    noidroid diff shift saved          # failure vs. success, and the step that differs
+    noidroid bisect shift              # every alternative, and which of them flip it
+
+The operator's policy is reasonable and wrong: chase output while the core is cool,
+pull back once it is nearly too late. It melts down on tick 4. Inserting one tick
+earlier does not.
+
+Two layers, and the second is what makes this a *reference* environment rather than a
+demo. It is the same shape the browser adapter has, and the same shape a robot or a
+laboratory adapter would have:
+
+* the readings, decisions and actions are **mediated**, so they become recorded,
+  replayable, branchable steps;
+* the reactor itself is **re-driven**, because nothing can put a reactor back. The
+  engine serves the program its recorded inputs, which reconstructs the *program*; the
+  reactor is reconstructed by re-performing the recorded moves, and then checked
+  against the fingerprint the recording holds.
+
+That second layer is not optional and it is not the engine's job. A `witnessed` world
+is precisely one that must be re-driven by whoever knows how to drive it. See
+`docs/environment-model.md` §4.2 and §7.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import noidroid
+from world import MELTDOWN, SHIFT, Reactor
+
+MOVES = ["insert", "hold", "withdraw"]
+
+#: Set to skip observing the reactor. The recording is still made, still replays and
+#: still branches -- it simply cannot be shown to have landed in the same place. That
+#: is `opaque`, and printing it is worth more than a number we invented instead.
+BLIND = os.environ.get("REFERENCE_BLIND") == "1"
+
+
+def policy(reading: dict) -> str:
+    """Chase output while it is cool; pull back once it is nearly too late.
+
+    Nothing here is subtle, and that is the point: the failure is in the *timing* of an
+    ordinary rule, which is the kind of failure a trajectory is for.
+    """
+    if reading["temp"] < 70:
+        return "withdraw"
+    if reading["temp"] > 95:
+        return "insert"
+    return "hold"
+
+
+class Shift:
+    """A reactor whose every interaction goes through Paranoid Android."""
+
+    def __init__(self, session) -> None:
+        self._nd = session
+        self._reactor = Reactor()
+        #: Moves the engine served from the recording, which this process has
+        #: therefore not actually performed. Re-driven before anything new happens.
+        self._owed: list = []
+        #: Cleared if re-driving does not land where the recording says it should.
+        self._grounded = True
+
+    # -- the mediated interface -------------------------------------------
+
+    def read(self) -> dict:
+        return self._nd.call("reactor.read", lambda: self._live(self._reactor.read))
+
+    def act(self, move: str) -> dict:
+        performed = []
+
+        def drive():
+            performed.append(True)
+            return self._live(lambda: self._reactor.act(move))
+
+        # `write`: re-driving the recorded moves rebuilds this reactor exactly. It is a
+        # claim about reversibility under reconstruction, not about disks.
+        reading = self._nd.call("reactor.act", drive, args={"move": move}, effect="write")
+        if not performed:
+            # Served from the recording. This process never moved the rods, so it owes
+            # the move to any counterfactual that follows.
+            self._owed.append((move, reading))
+        return reading
+
+    def scram(self) -> bool:
+        """Fire the emergency dump. Returns whether it was allowed to happen.
+
+        `irreversible`: it really happens, once, to a real world. Paranoid Android will
+        not perform it during any reconstruction, and will refuse to re-enter any
+        checkpoint sitting after it -- getting back there would mean firing it again.
+        """
+        try:
+            self._nd.call(
+                "reactor.scram",
+                lambda: self._live(self._reactor.scram),
+                effect="irreversible",
+            )
+            return True
+        except noidroid.Denied:
+            # A counterfactual does not get to fire a real emergency dump, so it is
+            # refused and the step is recorded as `unknown`. The shift still ended in a
+            # meltdown and the run still has to say so: letting the refusal escape
+            # reports `aborted`, which says nothing and is not what happened.
+            return False
+
+    # -- reconstruction ----------------------------------------------------
+
+    def _live(self, action):
+        """Do something to the real reactor, catching it up first if it is behind."""
+        self._catch_up()
+        result = action()
+        self._nd.observe(
+            "reactor",
+            None if BLIND else self._reactor.fingerprint(),
+            restorable=False,
+        )
+        return result if self._grounded else noidroid.Ungrounded(result)
+
+    def _catch_up(self) -> None:
+        """Re-drive every move the recording served, then check where we landed.
+
+        This is the whole of what reconstructing a witnessed world means. The engine
+        rebuilt the *program* by serving it recorded inputs; it cannot rebuild the
+        reactor, because nothing can put a reactor back. Only re-performing the moves
+        does that, and only comparing the result with the recorded reading shows that
+        it worked.
+
+        If it does not match, everything from here is ``Ungrounded``: a real value,
+        produced against an environment we could not put back, and therefore not
+        evidence about the original execution.
+        """
+        while self._owed:
+            move, recorded = self._owed.pop(0)
+            if self._reactor.act(move) != recorded:
+                self._grounded = False
+
+
+def main() -> int:
+    nd = noidroid.connect()
+    shift = Shift(nd)
+    try:
+        for _ in range(SHIFT):
+            reading = shift.read()
+            move = nd.decide("move", options=MOVES, choice=policy(reading))
+            reading = shift.act(move)
+
+            # The verdict comes from the *mediated* reading, never from the reactor
+            # object. Consulting the object here would work perfectly while recording
+            # and then quietly break: during a reconstruction the action is served from
+            # the recording, so the local reactor is still sitting at tick zero.
+            # Control flow that reads the world outside the boundary is control flow
+            # the recording does not contain.
+            if reading["temp"] >= MELTDOWN:
+                dumped = shift.scram()
+                nd.finish(
+                    "failure",
+                    {
+                        "reason": "meltdown",
+                        "tick": reading["tick"],
+                        "peak": reading["temp"],
+                        "scrammed": dumped,
+                    },
+                )
+                return 1
+
+        nd.finish(
+            "success",
+            {"reason": "shift completed", "tick": reading["tick"], "temp": reading["temp"]},
+        )
+        return 0
+    finally:
+        nd.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/reference/world.py
+++ b/examples/reference/world.py
@@ -1,0 +1,102 @@
+"""The reference environment: a reactor with a temperature and three control rods.
+
+Deliberately tiny, deliberately deterministic, and deliberately *outside* the program.
+It is here to be the smallest thing that is genuinely an environment rather than a
+function:
+
+* it has **state that persists between steps** — the temperature and the rod position.
+  Step 4 depends on what step 3 did, and no recorded return value contains it,
+* it is **acted on, not just read** — `insert` and `withdraw` change it,
+* it can be **re-driven but not restored** — replaying the same commands from the same
+  start reproduces it exactly, and nothing can put a running reactor back to how it was
+  at 14:03,
+* it has **one genuinely irreversible action** — `scram` fires the emergency dump. It
+  happens once, to a real world, and no reconstruction gets to un-fire it.
+
+That is the shape of a browser, an RL environment, a robot and a laboratory, minus
+everything that would make it slow to run in a test.
+
+No dependencies. No I/O. Same numbers on every machine.
+"""
+
+from __future__ import annotations
+
+#: At or above this, the core is damaged and the run has failed.
+MELTDOWN = 100.0
+#: How many ticks a shift lasts. Finish one without a meltdown and you have succeeded.
+SHIFT = 6
+#: Degrees per tick per unit of withdrawn rod.
+GAIN = 12.0
+#: Degrees per tick the coolant takes out regardless.
+COOLING = 6.0
+
+
+class Reactor:
+    """Deterministic. `temp` moves by the rod position; the rods move by one a tick."""
+
+    def __init__(self) -> None:
+        self.tick = 0
+        self.temp = 55.0
+        #: -2 (fully inserted, cooling hard) to +2 (fully withdrawn, heating hard).
+        self.rods = 0
+        self.scrammed = False
+
+    # -- observation ------------------------------------------------------
+
+    def read(self) -> dict:
+        """What the instruments say. This is the only way in."""
+        return {
+            "tick": self.tick,
+            "temp": round(self.temp, 1),
+            "rods": self.rods,
+            "scrammed": self.scrammed,
+        }
+
+    def fingerprint(self) -> dict:
+        """What must be true for a reconstruction of this world to count.
+
+        Not the same thing as `read()`, and the difference is the interesting part. A
+        fingerprint states what a reconstruction has to reproduce; anything volatile
+        left in here makes every reconstruction diverge, which is accurate and useless.
+        Here everything is deterministic, so the fingerprint is the whole state — a
+        browser's would be a URL and a structure hash, not the rendered text.
+        """
+        return self.read()
+
+    # -- action -----------------------------------------------------------
+
+    def act(self, move: str) -> dict:
+        """`insert`, `hold` or `withdraw`. Re-drivable: same sequence, same reactor."""
+        if self.scrammed:
+            return self.read()
+        if move == "insert":
+            self.rods = max(-2, self.rods - 1)
+        elif move == "withdraw":
+            self.rods = min(2, self.rods + 1)
+        elif move != "hold":
+            raise ValueError(f"no such move: {move!r}")
+        # Withdrawn rods heat, the coolant takes a fixed amount out, and the balance
+        # is what makes chasing output fatal three ticks later.
+        self.temp += self.rods * GAIN - COOLING
+        self.tick += 1
+        return self.read()
+
+    def scram(self) -> dict:
+        """Emergency dump. Works, ends the shift, and cannot be undone.
+
+        Declared `irreversible`, so Paranoid Android will refuse to perform it during
+        any reconstruction, and will refuse to re-enter any checkpoint that sits after
+        one — because getting back there would mean firing it again.
+        """
+        self.scrammed = True
+        self.temp = 20.0
+        return self.read()
+
+    # -- verdict ----------------------------------------------------------
+
+    def verdict(self) -> str:
+        if self.temp >= MELTDOWN:
+            return "meltdown"
+        if self.tick >= SHIFT:
+            return "safe"
+        return "running"


### PR DESCRIPTION
Closes #48

## What this is

Almost no new functionality. It makes the execution model coherent, so that adding
robotics, RL environments or an autonomous laboratory later is an adapter rather than a
redesign. The contract is [`docs/environment-model.md`](docs/environment-model.md).

## The problem it fixes

`Step.state_root` was the Merkle root of a directory, full stop. One answer to "what is
the state here", and the wrong one for most of what this project is aimed at.

That was not only a missing feature. It was a quiet lie: when a reconstruction skipped
re-performing a `write`/`irreversible` effect, the engine restored the recorded tree and
counted the step `state_restored`. For a filesystem that is true. For a browser it filed
a page nobody restored under the address of the page the recording saw.

## The contract

A state reference now carries a **grip**:

| grip | we hold | detect a difference? | put it back? |
|---|---|---|---|
| `captured` | the bytes | yes | **yes** |
| `witnessed` | a fingerprint | yes | no |
| `opaque` | nothing | no | no |

Grip joins like provenance — the weakest part decides — so composing a workspace with a
page needs no framework.

`Environment` is three methods, two of which may say no:

```rust
fn manifest(&self) -> Manifest;
fn observe(&mut self, store: &Store) -> Result<State>;
fn restore(&mut self, state: &State, store: &Store) -> Result<Grip>;
```

`restore` returning the grip it *achieved* is the load-bearing detail: anything short of
`captured` makes the engine stop asserting the recorded state and start checking it.
Three implementations — `Workspace`, `Reported`, `Situation` — because there are three
distinct answers. Anything not written in Rust declares its world over the wire with the
new `observe` protocol message.

A **checkpoint** answers three independent questions, none collapsible into another:

```
reach      can I get back here?           rebuild | rebuild+restore | unreachable
evidence   will I know if I got it wrong? captured | witnessed | opaque
grounding  is this a claim about reality? real | live | simulated | unknown
```

Branching from an `unreachable` checkpoint is refused **before the program is spawned**.
The version that finds out halfway through is the version that re-submits the form in
order to discover it should not have.

## Proof

- **`examples/reference/`** — a deterministic reactor, ~100 lines, whole lifecycle:
  original melts down, branch at the right decision survives. Its world can be re-driven
  and can never be put back, so nothing about it can be faked by a filesystem snapshot.
- **The browser adapter** now declares its page as a `witnessed` world instead of
  keeping the same machinery in a private vocabulary.
- **`environment_slice.rs`** — 8 invariant tests against the reference environment,
  including one that catches a *missing* re-drive by knowing which alternatives should
  flip the outcome.

## Compatibility

`STEP_VERSION` stays at **1**. `grip` defaults to `captured` and is skipped when
serialising, so an old step reads back as exactly what it was and a new workspace-only
step hashes to the same address as before. `model::tests::format_is_pinned` is unchanged
and passing. No migration.

## Limit stated rather than hidden

Re-driving a witnessed world is the adapter's job and **the engine cannot check that it
happened**. Skip it and the run completes, hashes consistently and reports a clean
outcome while describing a physics that never happened. The only source of truth about a
world the engine cannot see is the program that can. The model makes the obligation
explicit and hands the adapter a fingerprint to check itself against; it cannot do more
than that, and says so in §7.1.

## Verification

```
cargo test --all         68 passed, 0 failed  (browser tests skip: no Chromium libs here)
cargo fmt --all --check  clean
cargo clippy --all-targets -- -D warnings  clean
```

Examples run end to end: flight, llm, reference (record → replay → branch → diff →
bisect → export → import).

🤖 Generated with [Claude Code](https://claude.com/claude-code)