### PR TITLE
A shared scratch file made two writers of one object race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ how the package version relates to `STEP_VERSION`, the on-disk object format.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Two writers of the same object raced, and the loser said only `No such file or
+  directory`.** `Store::put` wrote through a scratch file named after the object, so
+  concurrent writers of identical bytes — which is the normal case in a
+  content-addressed store, not the exotic one — shared one scratch path. Whichever
+  renamed first moved the file out from under the other. The scratch name is now
+  unique to the writer. (#44)
+- **The object store and the tree walker never got the context #42 introduced.** A
+  failure reading, writing, listing or pruning now names the operation and the path,
+  so a `NotFound` in CI says which file it could not find. This is what made the macOS
+  failure in #44 unreadable for two runs. (#44)
+
+
 ## [0.3.0] - 2026-08-19
 
 *The laws of the Stand.* This release adds almost no functionality. It makes the

--- a/crates/noidroid-core/src/repo.rs
+++ b/crates/noidroid-core/src/repo.rs
@@ -8,7 +8,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use crate::error::{Error, Result};
+use crate::error::{Doing, Error, Result};
 use crate::hash::Digest;
 use crate::model::{Step, StepNote, Trajectory};
 use crate::store::Store;
@@ -32,7 +32,8 @@ impl Repo {
             "logs",
             "tmp",
         ] {
-            fs::create_dir_all(root.join(sub))?;
+            fs::create_dir_all(root.join(sub))
+                .doing(|| format!("creating {}", root.join(sub).display()))?;
         }
         let store = Store::open(root.join("objects"))?;
         Ok(Repo { root, store })
@@ -72,7 +73,9 @@ impl Repo {
     }
 
     pub fn save_trajectory(&self, t: &Trajectory) -> Result<()> {
-        fs::write(self.trajectory_path(&t.name), serde_json::to_vec_pretty(t)?)?;
+        let path = self.trajectory_path(&t.name);
+        fs::write(&path, serde_json::to_vec_pretty(t)?)
+            .doing(|| format!("writing the trajectory {}", path.display()))?;
         Ok(())
     }
 
@@ -81,7 +84,9 @@ impl Repo {
         if !path.exists() {
             return Err(Error::NotFound(format!("trajectory '{name}'")));
         }
-        Ok(serde_json::from_slice(&fs::read(path)?)?)
+        let bytes =
+            fs::read(&path).doing(|| format!("reading the trajectory {}", path.display()))?;
+        Ok(serde_json::from_slice(&bytes)?)
     }
 
     pub fn has_trajectory(&self, name: &str) -> bool {
@@ -92,7 +97,7 @@ impl Repo {
         let dir = self.root.join("trajectories");
         let mut names: Vec<String> = Vec::new();
         if dir.exists() {
-            for entry in fs::read_dir(&dir)? {
+            for entry in fs::read_dir(&dir).doing(|| format!("listing {}", dir.display()))? {
                 let path = entry?.path();
                 if path.extension().and_then(|s| s.to_str()) == Some("json") {
                     if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
@@ -111,7 +116,9 @@ impl Repo {
     }
 
     pub fn save_notes(&self, name: &str, notes: &[StepNote]) -> Result<()> {
-        fs::write(self.notes_path(name), serde_json::to_vec_pretty(notes)?)?;
+        let path = self.notes_path(name);
+        fs::write(&path, serde_json::to_vec_pretty(notes)?)
+            .doing(|| format!("writing the notes {}", path.display()))?;
         Ok(())
     }
 
@@ -120,7 +127,8 @@ impl Repo {
         if !path.exists() {
             return Ok(Vec::new());
         }
-        Ok(serde_json::from_slice(&fs::read(path)?)?)
+        let bytes = fs::read(&path).doing(|| format!("reading the notes {}", path.display()))?;
+        Ok(serde_json::from_slice(&bytes)?)
     }
 
     /// Materialise a trajectory's steps in execution order by walking parents from

--- a/crates/noidroid-core/src/store.rs
+++ b/crates/noidroid-core/src/store.rs
@@ -8,11 +8,12 @@ use std::collections::BTreeSet;
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
-use crate::error::{Error, Result};
+use crate::error::{Doing, Error, Result};
 use crate::hash::Digest;
 
 pub struct Store {
@@ -22,7 +23,7 @@ pub struct Store {
 impl Store {
     pub fn open(root: impl Into<PathBuf>) -> Result<Store> {
         let root = root.into();
-        fs::create_dir_all(&root)?;
+        fs::create_dir_all(&root).doing(|| format!("creating the store {}", root.display()))?;
         Ok(Store { root })
     }
 
@@ -39,15 +40,37 @@ impl Store {
         if path.exists() {
             return Ok(digest);
         }
-        fs::create_dir_all(path.parent().expect("object path has a parent"))?;
+        fs::create_dir_all(path.parent().expect("object path has a parent"))
+            .doing(|| format!("creating the object directory for {}", digest.short()))?;
         // Write to a temporary name and rename, so a crash can never leave a
         // half-written object sitting at a valid address.
-        let tmp = path.with_extension("tmp");
-        let mut f = fs::File::create(&tmp)?;
-        f.write_all(bytes)?;
-        f.sync_all()?;
+        //
+        // The scratch name has to be unique to the writer, not to the object. An
+        // address *is* its content, so two writers racing on one object is the normal
+        // case rather than the exotic one -- and a shared scratch name turns that into
+        // one writer renaming the file the other is still holding. The loser's rename
+        // then fails with a bare `NotFound` that names neither the object nor the
+        // operation. It still ends in `.tmp`, which is what `verify` skips on.
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+        let tmp = path.with_extension(format!(
+            "{}-{}.tmp",
+            std::process::id(),
+            SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        let mut f = fs::File::create(&tmp)
+            .doing(|| format!("creating the scratch file {}", tmp.display()))?;
+        f.write_all(bytes)
+            .doing(|| format!("writing {} bytes to {}", bytes.len(), tmp.display()))?;
+        f.sync_all()
+            .doing(|| format!("flushing {}", tmp.display()))?;
         drop(f);
-        fs::rename(&tmp, &path)?;
+        fs::rename(&tmp, &path).doing(|| {
+            format!(
+                "moving {} into place as object {}",
+                tmp.display(),
+                digest.short()
+            )
+        })?;
         Ok(digest)
     }
 
@@ -56,7 +79,7 @@ impl Store {
         if !path.exists() {
             return Err(Error::NotFound(format!("object {}", digest.short())));
         }
-        let bytes = fs::read(path)?;
+        let bytes = fs::read(&path).doing(|| format!("reading object {}", path.display()))?;
         let actual = Digest::of(&bytes);
         if &actual != digest {
             return Err(Error::Corrupt {
@@ -106,7 +129,8 @@ impl Store {
                     continue;
                 }
                 let named = Digest::from_hex(format!("{prefix}{rest}"));
-                let bytes = fs::read(&object)?;
+                let bytes =
+                    fs::read(&object).doing(|| format!("reading object {}", object.display()))?;
                 if Digest::of(&bytes) != named {
                     bad.push(named.to_string());
                 }
@@ -124,8 +148,12 @@ impl Store {
 
 fn sorted_dir(path: &Path) -> Result<Vec<PathBuf>> {
     let mut out: BTreeSet<PathBuf> = BTreeSet::new();
-    for entry in fs::read_dir(path)? {
-        out.insert(entry?.path());
+    for entry in fs::read_dir(path).doing(|| format!("listing {}", path.display()))? {
+        out.insert(
+            entry
+                .doing(|| format!("reading an entry of {}", path.display()))?
+                .path(),
+        );
     }
     Ok(out.into_iter().collect())
 }
@@ -155,6 +183,62 @@ mod tests {
         let b = store.put(b"hello").unwrap();
         assert_eq!(a, b);
         assert_eq!(store.object_count().unwrap(), 1);
+        fs::remove_dir_all(dir).ok();
+    }
+
+    /// Two writers storing the same bytes at the same moment is not a race the
+    /// caller can avoid: the address is the content, so identical content is exactly
+    /// what concurrent writers produce. Naming the scratch file after the object made
+    /// them collide — one writer's rename moved the file the other was about to
+    /// rename, and the loser got a bare `NotFound` naming nothing.
+    #[test]
+    fn two_writers_of_the_same_object_do_not_collide() {
+        let dir = tmp();
+        let store = Store::open(dir.join("objects")).unwrap();
+        let payload = vec![b'x'; 64 * 1024];
+
+        for round in 0..64 {
+            let store = &store;
+            let payload = &payload;
+            let bytes: Vec<u8> = payload
+                .iter()
+                .copied()
+                .chain(round.to_string().bytes())
+                .collect();
+            let start = std::sync::Barrier::new(8);
+            std::thread::scope(|s| {
+                for _ in 0..8 {
+                    s.spawn(|| {
+                        start.wait();
+                        store.put(&bytes).expect("a concurrent write must not fail");
+                    });
+                }
+            });
+        }
+
+        assert_eq!(store.object_count().unwrap(), 64);
+        fs::remove_dir_all(dir).ok();
+    }
+
+    /// #42 gave I/O failures a `doing`; the object store was never wired into it, so
+    /// a store failure still surfaced as a bare errno naming nothing. `NotFound` is
+    /// the verdict for a missing object, a missing shard and a scratch file that lost
+    /// a race, and a CI log that prints only the errno costs a day.
+    #[test]
+    fn a_store_failure_says_what_it_was_doing() {
+        let dir = tmp();
+        let blocked = dir.join("not-a-directory");
+        fs::write(&blocked, b"x").unwrap();
+
+        let err = match Store::open(blocked.join("objects")) {
+            Err(e) => e,
+            Ok(_) => panic!("a file is not a store"),
+        };
+        let said = err.to_string();
+        assert!(
+            said.contains("creating the store") && said.contains("objects"),
+            "a store failure must name the operation and the path, said: {said}"
+        );
         fs::remove_dir_all(dir).ok();
     }
 

--- a/crates/noidroid-core/src/tree.rs
+++ b/crates/noidroid-core/src/tree.rs
@@ -10,7 +10,7 @@ use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 
-use crate::error::Result;
+use crate::error::{Doing, Result};
 use crate::hash::Digest;
 use crate::model::{Tree, TreeEntry};
 use crate::store::Store;
@@ -121,12 +121,15 @@ fn collect(
     if !dir.exists() {
         return Ok(());
     }
-    let mut children: Vec<PathBuf> = fs::read_dir(dir)?
+    let mut children: Vec<PathBuf> = fs::read_dir(dir)
+        .doing(|| format!("listing {}", dir.display()))?
         .map(|e| e.map(|e| e.path()))
-        .collect::<std::result::Result<_, _>>()?;
+        .collect::<std::result::Result<_, _>>()
+        .doing(|| format!("reading the entries of {}", dir.display()))?;
     children.sort();
     for path in children {
-        let meta = fs::symlink_metadata(&path)?;
+        let meta =
+            fs::symlink_metadata(&path).doing(|| format!("inspecting {}", path.display()))?;
         if meta.file_type().is_symlink() {
             continue;
         }
@@ -145,7 +148,8 @@ fn collect(
                 .expect("child of root")
                 .to_string_lossy()
                 .replace('\\', "/");
-            let blob = store.put(&fs::read(&path)?)?;
+            let blob =
+                store.put(&fs::read(&path).doing(|| format!("reading {}", path.display()))?)?;
             let executable = meta.permissions().mode() & 0o111 != 0;
             out.push(TreeEntry {
                 path: rel,
@@ -182,7 +186,7 @@ pub fn materialize_with(
     ignores: &Ignores,
 ) -> Result<()> {
     let tree: Tree = store.get_json(digest)?;
-    fs::create_dir_all(dir)?;
+    fs::create_dir_all(dir).doing(|| format!("creating {}", dir.display()))?;
 
     // `ignores` applies to the recorded entries as well as to what is already on
     // disk. A tree can hold paths that are deliberately not files -- `.world/`, which
@@ -200,10 +204,12 @@ pub fn materialize_with(
     for entry in entries {
         let path = dir.join(&entry.path);
         if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent)?;
+            fs::create_dir_all(parent).doing(|| format!("creating {}", parent.display()))?;
         }
-        fs::write(&path, store.get(&entry.blob)?)?;
-        fs::set_permissions(&path, fs::Permissions::from_mode(entry.mode))?;
+        fs::write(&path, store.get(&entry.blob)?)
+            .doing(|| format!("restoring {}", path.display()))?;
+        fs::set_permissions(&path, fs::Permissions::from_mode(entry.mode))
+            .doing(|| format!("setting the mode of {}", path.display()))?;
     }
     Ok(())
 }
@@ -212,8 +218,10 @@ pub fn materialize_with(
 /// in place. Returns whether the directory ended up empty.
 fn prune(dir: &Path, wanted: &BTreeSet<PathBuf>, ignores: &Ignores) -> Result<bool> {
     let mut empty = true;
-    for entry in fs::read_dir(dir)? {
-        let path = entry?.path();
+    for entry in fs::read_dir(dir).doing(|| format!("listing {} to prune it", dir.display()))? {
+        let path = entry
+            .doing(|| format!("reading an entry of {}", dir.display()))?
+            .path();
         if path
             .file_name()
             .and_then(|n| n.to_str())
@@ -223,17 +231,18 @@ fn prune(dir: &Path, wanted: &BTreeSet<PathBuf>, ignores: &Ignores) -> Result<bo
             empty = false;
             continue;
         }
-        let meta = fs::symlink_metadata(&path)?;
+        let meta = fs::symlink_metadata(&path)
+            .doing(|| format!("inspecting {} before pruning it", path.display()))?;
         if meta.is_dir() && !meta.file_type().is_symlink() {
             if prune(&path, wanted, ignores)? {
-                fs::remove_dir(&path)?;
+                fs::remove_dir(&path).doing(|| format!("removing {}", path.display()))?;
             } else {
                 empty = false;
             }
         } else if wanted.contains(&path) {
             empty = false;
         } else {
-            fs::remove_file(&path)?;
+            fs::remove_file(&path).doing(|| format!("removing {}", path.display()))?;
         }
     }
     Ok(empty)

--- a/crates/noidroid-core/tests/watch_slice.rs
+++ b/crates/noidroid-core/tests/watch_slice.rs
@@ -9,6 +9,7 @@
 
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use noidroid_core::engine::{self, Mode, RunSpec};
 use noidroid_core::{tree, Repo};
@@ -35,13 +36,20 @@ struct Project {
 
 impl Project {
     fn new() -> Project {
+        // The counter is the point. `cargo test` runs these two tests in parallel
+        // threads of one process, so pid and clock are shared, and two fixtures that
+        // land on the same tick share a directory -- and therefore a store, and a
+        // `Drop` that deletes it out from under the other. The engine defends its
+        // socket names the same way, for the same reason.
+        static SEQ: AtomicU64 = AtomicU64::new(0);
         let dir = std::env::temp_dir().join(format!(
-            "noidroid-watch-{}-{}",
+            "noidroid-watch-{}-{}-{}",
             std::process::id(),
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap()
-                .as_nanos()
+                .as_nanos(),
+            SEQ.fetch_add(1, Ordering::Relaxed)
         ));
         fs::create_dir_all(dir.join("src")).unwrap();
         // The things a real project is full of and a recording must not carry.


### PR DESCRIPTION
`Store::put` wrote to `<object>.tmp` and renamed. The scratch name came from the object, so every writer of the same bytes used the same path — and identical bytes from concurrent writers is the ordinary case in a content-addressed store. The first rename moved the file the second was about to rename, and the loser returned:

```
Io { doing: "", source: Os { code: 2, kind: NotFound, message: "No such file or directory" } }
```

which is character-for-character what the macOS job printed twice on #28.

`store::tests::two_writers_of_the_same_object_do_not_collide` reproduces it on Linux and fails without the fix. The scratch name now carries the writer's pid and a counter, and still ends in `.tmp` so `verify` keeps skipping it.

**Why it was unreadable.** #42 gave I/O failures a `doing`; `store.rs`, `tree.rs` and `repo.rs` were never wired into it, so every `?` in them discarded the operation and kept the errno. `NotFound` is the verdict for a missing object, a missing shard, a scratch file that lost a race, and a path that is a file where a directory was wanted. They all name themselves now, and `a_store_failure_says_what_it_was_doing` holds the line.

**The fixture.** `watch_slice`'s `Project::new` names its directory from pid and clock with no counter, and `cargo test` runs its two tests in parallel threads of one process. Two fixtures on the same tick share a directory, therefore a store, therefore a `Drop` that removes it under the other. `unique_socket_path` already defends against exactly this and explains why; the fixture now does too.

## What is not proven

That this is what macOS hit. The mechanism produces that error and nothing else in the record path produces a bare `NotFound`, but the collision needs the two fixtures to land on the same clock tick and I have no macOS machine to demonstrate that they do. Both halves are worth having regardless: the race is real on every platform, and if a bare `NotFound` survives this, the next log says what it was doing.

Green locally: `fmt`, `clippy -D warnings`, `cargo test --all` (70 tests; browser tests skip, no Chromium here).

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)