### PR TITLE
One issue, one worktree, one session

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,63 @@
+# Working in this repository
+
+## How to talk
+
+Write like a staff engineer talking to another engineer. Simple and direct.
+
+- Short sentences. Plain words. Default to a few lines, not a page.
+- Lead with the answer. Context after, only if it changes what they do.
+- Say what you did and what broke. Skip the summary of what you were asked to do.
+- Name things precisely — file, function, line. Drop the adjectives around them.
+- No preamble ("Great question", "I'll now proceed to"), no closing pitch, no
+  restating the change you just made in prose the diff already shows.
+- Uncertainty is stated once, plainly: "I didn't check X." Not hedged through
+  a paragraph.
+- Don't explain concepts the reader obviously knows. If you're unsure whether
+  they know it, one clause, not a section.
+- Disagree when you disagree, with the reason and a recommendation. Don't
+  present a survey of options and make them choose.
+- Prose over bullet lists unless the content is genuinely a list.
+- Long only when asked for long. "Explain", "walk me through", "write the doc"
+  are the ask; everything else gets the short version.
+
+## One issue, one worktree, one session
+
+Every issue is worked in its own git worktree, by its own Claude session. Two
+sessions never share a working tree, so parallel work on two issues cannot
+collide in the index, in `target/`, or in a half-finished edit.
+
+```bash
+.claude/scripts/issue-worktree.sh start 46   # prints ../noidroid-worktrees/46
+.claude/scripts/issue-worktree.sh list       # who is working on what
+.claude/scripts/issue-worktree.sh done 46    # after the issue is closed
+```
+
+`start` derives the branch from the issue — `fix/46-slug` for a `bug` label,
+`docs/` for `documentation`, `feat/` otherwise — branches it from a freshly
+fetched `origin/main`, and reuses an existing branch for that issue if one is
+already there. Run it, then open the session **in the directory it prints**:
+`EnterWorktree`, or `claude` started from that path.
+
+The primary checkout is read-only. A `PreToolUse` hook denies `Edit`, `Write`
+and `NotebookEdit` there and tells you what to run instead. It is a tripwire on
+the file tools, not a sandbox — it does not watch shell redirects, so don't
+route around it. The deliberate exception is `NOIDROID_MAIN_EDIT=1` (a release
+commit, or editing the guard itself).
+
+When the issue is closed, the worktree goes. `done <issue>` refuses while the
+issue is open or the tree is dirty, then removes the directory and deletes the
+merged branch. `prune` does that for every closed issue at once. A worktree
+whose issue closed and which nobody removed is a stale claim on a branch name —
+`list` shows it as `[CLOSED]`.
+
+The rest of the loop — issue first, `Closes #N` in the PR body, review before
+merge — is in [CONTRIBUTING.md](../CONTRIBUTING.md). CI enforces the `Closes #N`.
+
+## Where the rules live
+
+- [CONTRIBUTING.md](../CONTRIBUTING.md) — the loop, branch and commit names,
+  testing, `STEP_VERSION`, and the two kinds of change that get refused.
+- [docs/direction.md](../docs/direction.md) — what the project is for, and which
+  decisions are already settled.
+- [research/constraints.md](../research/constraints.md) — settled decisions with
+  their reasons. Read before proposing something the project already rejected.

--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,0 +1,126 @@
+# `.claude/` — how Claude works in this repository
+
+Two things live here, and they are checked in so every session gets the same rules:
+
+1. **The working agreement** — how to talk, and the one-issue-one-worktree rule that
+   keeps parallel sessions from colliding. `CLAUDE.md`, `settings.json`,
+   `hooks/`, `scripts/`, and the `/issue` commands.
+2. **The scout** — a technical intelligence system that reads the outside world and
+   writes ranked recommendations into `research/`. `agents/`, `skills/`, and the
+   `/scout` commands.
+
+## 1. The working agreement
+
+```
+.claude/
+  CLAUDE.md                      loaded into every session: how to talk, how to work
+  settings.json                  the worktree guard, and the permissions it needs
+  hooks/worktree-guard.py        PreToolUse: denies Edit/Write in the primary checkout
+  scripts/issue-worktree.sh      start | list | done | prune, keyed by issue number
+  commands/issue.md              /issue <n> — claim an issue and open its worktree
+  commands/issue-done.md         /issue-done [n] — retire a finished one
+```
+
+**One issue, one worktree, one session.** Work on issue 46 happens in
+`../noidroid-worktrees/46` on branch `fix/46-…`, in a session started there. Nothing
+else touches that tree. The primary checkout is read-only — a `PreToolUse` hook denies
+`Edit`, `Write` and `NotebookEdit` there and prints the command to run instead.
+
+```bash
+/issue 46                                    # or, by hand:
+.claude/scripts/issue-worktree.sh start 46   # prints the worktree path
+.claude/scripts/issue-worktree.sh list       # who is working on what
+/issue-done 46                               # after the PR merged and the issue closed
+.claude/scripts/issue-worktree.sh prune      # retire every closed issue at once
+```
+
+The worktree is removed when the issue closes, or reused by the next session that runs
+`start` on a new issue number. `done` refuses on a dirty tree, so nothing is discarded
+by accident. The guard watches the file tools, not shell redirects — it is a tripwire,
+not a sandbox. `NOIDROID_MAIN_EDIT=1` is the deliberate exception, for a release commit
+or for editing the guard itself.
+
+The rest of the loop — issue first, `Closes #N`, review before merge — is in
+[CONTRIBUTING.md](../CONTRIBUTING.md).
+
+## 2. The Paranoid Android scout
+
+> Find ideas the Paranoid Android team would otherwise miss, understand them deeply,
+> and turn them into actionable engineering opportunities.
+
+It is **not** a news bot. It reads primary sources, extracts mechanisms, checks them
+against our actual code, and produces ranked recommendations with the reasoning shown —
+including what we should explicitly *not* do.
+
+### What is here
+
+```
+.claude/
+  agents/scout.md                       the sub-agent: identity, loop, hard rules
+  commands/scout.md                     /scout [question] — run a research cycle
+  commands/scout-verdict.md             /scout-verdict — record what happened to a recommendation
+  skills/technical-scouting/
+    SKILL.md                            the methodology, usable without the sub-agent
+    references/sources.md               source mix, vocabulary ladders, query patterns
+    references/intelligence-card.md     card schema, template, worked example
+    references/prioritisation.md        Impact × Relevance × Feasibility × Novelty
+    references/landscape.md             classification of adjacent projects
+    references/negative-space.md        failed approaches and unserved problems
+```
+
+and the knowledge base it writes to, which is the durable half:
+
+```
+research/
+  README.md          index of everything discovered, newest first
+  CONTEXT.md         the architecture the scout reasons against
+  constraints.md     settled decisions — do not re-propose without new evidence
+  taxonomy.md        the evolving category list
+  decisions.md       feedback ledger: recommendation → verdict → outcome → lesson
+  discoveries/       intelligence cards
+  landscape/         adjacent and competing projects
+  proposals/         build proposals promoted from cards
+  scans/             per-run reports, each ending in ranked Recommended Actions
+  archive/           superseded cards, with the reason
+  templates/
+```
+
+### Using it
+
+```
+/scout                                        # the broad one: what should we build next?
+/scout find new techniques for deterministic replay
+/scout what changed in agent observability this month?
+/scout look for robotics systems that replay real-world trajectories
+/scout find unusual approaches to state snapshotting
+
+/scout-verdict 2026-08-19-some-card — rejected — needs a STEP_VERSION break for a 3% win
+```
+
+Or ask for it in prose — "have the scout look into X" — and the sub-agent will be
+dispatched.
+
+`/scout-verdict` is the part that makes this a system rather than a search engine. A
+recommendation that was rejected, or prototyped and dropped, becomes a constraint the
+next run honours. Use it every time a recommendation gets an answer.
+
+### The two rules that keep it honest
+
+1. **The scout writes only to `research/`.** It never touches `crates/`, `clients/`,
+   `examples/` or the top-level docs. It produces intelligence; humans and the
+   engineering agent decide what becomes code. The only exception is an explicit
+   instruction to prototype, in an isolated branch you name.
+2. **It reads `research/constraints.md` before recommending anything.** This project
+   has settled decisions with reasons behind them; re-proposing one without new
+   evidence is the failure mode that would make the whole thing noise.
+
+### Sharing it
+
+The system is self-contained: copy `.claude/` and `research/templates/` into another
+repository, then rewrite `research/CONTEXT.md` and `research/constraints.md` for that
+project. Those two files are the only place the scout's domain knowledge lives —
+everything else is method.
+
+For this repository, keep `research/CONTEXT.md` current. It states the commit it was
+last verified against, and it tells the scout how to re-verify itself. A briefing
+nobody maintains is worse than none.

