### PR TITLE
feat(engine): name an insertion in the divergence report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ how the package version relates to `STEP_VERSION`, the on-disk object format.
 
 ## [Unreleased]
 
+### Changed
+
+- **A divergence report now names an insertion, not just the fields that differ.** It
+  could already say "this call is recorded at step N, it looks like interactions were
+  removed" and had no symmetric sentence: add a call and the reader got a target and an
+  argument diff and had to work out what moved. When what the run wants appears nowhere
+  in the recording, the report says it looks like an interaction was added there — and
+  says in the next breath that a rewritten interaction looks identical from one
+  mismatch, because it does. Matching is still positional and divergence is still
+  fatal; only the sentence changed. (#34)
+
 ### Fixed
 
 - **Two writers of the same object raced, and the loser said only `No such file or

--- a/crates/noidroid-core/src/engine.rs
+++ b/crates/noidroid-core/src/engine.rs
@@ -1314,6 +1314,22 @@ fn describe_mismatch(
         .any(|(_, step)| actions_agree(&step.action, incoming))
     {
         lines.push("this call already happened earlier in the recording".to_string());
+    } else {
+        // Nothing anywhere in the recording matches what the run wants, so the run is
+        // doing something the recording never did. That is what an inserted
+        // interaction looks like from here — and it is also exactly what a rewritten
+        // one looks like, because positional matching gets one mismatch either way.
+        // Name the likely reading, then say plainly that it is not established.
+        lines.push(
+            "this interaction appears nowhere in the recording; it looks like it was \
+             added here"
+                .to_string(),
+        );
+        lines.push(
+            "a rewritten interaction looks the same from here — one mismatch cannot \
+             tell the two apart"
+                .to_string(),
+        );
     }
 
     if lines.is_empty() {

--- a/crates/noidroid-core/tests/vertical_slice.rs
+++ b/crates/noidroid-core/tests/vertical_slice.rs
@@ -39,6 +39,11 @@ with open("notes.txt", "w", encoding="utf-8") as handle:
 
 nd.call("world.read", lambda: touch("read"), args={"variant": variant})
 
+# An interaction the recording has never seen, at a position the recording already
+# uses for something else.
+if os.environ.get("INSERT"):
+    nd.call("world.insert", lambda: touch("insert"), args={})
+
 # A mediated write, so replaying this step restores the workspace underneath a
 # process that is still running in it.
 nd.call("world.stage", lambda: touch("stage"), args={}, effect="write")
@@ -374,6 +379,40 @@ fn a_changed_program_is_reported_rather_than_papered_over() {
             .any(|d| d.kind == DivergenceKind::KeyMismatch),
         "a different interaction must be reported as a key mismatch, got {:?}",
         report.divergences
+    );
+    assert!(!report.faithful());
+}
+
+#[test]
+fn an_inserted_call_is_reported_as_an_insertion() {
+    let f = Fixture::new("insertion");
+    let recorded = f.record();
+
+    // Same program, one extra mediated call ahead of a recorded one. Positional
+    // matching sees a mismatch at the step the extra call landed on.
+    let report = f.replay(&recorded, &[("INSERT", "1")]);
+
+    let mismatch = report
+        .divergences
+        .iter()
+        .find(|d| d.kind == DivergenceKind::KeyMismatch)
+        .unwrap_or_else(|| {
+            panic!(
+                "an inserted call must be reported, got {:?}",
+                report.divergences
+            )
+        });
+    assert!(
+        mismatch.detail.contains("appears nowhere in the recording")
+            && mismatch.detail.contains("added here"),
+        "the report has to name the insertion, not just the fields that differ, got {}",
+        mismatch.detail
+    );
+    assert!(
+        mismatch.detail.contains("cannot tell the two apart"),
+        "one mismatch cannot distinguish an insertion from a rewrite, and the report \
+         must not pretend otherwise, got {}",
+        mismatch.detail
     );
     assert!(!report.faithful());
 }


### PR DESCRIPTION
Closes #34

`describe_mismatch` scanned forward and could say "this call is recorded at step N; it looks like N interaction(s) were removed". The other direction had no sentence — insert an interaction and the report gave a target diff and an argument diff, leaving the reader to work out what moved.

## What changed

One `else` branch in `describe_mismatch`. When the incoming action matches nothing anywhere in the recording — not later, not earlier — the report now adds:

```
divergence at step 2 (key_mismatch):
      target: recorded "world.stage", got "world.insert"
      effect: recorded write, got read
      this interaction appears nowhere in the recording; it looks like it was added here
      a rewritten interaction looks the same from here — one mismatch cannot tell the two apart
```

The second line is not padding. An insertion and a rewrite produce identical evidence at the moment of divergence: in both cases the run wants something the recording never did, and the recorded step is still outstanding. Distinguishing them needs the run's future, which a fatal divergence does not have. So the report names the likely reading and says in the same breath that it is not established, rather than shipping a guess as a finding.

Matching stays positional, divergence stays fatal, `actions_agree` is untouched. Only the message changed.

## What I verified

- `an_inserted_call_is_reported_as_an_insertion` in `crates/noidroid-core/tests/vertical_slice.rs` — drives the real Python child over the real protocol, records, then replays the same program with one extra mediated call in front of a recorded one. It fails on `main` with the old bare field diff, and it asserts both halves: that the insertion is named, and that the report does not claim more than one mismatch can know.
- `cargo fmt --all`, `cargo clippy --all-targets -- -D warnings`, `cargo test --all` — all green locally (69 tests).
- The test agent gained an `INSERT`-gated call. With the variable unset the program is byte-for-byte what it was, so the other 14 tests in the file record and replay exactly what they did before; they pass unchanged.

## What I did not verify

- Chromium is not installed here, so `browser_slice` skipped rather than ran. It does not touch this path.
- I did not add a test pinning the existing removal message. It is an untested message today and this change is an `else` branch that cannot reach it; widening the coverage there is a separate change.