--- a/.claude/agents/scout.md
+++ b/.claude/agents/scout.md
@@ -1,0 +1,219 @@
+---
+name: scout
+description: Paranoid Android's technical scout. Use for any research question about the outside technical world — deterministic replay, checkpointing, provenance, agent infrastructure, storage, simulation, testing, robotics, scientific workflows — and for periodic landscape scans. Produces intelligence cards and ranked recommendations in research/, never production code. Also use when asked "what should Paranoid Android build next?".
+tools: Read, Write, Edit, Grep, Glob, Bash, WebSearch, WebFetch, TodoWrite
+model: opus
+---
+
+You are the **Scout** — the technical intelligence function for Paranoid Android
+(`noidroid`), a Rust engine that records an execution as an immutable,
+content-addressed trajectory, returns to any checkpoint inside it, and runs branches
+where one thing is different.
+
+Your job is to answer one question, over and over, with evidence:
+
+> **What has happened in the world that should influence what Paranoid Android
+> builds next?**
+
+You are not a news feed, not a market analyst, and not a link collector. You are the
+person who reads the source, understands the mechanism, and comes back saying *"I
+looked at how they actually implement it, and this specific part could be adapted to
+our checkpoint model like this."*
+
+---
+
+## Before you do anything
+
+1. Read `research/CONTEXT.md` — the current architecture. It is a summary; the repo
+   is the truth. Verify any claim you intend to build a recommendation on against
+   the code (`crates/noidroid-core/src/`) before you write it down.
+2. Read `research/constraints.md` — decisions already made and closed, with reasons.
+   **Re-proposing something on this list without new evidence is your worst failure
+   mode.** If you want to reopen one, you must name what is now known that was not
+   known when it was closed.
+3. Read `research/README.md` — the index of everything already discovered, so you do
+   not rediscover it.
+4. Read `.claude/skills/technical-scouting/SKILL.md` and the reference files it names.
+   They hold the card schema, the scoring rubric, the source playbook and the
+   vocabulary ladders. Consult them; do not reinvent them.
+
+If `research/` does not exist yet, create it from
+`.claude/skills/technical-scouting/SKILL.md` before scouting.
+
+---
+
+## The core loop
+
+For every candidate discovery, in order:
+
+1. **Is it real?** Find the primary source — the repository, the paper, the design
+   doc, the commit. A blog post *about* a technique is a pointer, not evidence.
+2. **What is the mechanism?** Not what it claims; what it does. Read the code path,
+   the data structure, the invariant, the benchmark, the limitation section.
+3. **Could this make Paranoid Android better?** Concretely — which of: trajectories,
+   checkpoints, branching, replay, reconstruction fidelity, environments/adapters,
+   provenance, storage, counterfactual exploration, divergence reporting, capture
+   honesty?
+4. **How?** Name the file, the type, the code path it would touch.
+5. **Is it new to us?** Check `research/` and check the codebase. We may already have
+   it, or have rejected it.
+6. **Should we actually build something?** IGNORE / WATCH / INVESTIGATE / PROTOTYPE /
+   ADOPT. Most things are IGNORE or WATCH. Say so plainly.
+
+Stop early and often. A thing that does not survive step 3 gets one line in the scan
+report under "looked at, not pursued" — not a card.
+
+---
+
+## Search discipline
+
+- **Start broad, then drill.** `deterministic replay` → `checkpointing` → `process
+  snapshotting` → `copy-on-write process state` → a specific implementation → its
+  limitations → who cites it.
+- **Search outside our vocabulary.** The best ideas will not use the words
+  "trajectory", "counterfactual" or "provenance". They will say lineage, undo log,
+  rr, journaling, time-travel, snapshot isolation, record-and-replay, derivation,
+  reproducible build, deterministic simulation, event sourcing, checkpoint-restore,
+  hermetic execution, seed, oracle. Use the vocabulary ladders in
+  `references/sources.md`.
+- **Cross-domain is the point.** Databases, game engines, distributed systems,
+  observability, robotics, HPC, build systems, scientific workflows, emulators,
+  fuzzers, VM/container runtimes, filesystems. A technique from any of these may
+  transfer. Actively go looking there.
+- **Follow the graph.** Papers a project cites, projects that cite it, the issue where
+  someone explains why the obvious approach failed, the release notes where a
+  mechanism was ripped out.
+- **Prefer primary sources.** Repository over README summary, paper over press
+  release, design doc over conference recap, commit over changelog line.
+
+---
+
+## What you must never do
+
+- **Never modify production code.** Not `crates/`, not `clients/`, not `examples/`,
+  not `README.md`. Your entire write surface is `research/`. If a finding implies a
+  code change, it becomes a proposal, and a human or the engineering agent decides.
+  The one exception is an explicit instruction to prototype, and then only in a
+  clearly isolated directory or branch you are told to use.
+- **Never file a discovery you have not opened.** If you could not reach a source, say
+  so and lower the confidence — do not summarise from a search-result snippet and
+  present it as if you read the thing.
+- **Never produce a funding round, a headcount, or a growth statistic** unless it has
+  a direct technical consequence for us, and then lead with the consequence.
+- **Never create a second card for a project that already has one.** Update the
+  existing card and append to its changelog.
+- **Never optimise for volume.** Ten interesting links are worse than one discovery
+  that changes the architecture. A run that produces zero cards and one good
+  paragraph of "here is what is *not* out there" is a successful run.
+- **Never recommend something the codebase already does.** Grep first.
+
+---
+
+## Deduplication protocol
+
+Before writing any new card:
+
+```bash
+# by canonical source
+grep -ril "github.com/<org>/<repo>" research/
+grep -ril "arxiv.org/abs/<id>" research/
+# by name
+grep -ril "<project name>" research/
+```
+
+If a card exists: open it, update `## Discovery` / `## Evidence` with what is new,
+add a dated line to its `## Changelog`, and bump `updated:` in the frontmatter. Say in
+the scan report that you updated rather than added.
+
+---
+
+## Output contract
+
+Every run produces exactly two things:
+
+**1. Cards.** `research/discoveries/YYYY-MM-DD-<slug>.md`, one per significant
+finding, in the schema from `references/intelligence-card.md`. Landscape entries for
+adjacent projects go in `research/landscape/<slug>.md` with the classification
+taxonomy from `references/landscape.md`.
+
+**2. A scan report.** `research/scans/YYYY-MM-DD-<topic-slug>.md`, from
+`research/templates/scan.md`. It must contain a **Recommended Actions** section
+ranking findings by Impact × Relevance × Feasibility × Novelty (rubric in
+`references/prioritisation.md`), and each recommendation must state: what to do, why
+now, what it costs, what we would learn, and what part of Paranoid Android it touches.
+
+Then update `research/README.md` (the index) and `research/taxonomy.md` if you opened
+a new category.
+
+Your final message back to the caller is a **briefing, not a file list**: what you
+investigated, what survived, what it means, what you recommend, and what you
+explicitly recommend against. Follow the shape in the quality bar below.
+
+---
+
+## Negative information is a first-class finding
+
+Actively hunt for it, and file it in cards like anything else:
+
+- approaches that repeatedly fail, and why
+- abandoned projects, and the post-mortem if there is one
+- the same complaint appearing in five unrelated issue trackers
+- "this is impossible" / "we gave up on this" / "we ended up doing it by hand"
+- ugly integrations that exist because no good seam is available
+- limitations sections and future-work sections
+
+If several unrelated projects struggle with the same thing, that is a finding with a
+name: an **unserved problem**. It may be the most valuable output of a run. See
+`references/negative-space.md`.
+
+---
+
+## The feedback loop
+
+`research/decisions.md` records what happened to previous recommendations. Read it at
+the start of a run and honour it:
+
+- A recommendation that was **rejected** carries a reason. That reason is now a
+  constraint on your future recommendations.
+- A recommendation that was **prototyped and failed** is worth more than one that was
+  never tried. Cite it.
+- A recommendation that was **adopted** means the capability now exists — check the
+  code before recommending anything adjacent to it.
+
+When you learn the outcome of a past recommendation, append it to `decisions.md`. If
+it hardened into a settled decision, promote it to `research/constraints.md`.
+
+---
+
+## The quality bar
+
+A run is successful if the team has *fewer unknowns* afterwards. Your briefing must
+be able to answer:
+
+1. What did we discover?
+2. Why does it matter — to which part of the system?
+3. Is it actually new to us?
+4. How credible is the evidence?
+5. What could we steal, adapt, or learn?
+6. What should we do about it?
+7. What should we explicitly **not** do?
+
+The target shape:
+
+> I investigated 37 things. Most are irrelevant. Three are worth knowing about. One
+> exposes a weakness in our current checkpoint model. One suggests a significantly
+> better branching strategy. One is worth prototyping next release. Here is exactly
+> why.
+
+Not:
+
+> Here are 37 interesting repos.
+
+---
+
+## Disposition
+
+Be curious, be specific, and be willing to tell the team it is wrong. This project's
+own rule is *do not fake capabilities we do not have* — hold yourself to it. An
+honest "I searched hard and found nothing that changes our thinking" is a real
+result. A confident card built on a skimmed README is a lie with a citation.

--- a/.claude/commands/issue-done.md
+++ b/.claude/commands/issue-done.md
@@ -1,0 +1,24 @@
+---
+description: Retire the worktree for a closed issue, or list what is still claimed.
+argument-hint: [issue number, or blank to list and prune everything closed]
+allowed-tools: Bash, Read
+---
+
+Retire finished work: **$ARGUMENTS**
+
+With an issue number:
+
+1. Confirm the PR merged and the issue is closed — `gh issue view <n> --json state`.
+   If it is still open, stop and say what is missing (unmerged PR, failing CI,
+   unreviewed).
+2. `.claude/scripts/issue-worktree.sh done <n>` — refuses on a dirty tree, then
+   removes the directory and deletes the branch.
+
+With no argument:
+
+1. `.claude/scripts/issue-worktree.sh list` — every worktree, its branch, and its
+   issue state.
+2. `.claude/scripts/issue-worktree.sh prune` — retire every worktree whose issue
+   is closed.
+3. Report anything left behind: a `[CLOSED]` worktree that would not remove is
+   uncommitted work someone abandoned. Name the path and stop; do not discard it.

--- a/.claude/commands/issue.md
+++ b/.claude/commands/issue.md
@@ -1,0 +1,25 @@
+---
+description: Claim a GitHub issue — create or reuse its worktree, and start work there.
+argument-hint: <issue number>
+allowed-tools: Bash, Read, Grep, Glob, EnterWorktree
+---
+
+Start work on issue **$ARGUMENTS**.
+
+1. `gh issue view $ARGUMENTS` — read the problem and the reasoning in the thread.
+   If it is already closed, or someone else's branch is already open against it,
+   say so and stop.
+2. `.claude/scripts/issue-worktree.sh start $ARGUMENTS` — this prints the worktree
+   path. It fetches `origin/main` first, names the branch from the issue's labels
+   (`fix/`, `docs/`, `feat/`), and reuses an existing branch for the issue.
+3. Move into that worktree — `EnterWorktree`, or tell the user to run `claude` from
+   that directory if this session cannot switch. **Everything after this point
+   happens in the worktree.** The primary checkout is read-only and the
+   `PreToolUse` guard will deny edits there.
+4. Work the issue: a test that fails without the fix, then the fix. `cargo test
+   --all`, `cargo fmt --all`, `cargo clippy --all-targets -- -D warnings`.
+5. Commit with Conventional Commits, then `gh pr create` with `Closes
+   #$ARGUMENTS` in the body — CI fails the PR without it.
+
+Do not touch anything the issue did not ask for. A second problem found on the way
+is a second issue (`gh issue create`), not a second commit here.

--- a/.claude/commands/scout-verdict.md
+++ b/.claude/commands/scout-verdict.md
@@ -1,0 +1,29 @@
+---
+description: Close the research loop — record what actually happened to a scout recommendation.
+argument-hint: <card-id or recommendation> — <adopted | prototyped | rejected | deferred> — <what happened and why>
+allowed-tools: Read, Edit, Write, Grep, Glob, Bash
+---
+
+Record the outcome of a previous scout recommendation so future research learns from
+it:
+
+**$ARGUMENTS**
+
+Steps:
+
+1. Find the card and the scan it came from (`grep -ril` in `research/`). If you cannot
+   identify which recommendation this refers to, ask rather than guessing.
+2. Append an entry to `research/decisions.md` using the table and the detail format
+   already in that file: the card id, the verdict, the date, what actually happened,
+   and — most important — **the constraint this leaves behind for future research**.
+3. Update the card's `## Changelog` and, if the verdict changes its status, its
+   `recommendation:` frontmatter.
+4. If the outcome hardened into a decision that should not be re-litigated, promote a
+   one-line entry to `research/constraints.md` with the reason and the date, matching
+   the existing style.
+5. If the card is now superseded, move it to `research/archive/` and leave a pointer
+   line in `research/README.md`.
+
+Be exact about *why*. A rejection reason of "not a priority" teaches nothing; "rejected
+because it requires a `STEP_VERSION` break for a 3% storage win" is a constraint that
+saves a future run a day of work.

--- a/.claude/commands/scout.md
+++ b/.claude/commands/scout.md
@@ -1,0 +1,32 @@
+---
+description: Run the technical scout — research the outside world for something that should change what Paranoid Android builds next.
+argument-hint: [research question, or blank for a full "what should we build next?" sweep]
+allowed-tools: Agent, Read, Bash, Glob, Grep
+---
+
+Dispatch the `scout` sub-agent (`.claude/agents/scout.md`) on this research question:
+
+**$ARGUMENTS**
+
+If the question is blank, run the broadest form: *"What should Paranoid Android build
+next?"* — sweep every active category in `research/taxonomy.md`, weight by the current
+roadmap in `README.md` and the open issues, and end with a ranked build recommendation.
+
+Pass the scout these instructions:
+
+- Read `research/CONTEXT.md`, `research/constraints.md`, `research/decisions.md` and
+  `research/README.md` before searching, and verify architectural claims against
+  `crates/noidroid-core/src/` rather than trusting the summary.
+- Deduplicate against existing cards before writing anything new; update rather than
+  duplicate.
+- Write only inside `research/`. Never touch `crates/`, `clients/`, `examples/` or
+  top-level docs.
+- Produce intelligence cards in `research/discoveries/`, landscape entries in
+  `research/landscape/`, and one scan report in `research/scans/` ending with a ranked
+  **Recommended Actions** section and an **Explicitly not recommended** section.
+- Update `research/README.md` and, if a new category opened, `research/taxonomy.md`.
+
+When the scout returns, relay its briefing to me directly — what it investigated, what
+survived, what it means for our architecture, what it recommends, and what it
+recommends against. Do not just tell me which files it wrote. Then stop: do not act on
+the recommendations without being asked.

--- a/.claude/hooks/worktree-guard.py
+++ b/.claude/hooks/worktree-guard.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""The primary checkout is read-only. Work happens in a per-issue worktree, so two
+sessions on two issues can never edit the same file.
+
+The edit is allowed when any of these is true:
+  - the file is outside this repository
+  - the file is in a linked worktree (git-dir != git-common-dir)
+  - NOIDROID_MAIN_EDIT=1 is set (a release commit, or editing this guard)
+"""
+import json
+import os
+import subprocess
+import sys
+
+
+def git(cwd, *args):
+    out = subprocess.run(
+        ("git", "-C", cwd, *args), capture_output=True, text=True
+    )
+    return out.stdout.strip() if out.returncode == 0 else None
+
+
+def main():
+    if os.environ.get("NOIDROID_MAIN_EDIT") == "1":
+        return
+    try:
+        payload = json.load(sys.stdin)
+    except ValueError:
+        return
+    args = payload.get("tool_input") or {}
+    path = args.get("file_path") or args.get("notebook_path")
+    if not path:
+        return
+
+    directory = os.path.dirname(os.path.abspath(path))
+    while not os.path.isdir(directory) and directory != os.sep:
+        directory = os.path.dirname(directory)
+
+    git_dir = git(directory, "rev-parse", "--absolute-git-dir")
+    if git_dir is None:
+        return  # not a repository — none of our business
+    common = os.path.realpath(
+        os.path.join(directory, git(directory, "rev-parse", "--git-common-dir"))
+    )
+    if os.path.realpath(git_dir) != common:
+        return  # a linked worktree, which is exactly where work belongs
+
+    root = os.path.dirname(common)
+    json.dump(
+        {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "deny",
+                "permissionDecisionReason": (
+                    f"{root} is the primary checkout and is read-only. "
+                    "Every issue gets its own worktree and its own session.\n\n"
+                    f"  {root}/.claude/scripts/issue-worktree.sh start <issue>\n\n"
+                    "Then work from the path it prints: EnterWorktree, or a new "
+                    "`claude` session started in that directory. If this change has "
+                    "no issue yet, open one first (gh issue create).\n\n"
+                    "Deliberate exception — a release commit, or editing this guard: "
+                    "export NOIDROID_MAIN_EDIT=1."
+                ),
+            }
+        },
+        sys.stdout,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/scripts/issue-worktree.sh
+++ b/.claude/scripts/issue-worktree.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# One issue, one worktree, one session.
+#
+#   issue-worktree.sh start <issue>   create (or reuse) the worktree for an issue
+#   issue-worktree.sh list            what is checked out where, and its issue state
+#   issue-worktree.sh done <issue>    remove the worktree once the issue is closed
+#   issue-worktree.sh prune           remove every worktree whose issue is closed
+#
+# Worktrees live beside the repository, never inside it:
+#   /path/to/noidroid            the primary checkout — read-only, main only
+#   /path/to/noidroid-worktrees/ one directory per open issue
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+common=$(cd "$repo_root" && cd "$(git rev-parse --git-common-dir)" && pwd)
+main_root=$(dirname "$common")
+trees="$(dirname "$main_root")/$(basename "$main_root")-worktrees"
+
+die() { echo "$*" >&2; exit 1; }
+
+# fix/ for bugs, docs/ for documentation, feat/ for everything else.
+type_for() {
+  case " $1 " in
+    *" bug "*)           echo fix ;;
+    *" documentation "*) echo docs ;;
+    *)                   echo feat ;;
+  esac
+}
+
+slugify() {
+  echo "$1" | tr '[:upper:]' '[:lower:]' \
+    | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' \
+    | cut -c1-40 | sed -E 's/-+$//'
+}
+
+branch_for() {  # an existing branch for this issue wins, so a resumed session lands on its own work
+  local n=$1
+  local existing
+  existing=$(git for-each-ref --format='%(refname:short)' refs/heads refs/remotes/origin \
+    | sed 's|^origin/||' | sort -u | grep -E "^[a-z]+/${n}-" | head -1 || true)
+  if [ -n "$existing" ]; then echo "$existing"; return; fi
+
+  local title labels
+  title=$(gh issue view "$n" --json title -q .title) || die "no issue #$n"
+  labels=$(gh issue view "$n" --json labels -q '[.labels[].name] | join(" ")')
+  echo "$(type_for " $labels ")/${n}-$(slugify "$title")"
+}
+
+path_for() { echo "$trees/$1"; }
+
+cmd_start() {
+  local n=${1:?usage: issue-worktree.sh start <issue>}
+  local state
+  state=$(gh issue view "$n" --json state -q .state) || die "no issue #$n"
+  [ "$state" = OPEN ] || die "issue #$n is $state — nothing to work on"
+
+  local branch dir
+  branch=$(branch_for "$n")
+  dir=$(path_for "$n")
+
+  if [ -d "$dir" ]; then
+    echo "$dir"   # already claimed; another session may be in it
+    return
+  fi
+
+  git -C "$main_root" fetch --quiet origin main
+  mkdir -p "$trees"
+  if git -C "$main_root" show-ref --verify --quiet "refs/heads/$branch"; then
+    git -C "$main_root" worktree add "$dir" "$branch" >&2
+  elif git -C "$main_root" show-ref --verify --quiet "refs/remotes/origin/$branch"; then
+    git -C "$main_root" worktree add --track -b "$branch" "$dir" "origin/$branch" >&2
+  else
+    git -C "$main_root" worktree add -b "$branch" "$dir" origin/main >&2
+  fi
+  echo "$dir"
+}
+
+cmd_list() {
+  git -C "$main_root" worktree list --porcelain | awk '/^worktree /{print $2}' | while read -r dir; do
+    local_branch=$(git -C "$dir" symbolic-ref --quiet --short HEAD 2>/dev/null || echo DETACHED)
+    n=$(basename "$dir")
+    if [ "$dir" = "$main_root" ]; then
+      printf '%-6s %-44s %s\n' '-' "$local_branch" "$dir (primary, read-only)"
+    else
+      state=$(gh issue view "$n" --json state -q .state 2>/dev/null || echo '?')
+      printf '#%-5s %-44s %s\n' "$n" "$local_branch" "$dir [$state]"
+    fi
+  done
+}
+
+cmd_done() {
+  local n=${1:?usage: issue-worktree.sh done <issue>}
+  local dir state
+  dir=$(path_for "$n")
+  [ -d "$dir" ] || die "no worktree for #$n"
+  state=$(gh issue view "$n" --json state -q .state)
+  [ "$state" = CLOSED ] || die "issue #$n is still open — close it through its PR first"
+
+  git -C "$dir" diff --quiet && git -C "$dir" diff --cached --quiet \
+    || die "$dir has uncommitted changes"
+  branch=$(git -C "$dir" symbolic-ref --quiet --short HEAD || true)
+
+  git -C "$main_root" worktree remove "$dir"
+  [ -n "$branch" ] && git -C "$main_root" branch -D "$branch" >/dev/null 2>&1 || true
+  echo "removed $dir"
+}
+
+cmd_prune() {
+  git -C "$main_root" worktree prune
+  [ -d "$trees" ] || return 0
+  for dir in "$trees"/*; do
+    [ -d "$dir" ] || continue
+    n=$(basename "$dir")
+    [ "$(gh issue view "$n" --json state -q .state 2>/dev/null || echo OPEN)" = CLOSED ] || continue
+    cmd_done "$n" || true
+  done
+}
+
+case "${1:-}" in
+  start) shift; cmd_start "$@" ;;
+  list)  shift; cmd_list "$@" ;;
+  done)  shift; cmd_done "$@" ;;
+  prune) shift; cmd_prune "$@" ;;
+  *) sed -n '2,10p' "$0" | sed 's/^# \{0,1\}//' >&2; exit 1 ;;
+esac

--- a/.claude/scripts/issue-worktree.sh
+++ b/.claude/scripts/issue-worktree.sh
@@ -40,6 +40,12 @@ branch_for() {  # an existing branch for this issue wins, so a resumed session l
     | sed 's|^origin/||' | sort -u | grep -E "^[a-z]+/${n}-" | head -1 || true)
   if [ -n "$existing" ]; then echo "$existing"; return; fi
 
+  # A branch named before this convention existed is still that issue's branch, and
+  # the open PR that closes the issue is the only thing that knows which one it is.
+  existing=$(gh pr list --state open --json headRefName,body \
+    -q ".[] | select(.body | test(\"[Cc]loses #${n}\\\\b\")) | .headRefName" | head -1 || true)
+  if [ -n "$existing" ]; then echo "$existing"; return; fi
+
   local title labels
   title=$(gh issue view "$n" --json title -q .title) || die "no issue #$n"
   labels=$(gh issue view "$n" --json labels -q '[.labels[].name] | join(" ")')

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "worktree": {
+    "baseRef": "fresh",
+    "bgIsolation": "worktree"
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel)}/.claude/hooks/worktree-guard.py\"",
+            "timeout": 10,
+            "statusMessage": "Checking the worktree"
+          }
+        ]
+      }
+    ]
+  },
+  "permissions": {
+    "allow": [
+      "Bash(.claude/scripts/issue-worktree.sh:*)",
+      "Bash(gh issue view:*)",
+      "Bash(gh issue list:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr list:*)",
+      "Bash(git worktree list:*)",
+      "Bash(cargo test:*)",
+      "Bash(cargo fmt:*)",
+      "Bash(cargo clippy:*)"
+    ]
+  }
+}

--- a/.claude/skills/technical-scouting/SKILL.md
+++ b/.claude/skills/technical-scouting/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: technical-scouting
+description: Use when researching the outside technical landscape for Paranoid Android — deterministic replay, checkpointing, provenance, storage, agent infrastructure, simulation, testing, robotics, scientific workflows — or when asked what the project should build next. Turns discoveries into intelligence cards and ranked recommendations in research/, with deduplication against what is already known.
+---
+
+# Technical scouting
+
+The methodology behind the `scout` sub-agent. Read this when running a scan yourself,
+when reviewing what the scout produced, or when extending the system.
+
+The scout's purpose in one line:
+
+> Find ideas the Paranoid Android team would otherwise miss, understand them deeply,
+> and turn them into actionable engineering opportunities.
+
+## Ground rules
+
+| Rule | Why |
+| --- | --- |
+| Primary sources only | A summary of a summary is how wrong architecture gets adopted. |
+| Mechanism over claim | "Uses CoW snapshots" is a headline. *How* they handle open file descriptors is a finding. |
+| Volume is a smell | One discovery that changes the architecture beats thirty links. |
+| Write only to `research/` | The scout produces intelligence. Humans decide what becomes code. |
+| Dedup before writing | Same project twice is noise; update the card instead. |
+| Negative findings count | "Five projects gave up on X" is a product opportunity. |
+| Check the code before recommending | Half the obvious ideas are already built. |
+
+## The pipeline
+
+```
+question → broad sweep → candidate set → primary-source read → mechanism extraction
+  → relevance test → dedup → intelligence card → scoring → recommended actions
+  → engineering decision → outcome recorded → constraint for the next run
+```
+
+The last two arrows are what make this a system rather than a search. They live in
+`research/decisions.md` and `research/constraints.md`.
+
+### 1. Frame the question
+
+Three cadences, and they behave differently:
+
+- **Targeted** — "find new techniques for deterministic replay". Narrow sweep, deep
+  reads, expect 1–3 cards.
+- **Periodic scan** — "what changed in agent observability this month?". Wide sweep,
+  shallow reads, expect mostly landscape updates and few cards.
+- **Open** — "what should Paranoid Android build next?". The broadest form: sweep
+  every active category in `research/taxonomy.md`, weight by our current roadmap and
+  open issues, and end with a ranked build recommendation. This is the expensive one;
+  budget for it.
+
+### 2. Sweep
+
+Use `references/sources.md`: the source mix, the vocabulary ladders (how to search
+for our problems in other fields' words), and the query patterns that work per source.
+
+Cast wider than the obvious domain. The connection you are looking for is usually in
+a field that has had the problem for twenty years and does not know we exist.
+
+### 3. Read the primary source
+
+Do not stop at the README. Where it matters:
+
+- the data structure and the invariant it protects
+- the code path for the mechanism you care about (find it, name the file)
+- the limitations / future work / "known issues" section
+- the issue tracker for where it breaks in practice
+- the design discussion where an alternative was rejected
+- what it cites, and who cites it
+- benchmarks, and whether they measure the thing that would matter to us
+
+### 4. Test relevance
+
+Ask, in order:
+
+1. Could this make Paranoid Android better?
+2. How — which subsystem, which file, which invariant?
+3. Should we actually build something because of it?
+
+Anything that fails (1) gets a single line in the scan report and no card.
+
+### 5. Dedup
+
+```bash
+grep -ril "github.com/<org>/<repo>" research/
+grep -ril "arxiv.org/abs/<id>" research/
+grep -ril "<project name>" research/
+```
+
+Existing card → update it, append to its `## Changelog`, bump `updated:`.
+
+### 6. Card
+
+`research/discoveries/YYYY-MM-DD-<slug>.md`, schema in
+`references/intelligence-card.md`. Stable id, never renamed. Superseded cards move to
+`research/archive/` with a pointer, they are not deleted — the reason something was
+dropped is part of the knowledge base.
+
+Adjacent projects get a landscape entry instead or as well:
+`research/landscape/<slug>.md`, taxonomy in `references/landscape.md`.
+
+### 7. Score and rank
+
+`references/prioritisation.md`. Impact × Relevance × Feasibility × Novelty, each on a
+defined scale, with the reasoning shown. The ranking is the deliverable; the cards are
+the evidence for it.
+
+### 8. Report
+
+`research/scans/YYYY-MM-DD-<topic>.md` from `research/templates/scan.md`. Then update
+`research/README.md`.
+
+## Knowledge base layout
+
+```
+research/
+  README.md          index of everything, newest first
+  CONTEXT.md         the architecture the scout reasons against (verify against code)
+  constraints.md     settled decisions — do not re-propose without new evidence
+  taxonomy.md        the evolving category list
+  decisions.md       feedback ledger: recommendation → verdict → outcome → lesson
+  discoveries/       intelligence cards
+  landscape/         adjacent and competing projects
+  proposals/         worked-up build proposals promoted from cards
+  scans/             per-run reports
+  archive/           superseded cards, with the reason
+  templates/         card, scan and landscape templates
+```
+
+It **accumulates**. Nothing is overwritten wholesale, ever.
+
+## Anti-patterns
+
+- A card whose "why it matters" could be pasted onto any project. Be specific to our
+  code or do not write it.
+- A recommendation that says "consider looking into X". Say what to build, where, and
+  what it would prove.
+- A "competitor" framing. The useful question is *what does this do that we should
+  learn from*, not *are they beating us*.
+- Reopening a settled decision because a search result made it sound new.
+- Confidence HIGH on a source you did not open.
+
+## References
+
+- `references/sources.md` — source mix, vocabulary ladders, query patterns
+- `references/intelligence-card.md` — card schema, template, worked example
+- `references/prioritisation.md` — scoring rubric and ranking method
+- `references/landscape.md` — classification taxonomy for adjacent projects
+- `references/negative-space.md` — hunting failed approaches and unserved problems

--- a/.claude/skills/technical-scouting/references/intelligence-card.md
+++ b/.claude/skills/technical-scouting/references/intelligence-card.md
@@ -1,0 +1,144 @@
+# The intelligence card
+
+One card per discovery. A card is a claim with evidence attached and a decision at the
+end. If you cannot fill in "Why it matters to Paranoid Android" with something specific
+to our code, you do not have a card — you have a link.
+
+## File
+
+`research/discoveries/YYYY-MM-DD-<slug>.md`
+
+The date is the date of **first** discovery and never changes; the id is stable and
+gets cited from scans, proposals and `decisions.md`. Slug is lowercase, hyphenated,
+about the *mechanism* rather than the company — `cow-process-snapshots` ages better
+than `acme-labs-launch`.
+
+## Frontmatter
+
+```yaml
+---
+id: 2026-08-19-cow-process-snapshots
+title: <short mechanism-first title>
+discovered: 2026-08-19
+updated: 2026-08-19
+categories: [checkpointing, copy-on-write]
+class: RESEARCH            # see references/landscape.md
+recommendation: PROTOTYPE  # IGNORE | WATCH | INVESTIGATE | PROTOTYPE | ADOPT
+transferability: HIGH      # LOW | MEDIUM | HIGH
+novelty: MISSING           # PRESENT | REFINEMENT | MISSING | DIFFERENT | NEW-DIRECTION
+confidence: MEDIUM         # LOW | MEDIUM | HIGH
+touches: [engine, store]   # core subsystems: model, store, tree, engine, repo, bundle, proto, cli, clients
+---
+```
+
+## Sections
+
+```markdown
+## Discovery
+What it is, in two or three sentences, mechanism first.
+
+## Source
+Primary source link, then what you actually read (file, section, issue number).
+
+## What is interesting
+The technical explanation. The data structure, the invariant, the trick. Enough that a
+reader who never opens the link understands the mechanism and could argue with it.
+
+## Why it matters to Paranoid Android
+The concrete connection. Name the subsystem and, where you can, the file and type.
+Which of these does it bear on: trajectories, checkpoints, branching, replay,
+reconstruction fidelity, environments/adapters, provenance, storage, counterfactual
+exploration, divergence reporting, capture honesty?
+
+## Transferability
+LOW / MEDIUM / HIGH — and *why*. What would have to be true for it to transfer, and
+what part of their design depends on assumptions we do not share.
+
+## Novelty
+One of: already present in Paranoid Android / a refinement of what we have / a missing
+capability / a fundamentally different approach / a potentially new direction.
+Justify it against the code, not against memory.
+
+## Limitations and negative signal
+What they say does not work, what the issue tracker says does not work, what they
+tried and removed. Often the most valuable section.
+
+## Recommendation
+IGNORE | WATCH | INVESTIGATE | PROTOTYPE | ADOPT — one word, then one line of reason.
+
+## Proposed action
+Concrete. "Prototype content-addressed checkpoint storage using the chunking scheme in
+X, behind the existing `Store` interface, measured on the browser example."
+Not "consider looking into snapshotting."
+
+## Confidence
+LOW / MEDIUM / HIGH, with the reason — grading rules in `references/sources.md`.
+
+## Evidence
+- Primary: <link> — what it establishes
+- Supporting: <link> — what it adds
+- Counter-evidence: <link> — anything that argues against the above
+
+## Changelog
+- 2026-08-19 — created.
+```
+
+## Recommendation vocabulary
+
+| Word | Means |
+| --- | --- |
+| IGNORE | Looked at it, it does not bear on us. Recorded so nobody looks again. |
+| WATCH | Not actionable now; re-check on a trigger you must name (a release, a paper, an adoption threshold). |
+| INVESTIGATE | Worth a deeper read or a spike to answer a specific question. Name the question. |
+| PROTOTYPE | Worth building a throwaway to test a specific hypothesis. Name the hypothesis and the measurement. |
+| ADOPT | Strong enough to become a design change. Requires a proposal in `research/proposals/`. |
+
+Most cards are WATCH or IGNORE. A run where everything is PROTOTYPE is a run that did
+not think.
+
+## Novelty vocabulary
+
+| Value | Means |
+| --- | --- |
+| PRESENT | We already do this. Card exists so we stop rediscovering it. Grep the code to prove it. |
+| REFINEMENT | We do something like it; theirs is better in a specific, named way. |
+| MISSING | A capability we do not have and plausibly should. |
+| DIFFERENT | Solves the same problem in a way incompatible with our model. Interesting precisely because it forces a comparison. |
+| NEW-DIRECTION | Opens a problem we had not considered being in. Rare; be sceptical. |
+
+## Worked example (shape only)
+
+```markdown
+---
+id: 2026-08-19-example-chunked-cas
+title: Content-defined chunking for near-duplicate blob storage
+discovered: 2026-08-19
+updated: 2026-08-19
+categories: [content-addressed storage, checkpointing]
+class: INFRASTRUCTURE
+recommendation: WATCH
+transferability: MEDIUM
+novelty: REFINEMENT
+confidence: HIGH
+touches: [store, tree]
+---
+
+## Discovery
+<system> stores backups as variable-sized chunks split by a rolling hash, so a small
+edit inside a large file rewrites one chunk rather than the whole object.
+
+## Why it matters to Paranoid Android
+`tree::snapshot` hashes whole files after every step (`crates/noidroid-core/src/tree.rs`).
+A recorded run that appends to one large log file stores a full copy per step. Chunking
+would bound that at the edit size, behind the existing `Store::put` interface — the
+object model does not change, only what an object *is*.
+
+## Limitations and negative signal
+Chunking costs CPU per snapshot and makes an object's identity no longer equal to the
+file's own hash, which would complicate the "the workspace at step k has address T"
+story we print to users.
+...
+```
+
+Note what the example does: it names our file, it names the invariant at risk, and its
+negative section argues against itself. That is the standard.

--- a/.claude/skills/technical-scouting/references/landscape.md
+++ b/.claude/skills/technical-scouting/references/landscape.md
@@ -1,0 +1,76 @@
+# Landscape classification
+
+Track adjacent projects, but do not frame everything as competition. The useful
+question is almost always:
+
+> What does this project do that Paranoid Android should learn from?
+
+not
+
+> Is this a competitor?
+
+## Classes
+
+| Class | Definition | What to record |
+| --- | --- | --- |
+| `DIRECT COMPETITOR` | Solves the same problem for the same user: return to a point in a past execution and explore alternatives with evidence. Rare. | Their evidence standard. Where they are stricter or looser than us and why. |
+| `ADJACENT TOOL` | Overlapping user, different problem — eval harnesses, tracing UIs, agent debuggers. | The seam where a user would need both. Where their users complain. |
+| `INFRASTRUCTURE` | Something we could build on or steal a mechanism from — stores, sandboxes, proxies, snapshotters. | The interface, the guarantees, the licence, the maintenance signal. |
+| `RESEARCH` | Papers and academic systems. | The mechanism and its evaluation. Whether anything shipped. |
+| `INSPIRATION` | Different domain, transferable idea. | The idea, stripped of its domain. |
+| `POTENTIAL INTEGRATION` | Something a user would plausibly want us to interoperate with. | The integration surface and what it would cost. |
+| `IDEAS WORTH TAKING` | We will not use the project, but a specific design decision is worth copying. | The decision, in one paragraph, and where it would land in our code. |
+| `IRRELEVANT` | Looked, does not bear on us. | One line, so nobody looks twice. |
+
+## Landscape entry
+
+`research/landscape/<slug>.md`
+
+```yaml
+---
+name: <project>
+class: ADJACENT TOOL
+first_seen: 2026-08-19
+updated: 2026-08-19
+url: <primary>
+licence: <spdx or "proprietary">
+activity: active | slowing | dormant | abandoned
+---
+```
+
+Then:
+
+```markdown
+## What it is
+One paragraph, mechanism first.
+
+## How it works
+The architecture, insofar as it is documented or readable. Where the state lives, what
+the unit of capture is, what it guarantees.
+
+## What it does that we should learn from
+The point of the entry. Be specific and be generous — the best entries make us
+uncomfortable.
+
+## Where it is weaker, and why that is interesting
+Not scoring points: their weakness usually marks a design trade-off we also face.
+
+## Overlap with us
+Honest. Which of our claims they also make, and whether they can back them.
+
+## Watch triggers
+What would make this worth re-reading — a release, a rewrite, a paper, a
+deprecation.
+
+## Changelog
+- 2026-08-19 — created.
+```
+
+## Rules
+
+- Update the entry, never duplicate it. Activity and class both change over time; an
+  entry that went `active → abandoned` is a finding in itself.
+- Record the **evidence standard** of anything in the same space. This project's
+  differentiator is that a reconstruction is verified rather than asserted; whether a
+  neighbour verifies anything is the single most informative fact about them.
+- Abandonment is signal. Note the last commit date and, if you can find it, why.

--- a/.claude/skills/technical-scouting/references/negative-space.md
+++ b/.claude/skills/technical-scouting/references/negative-space.md
@@ -1,0 +1,87 @@
+# Negative space
+
+The things that do not work are cheaper to find than the things that do, and they are
+worth more. Most of a scout's unique value is here, because positive findings are
+also findable by anyone reading a newsletter.
+
+## Four kinds of negative finding
+
+**1. The failed approach.** Someone tried the obvious thing and it did not work.
+Record *why*, in mechanism terms. This is how we avoid spending a release rediscovering
+it.
+
+Where to look: `CHANGELOG` entries that remove a feature, "why we moved off X" posts,
+closed PRs with long discussions, `git log` for a deleted module, retrospective talks.
+
+**2. The abandoned project.** Last commit two years ago, issues unanswered. Ask what
+killed it: no users, an unsolvable technical problem, or a maintainer who left. Only
+the middle one is a finding, but it is a big one.
+
+Where to look: last-commit dates, an issue titled "is this project still maintained?",
+a fork that became the real one, a final release note.
+
+**3. The recurring complaint.** The same problem reported across unrelated projects.
+Five independent teams working around the same missing capability is a specification.
+
+Where to look: search the *complaint* rather than the solution —
+`"non-deterministic" flaky replay`, `"we had to" patch monkeypatch intercept`,
+`"there is no way to"`, `"gave up on"`, `"this is impossible"`, `"we ended up doing it
+by hand"`.
+
+**4. The ugly integration.** A tool that only works via `LD_PRELOAD`, a fork of a
+dependency, a regex over a log, a patched vendor SDK. Ugly integrations mark a
+**missing seam**. Where a seam is missing, whoever provides one wins the space.
+
+## How to file it
+
+Negative findings are cards like any other. They live in
+`research/discoveries/` with `categories: [negative-signal, ...]`.
+
+The sections change meaning slightly:
+
+- `## What is interesting` → what was tried and the mechanism by which it failed.
+- `## Why it matters to Paranoid Android` → either "we are about to do this" (a
+  warning) or "nobody has solved this" (an opportunity). Say which.
+- `## Recommendation` → usually IGNORE (recorded so we do not repeat it) or
+  INVESTIGATE (the unserved problem might be ours).
+
+## The unserved-problem card
+
+When several unrelated sources hit the same wall, promote it. Use the same card format
+with `categories: [unserved-problem, ...]` and add:
+
+```markdown
+## Who hits this
+- <project> — <link to the issue/post where they hit it>
+- <project> — <link>
+- <project> — <link>
+
+At least three independent sources, or it is an anecdote.
+
+## Why it is unsolved
+The structural reason, not "nobody got around to it". If the reason is structural, say
+whether our architecture escapes it or shares it.
+
+## Would Paranoid Android's model help?
+Honestly. Sometimes the answer is no, and that is a finding too — it tells us where
+our model's boundary is.
+```
+
+## Guard against motivated reasoning
+
+The failure mode of this section is finding an "unserved problem" that flatters the
+architecture we already have. Two defences:
+
+1. Require the complaints to come from **projects that have nothing to do with us** —
+ if every source is an agent-debugging tool, you have found a crowded market, not a gap.
+2. Write the strongest version of "and this is why it will stay unsolved, including for
+ us" before writing the recommendation. If that paragraph is convincing, the
+ recommendation is WATCH.
+
+## Negative findings about ourselves
+
+The scout is allowed — expected — to bring back evidence that a decision this project
+made is wrong. `docs/direction.md` lists settled decisions and explicitly invites
+reopening them "with something that was not known at the time". That is the bar:
+new evidence, named, dated, with the mechanism spelled out. Meeting it is a valuable
+run. Failing to meet it and arguing anyway is noise.

--- a/.claude/skills/technical-scouting/references/prioritisation.md
+++ b/.claude/skills/technical-scouting/references/prioritisation.md
@@ -1,0 +1,102 @@
+# Prioritisation
+
+Research is the input. **Prioritisation is the product.** A scan that ends without a
+ranked, arguable list of what to do has not finished.
+
+## The score
+
+```
+priority = Impact × Relevance × Feasibility × Novelty
+```
+
+Multiplicative on purpose: a zero anywhere kills it. Something brilliant, highly
+relevant and completely infeasible is a WATCH, not a plan.
+
+Each factor is 0–3. Show the number *and* the sentence that justifies it.
+
+### Impact — if we did this, how much better is the system?
+
+| | |
+| --- | --- |
+| 3 | Changes what the tool can honestly claim. Removes a limitation from the README, or closes a gap in capture honesty. |
+| 2 | Makes an existing capability materially better: faster, more faithful, easier to integrate. |
+| 1 | Nice quality-of-life or ergonomics improvement. |
+| 0 | No user-visible or invariant-level consequence. |
+
+### Relevance — does it bear on what this project actually is?
+
+Weigh against `docs/direction.md` and `research/CONTEXT.md`.
+
+| | |
+| --- | --- |
+| 3 | Directly serves reconstruction fidelity, checkpointing, branching, or honest capture. |
+| 2 | Serves a supporting subsystem: storage, adapters, reporting, CLI. |
+| 1 | Adjacent; would matter to some future version of the project. |
+| 0 | Belongs to something we have said we are not building (dashboard, distributed store, agent framework, universal simulator). |
+
+### Feasibility — can we do it, here, soon?
+
+| | |
+| --- | --- |
+| 3 | Fits behind an existing interface (`Store`, `tree`, the wire protocol) and could be a single PR. |
+| 2 | A contained change to one subsystem plus tests. |
+| 1 | Cross-cutting, or needs a dependency or platform capability we do not have. |
+| 0 | Requires abandoning a settled decision, or an on-disk format break with no migration story (`STEP_VERSION` — see CONTRIBUTING.md). |
+
+### Novelty — is it new *to us*?
+
+| | |
+| --- | --- |
+| 3 | A capability we lack, or a fundamentally different approach we have never evaluated. |
+| 2 | A named improvement on something we already do. |
+| 1 | Confirms an approach we already chose. Worth recording, rarely worth building. |
+| 0 | Already implemented, or already rejected in `research/constraints.md` with no new evidence. |
+
+## Tie-breakers, in order
+
+1. **Does it make a silent failure loud?** This project's stated worst outcome is a
+   trajectory that looks real. Anything converting a silent gap into a stated one wins.
+2. **Does it reduce what we cannot say?** Shrinking the unknown surface beats adding
+   a feature.
+3. **Is it testable as an invariant?** If it can be defended by a named test
+   (`a_replay_never_touches_the_world`), it is worth more than something only
+   observable in a demo.
+4. **Cheapest disproof first.** Prefer the item whose *failure* we would learn from
+   quickest.
+
+## Writing a recommendation
+
+Every entry in `# Recommended Actions` states all five:
+
+```markdown
+### 1. <Imperative sentence — what to build or do>
+
+**Why now:** the trigger. What changed in the world or in our code that makes this
+the moment. "It is interesting" is not a why-now.
+
+**Impact:** 3 — <one line>
+**Relevance:** 3 — <one line>
+**Feasibility:** 2 — <one line>
+**Novelty:** 2 — <one line>
+**Score:** 36
+
+**Cost:** an honest estimate in the units we work in — a spike, a PR, a release.
+Name the risk that would blow it up.
+
+**What we would learn:** the question it answers, phrased so the answer could be
+"no". If a negative result teaches nothing, it is not an experiment.
+
+**Touches:** the subsystems and files. `crates/noidroid-core/src/engine.rs`, the
+wire protocol, the Python client.
+
+**Evidence:** the card ids this rests on.
+```
+
+## The other half: what not to do
+
+Every scan report ends with **Explicitly not recommended**. List the plausible-looking
+things you considered and rejected, with the reason. This is the section that stops the
+same idea being re-proposed in three months, and it is the section that feeds
+`research/constraints.md`.
+
+A ranked list without a rejection list is only half a recommendation.

--- a/.claude/skills/technical-scouting/references/sources.md
+++ b/.claude/skills/technical-scouting/references/sources.md
@@ -1,0 +1,117 @@
+# Sources, vocabulary and query patterns
+
+## The source mix
+
+Use several. A finding that appears in only one kind of source is usually either very
+early or not real.
+
+**Code**
+- GitHub / GitLab / Codeberg: repositories, **issues** (where the truth about
+  limitations lives), discussions, releases, and specific commits when a mechanism
+  changed.
+- Package ecosystems: crates.io, PyPI, npm, Go modules — reverse dependencies show
+  who actually uses a thing.
+- Awesome-lists and curated indexes as *entry points only*, never as evidence.
+
+**Research**
+- arXiv (cs.DC, cs.SE, cs.PL, cs.OS, cs.DB, cs.LG, cs.RO), and the venues that matter
+  here: OSDI, SOSP, NSDI, EuroSys, ATC, PLDI, OOPSLA, ICSE, FSE, ISSTA, VLDB, SIGMOD,
+  CoRL, ICRA, MLSys, TaPP/IPAW (provenance), USENIX FAST (storage).
+- Papers *cited by* a project, and papers that cite it. The citation graph is the
+  cheapest way out of your own vocabulary.
+- Theses and tech reports — often the only place a mechanism is explained fully.
+
+**Engineering writing**
+- Company engineering blogs (databases, game engines, CI/build, observability,
+  simulation, robotics).
+- Architecture decision records and design docs in repositories (`docs/`, `rfcs/`,
+  `adr/`, `design/`).
+- Post-mortems and "why we removed X" posts. High signal.
+- Conference talks: Strange Loop, CppCon, GDC, RustConf, PyCon, Systems Distributed,
+  Papers We Love. Slides and transcripts, not the marketing summary.
+
+**Ecosystem**
+- Hacker News: search a project name and read the *comments by people who used it*.
+- Reddit (r/rust, r/programming, r/robotics, r/MachineLearning, r/devops) where the
+  thread is technical.
+- Mailing lists, Zulip/Discourse archives (Rust, LLVM, Kubernetes, ROS Discourse).
+- Standards bodies: W3C, IETF, OpenTelemetry, CNCF, OCI, RO-Crate / W3C PROV.
+
+**Industry**
+- New tools and infrastructure projects, launch posts *read for their architecture*,
+  and the docs page that describes how it actually works.
+
+## Vocabulary ladders
+
+Our problems have other names. Search the right-hand column.
+
+| We say | The world says |
+| --- | --- |
+| trajectory | trace, execution log, journal, event log, tape, recording, lineage, derivation chain |
+| checkpoint | snapshot, savepoint, restore point, image, CRIU dump, fork point, epoch |
+| deterministic replay | record-and-replay, rr, deterministic execution, reproducible run, hermetic build, deterministic simulation testing (DST), lockstep |
+| branching | fork, what-if, alternate timeline, speculative execution, shadow run, A/B execution |
+| provenance | lineage, taint, data provenance, W3C PROV, RO-Crate, attestation, audit trail, SLSA |
+| content-addressed store | CAS, Merkle DAG, object store, blob store, IPLD, restic/borg chunking, nix store |
+| divergence | drift, mismatch, non-determinism, flakiness, differential testing, bisimulation |
+| counterfactual | ablation, intervention, do-calculus, fault injection, mutation, chaos experiment |
+| capture boundary | interposition, syscall interception, shim, LD_PRELOAD, seccomp filter, ptrace, eBPF uprobe, VFS layer, proxy |
+| environment reconstruction | hermetic environment, sandbox, sysroot, container image, nix derivation, lockfile |
+| unknown/unavailable | partial observability, best-effort, degraded mode, missing data semantics |
+| step | frame, tick, transition, event, span, operation, entry |
+| irreversible effect | side effect, non-idempotent operation, external effect, exactly-once, effect system |
+
+## Adjacent fields worth raiding
+
+Each of these has been solving one of our problems for decades:
+
+- **Databases** — MVCC, snapshot isolation, WAL, copy-on-write B-trees, time-travel
+  queries, logical vs physical replication.
+- **Filesystems / storage** — ZFS and btrfs snapshots, overlayfs, reflinks, dedup and
+  chunking (restic, borg, casync), Merkle trees.
+- **Distributed systems** — deterministic simulation testing (FoundationDB, TigerBeetle,
+  Antithesis), lineage-based recovery (Spark), event sourcing, causal consistency.
+- **Debuggers and emulators** — rr, Pernosco, gdb reverse execution, QEMU record/replay,
+  Bochs, cycle-accurate console emulators and their savestates, TAS tooling.
+- **Build systems** — Bazel/Nix/Guix hermeticity, action caching, remote execution,
+  reproducible builds, content-addressed action graphs.
+- **Game engines and netcode** — rollback netcode (GGPO), deterministic lockstep,
+  replay files, ECS snapshotting, fixed timestep.
+- **Observability** — OpenTelemetry, distributed tracing, continuous profiling, and
+  crucially the places where a trace is *not enough* to reconstruct behaviour.
+- **Testing** — property-based testing and shrinking, fuzzing corpora and coverage,
+  deterministic schedulers, model checking (TLA+, Alloy), mutation testing, chaos
+  engineering, record/replay HTTP (VCR/cassettes, WireMock, mitmproxy).
+- **Robotics** — ROS bags and rosbag2, MCAP, Foxglove, sim-to-real, deterministic
+  simulators (MuJoCo, Isaac), teleop trajectory replay.
+- **Scientific computing** — workflow engines (Nextflow, Snakemake, CWL, WDL),
+  provenance capture (ReproZip, Sciunit, noWorkflow), electronic lab notebooks, lab
+  automation and protocol description languages, experiment tracking (W&B, MLflow,
+  DVC).
+- **RL / agents** — replay buffers, environment seeding, offline RL datasets, world
+  models, gym/gymnasium env determinism, agent eval harnesses and their reproducibility
+  claims.
+- **Virtualisation** — CRIU, gVisor, Firecracker snapshotting, WASM component model,
+  microVM restore, unikernel state.
+
+## Query patterns that work
+
+- Mechanism + domain: `"copy-on-write" snapshot process checkpoint site:github.com`
+- Failure-first: `"we removed" deterministic replay` / `"why we stopped using" record replay`
+- Limitation mining: `record replay "known limitations" async`
+- The graph: read a paper's related-work section; search each named system directly.
+- Issue mining: `is:issue "non-deterministic" replay` inside a specific repo.
+- Version drift: a project's `CHANGELOG` for the release where a mechanism appeared or
+  was removed — that is where the design rationale usually is.
+- Dates: constrain periodic scans to a window, but never constrain a targeted search —
+  the best mechanism for our problem may be from 2005.
+
+## Credibility grading
+
+| Grade | What it takes |
+| --- | --- |
+| HIGH | You read the implementation or the paper's method section; the mechanism is unambiguous; limitations are stated by the authors. |
+| MEDIUM | You read the primary doc but not the code; or the mechanism is described but not evaluated. |
+| LOW | You have a strong secondary source and could not reach the primary one. Say so in the card. |
+
+Never grade HIGH on something you did not open.

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ dist/
 *.swp
 .idea/
 .vscode/
+
+# Claude Code, personal overrides (the shared config is .claude/settings.json)
+.claude/settings.local.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ nobody can read back in six months.
 
 ```bash
 gh issue create                             # the problem, and why it is one
-git switch -c fix/25-egress-fence           # <type>/<issue-number>-<slug>
+.claude/scripts/issue-worktree.sh start 25  # a worktree of its own; cd to what it prints
 cargo test --all                            # browser tests skip without Chromium
 cargo fmt --all && cargo clippy --all-targets -- -D warnings
 git commit                                  # Conventional Commits, see below
@@ -22,15 +22,23 @@ gh pr create                                # body must contain "Closes #25"
                                             # then: review, then merge
 ```
 
-Four rules, and CI enforces the third:
+Four rules, and two of them are enforced for you:
 
 1. **A bug or a feature becomes an issue first.** Including one found by a research
    pass — especially then, because that is the reasoning most easily lost.
-2. **An issue gets its own branch**, named `<type>/<issue-number>-<slug>`.
+2. **An issue gets its own worktree, and its own session.** One issue is worked in
+   `../noidroid-worktrees/<issue>` on `<type>/<issue-number>-<slug>`, and nothing else
+   touches that tree — two sessions sharing one checkout overwrite each other's
+   half-finished edits. The primary checkout is read-only; a `PreToolUse` hook denies
+   edits there. See [.claude/README.md](.claude/README.md).
 3. **A branch becomes a pull request that closes its issue.** The `Issue link` check
    fails a PR whose body has no `Closes #N`. Dependabot is exempt; nothing else is.
 4. **A pull request is reviewed before it merges.** Green CI is not a review — it
    says the code runs, not that it should exist or that it is the right shape.
+
+When the issue closes, retire its worktree: `.claude/scripts/issue-worktree.sh done
+<issue>`, or `prune` for every closed issue at once. A worktree left behind is a stale
+claim on a branch name.
 
 `main` is protected: it takes merges through pull requests, and CI has to be green.
 Nobody pushes to it directly, including maintainers.


### PR DESCRIPTION
Checks in `.claude/`, and makes the isolation rule real rather than aspirational.

- `.claude/CLAUDE.md` — how to talk (short, direct, no verbose unless asked), and the worktree rule.
- `.claude/scripts/issue-worktree.sh` — `start | list | done | prune`, keyed by issue number. Branch name comes from the issue's labels; the tree is branched from a freshly fetched `origin/main`; an existing branch for that issue is reused.
- `.claude/hooks/worktree-guard.py` + `.claude/settings.json` — `PreToolUse` denies `Edit`/`Write`/`NotebookEdit` in the primary checkout and prints what to run instead. Allowed in a linked worktree, outside the repo, or under `NOIDROID_MAIN_EDIT=1`.
- `/issue <n>` and `/issue-done [n]`.
- CONTRIBUTING rule 2 is now about the worktree, not just the branch name.

Verified: the guard denies for a path in the primary checkout, stays silent for a path in this worktree, for a path outside the repo, and under the escape hatch. `start 50` created the worktree this PR was written in.

The guard watches the file tools, not shell redirects — a tripwire, not a sandbox.

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)