### PR TITLE
fix(proxy): pass a streamed response through as it arrives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,16 @@ how the package version relates to `STEP_VERSION`, the on-disk object format.
   failure reading, writing, listing or pruning now names the operation and the path,
   so a `NotFound` in CI says which file it could not find. This is what made the macOS
   failure in #44 unreadable for two runs. (#44)
+- **An agent behaved differently under recording than outside it.** The proxy read a
+  whole response before writing a byte back, so a streamed completion arrived as one
+  block at the end instead of as tokens. The bytes were identical and the recording
+  faithful, which is what made it easy to miss: an agent that only times out when
+  recorded is not the agent you set out to record. A `text/event-stream` response is
+  now relayed chunk by chunk while the concatenation is kept for the trajectory.
+  Everything else still buffers, because a JSON body is one value that exists all at
+  once. The engine hears about a call only when it completes, so a passed-through
+  stream is recorded after its last byte has reached the agent — fine for a recording,
+  and to be reconsidered if a replay ever streams. (#45)
 - **The fence blocked calls the engine had authorised.** Egress is now permitted for
   the body of a call the engine answered `execute` to — and nowhere else, on the
   thread that call runs on. A plain replay authorises nothing, so the window never

--- a/README.md
+++ b/README.md
@@ -451,8 +451,9 @@ so a replay matches on what was sent rather than on a lossy summary of it.
 
 It captures the provider traffic and nothing else: files the agent writes, commands it
 runs and other services it calls are invisible to it. Pair it with `--watch` to record
-the files too. A streamed response is buffered rather than passed through — the content
-is identical, the timing is not.
+the files too. A server-sent event stream is passed through as it arrives, so an agent
+under recording sees its tokens on the same schedule as one that is not; everything
+else is still read in full before it is written back.
 
 ### What neither can do
 

--- a/clients/python/noidroid/proxy.py
+++ b/clients/python/noidroid/proxy.py
@@ -24,10 +24,15 @@ response. **What it does not**: anything the agent does that is not that request
 files it writes, commands it runs, other services it calls. Those are invisible here,
 and a replay will not reproduce them.
 
-**A streamed response is buffered.** The whole thing is read before a single byte goes
-back, so the agent gets a complete answer rather than an incremental one. The content
-is identical and the recording is faithful; what changes is the timing, which for a
-long generation can be the difference between a progress bar and a client timeout.
+**A server-sent event stream is passed through as it arrives**, chunk by chunk, while
+the concatenation is kept for the trajectory. An agent under recording therefore sees
+its tokens on the same schedule as one that is not being recorded — which matters,
+because an agent that times out only when recorded is not the agent you meant to
+record. Everything else is still read in full before it is written back.
+
+The engine hears about a call only once it completes, so a passed-through stream is
+recorded after its last byte has already reached the agent. That is fine for a
+recording; it would have to be reconsidered if a replay ever streamed.
 
 No TLS interception. The agent is pointed at a plain local address and the proxy makes
 the upstream call itself, so nothing has to trust a forged certificate.
@@ -60,10 +65,25 @@ SKIP_REQUEST_HEADERS = {"host", "connection", "proxy-connection", "keep-alive",
 SKIP_RESPONSE_HEADERS = {"connection", "keep-alive", "transfer-encoding", "upgrade",
                          "content-encoding", "content-length"}
 
+#: How much to ask upstream for at a time; it returns whatever has arrived.
+CHUNK = 64 * 1024
+
 
 def _target(path: str) -> str:
     """Name a call after its endpoint, so a timeline reads as something recognisable."""
     return "http" + path.split("?", 1)[0].replace("/", ".").rstrip(".")
+
+
+def _is_stream(headers: dict) -> bool:
+    """Is this the one content type where arrival time is part of the behaviour?
+
+    Only server-sent events. A JSON body is one value that exists all at once, and
+    handing it over in pieces buys the agent nothing.
+    """
+    for key, value in headers.items():
+        if key.lower() == "content-type":
+            return value.split(";", 1)[0].strip().lower() == "text/event-stream"
+    return False
 
 
 class _Handler(BaseHTTPRequestHandler):
@@ -93,6 +113,11 @@ class _Handler(BaseHTTPRequestHandler):
         except ValueError:
             body = {"__raw__": raw.decode("utf-8", "replace")}
 
+        # Set by perform() when the response has already gone back to the agent a
+        # chunk at a time. Only a recording gets there: a reconstruction serves the
+        # body from the trajectory, so perform() is never called.
+        passed_through = []
+
         def perform():
             request = urllib.request.Request(
                 self.upstream.rstrip("/") + self.path,
@@ -102,9 +127,13 @@ class _Handler(BaseHTTPRequestHandler):
             )
             try:
                 with urllib.request.urlopen(request) as response:
-                    payload = response.read()
                     status = response.status
                     got = dict(response.headers)
+                    if _is_stream(got):
+                        payload = self._pass_through(status, got, response)
+                        passed_through.append(True)
+                    else:
+                        payload = response.read()
             except urllib.error.HTTPError as failure:
                 # A provider error is part of what happened, not a reason to stop.
                 payload = failure.read()
@@ -127,6 +156,9 @@ class _Handler(BaseHTTPRequestHandler):
                 effect=READ,
             )
 
+        if passed_through:
+            return  # the agent already has every byte of it
+
         payload = (recorded.get("body") or "").encode("utf-8")
         self.send_response(int(recorded.get("status", 200)))
         for key, value in (recorded.get("headers") or {}).items():
@@ -135,6 +167,34 @@ class _Handler(BaseHTTPRequestHandler):
         self.send_header("Content-Length", str(len(payload)))
         self.end_headers()
         self.wfile.write(payload)
+
+    def _pass_through(self, status: int, headers: dict, response) -> bytes:
+        """Relay a stream while it is still running, and return all of what went by.
+
+        Chunked, because the length of a generation is not known until it ends, and
+        the whole point is to not wait for that. Flushed after every write: a chunk
+        sitting in our buffer is the same delay we are removing.
+        """
+        self.send_response(status)
+        for key, value in headers.items():
+            if key.lower() not in SKIP_RESPONSE_HEADERS:
+                self.send_header(key, value)
+        self.send_header("Transfer-Encoding", "chunked")
+        self.end_headers()
+
+        seen = []
+        while True:
+            # read1, so a chunk goes out when it arrives rather than when enough of
+            # them have arrived to fill a buffer.
+            chunk = response.read1(CHUNK)
+            if not chunk:
+                break
+            seen.append(chunk)
+            self.wfile.write(b"%X\r\n" % len(chunk) + chunk + b"\r\n")
+            self.wfile.flush()
+        self.wfile.write(b"0\r\n\r\n")
+        self.wfile.flush()
+        return b"".join(seen)
 
     # Anthropic and OpenAI between them use more than two verbs — files and batches
     # are deleted, assistants are patched. An unhandled method would 501 here, which

--- a/crates/noidroid-core/tests/proxy_slice.rs
+++ b/crates/noidroid-core/tests/proxy_slice.rs
@@ -20,6 +20,7 @@ use noidroid_core::engine::{self, Mode, RunSpec};
 use noidroid_core::Repo;
 
 const PORT: u16 = 8791;
+const STREAM_PORT: u16 = 8792;
 
 const PROVIDER: &str = r#"
 import json, sys
@@ -41,6 +42,81 @@ class Handler(BaseHTTPRequestHandler):
         self.wfile.write(body)
 
 ThreadingHTTPServer(("127.0.0.1", int(sys.argv[1])), Handler).serve_forever()
+"#;
+
+/// Emits a message stream the way a provider does: an event, a pause, another event.
+/// The pauses are the point — a proxy that buffers collapses them all to the end.
+const STREAMING_PROVIDER: &str = r#"
+import json, sys, time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+DELTAS = ["one ", "two ", "three ", "four ", "five ", "six"]
+GAP = 0.25
+
+def events():
+    yield "message_start", {"type": "message_start", "message": {
+        "id": "msg_local", "type": "message", "role": "assistant",
+        "model": "claude-opus-5", "content": [], "stop_reason": None,
+        "stop_sequence": None, "usage": {"input_tokens": 11, "output_tokens": 0}}}
+    yield "content_block_start", {"type": "content_block_start", "index": 0,
+        "content_block": {"type": "text", "text": ""}}
+    for piece in DELTAS:
+        yield "content_block_delta", {"type": "content_block_delta", "index": 0,
+            "delta": {"type": "text_delta", "text": piece}}
+    yield "content_block_stop", {"type": "content_block_stop", "index": 0}
+    yield "message_delta", {"type": "message_delta",
+        "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+        "usage": {"output_tokens": 6}}
+    yield "message_stop", {"type": "message_stop"}
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+    def log_message(self, *a): pass
+    def do_POST(self):
+        self.rfile.read(int(self.headers.get("Content-Length") or 0))
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.send_header("Transfer-Encoding", "chunked")
+        self.end_headers()
+        for name, payload in events():
+            frame = ("event: %s\ndata: %s\n\n" % (name, json.dumps(payload))).encode()
+            self.wfile.write(b"%X\r\n" % len(frame) + frame + b"\r\n")
+            self.wfile.flush()
+            if name == "content_block_delta":
+                time.sleep(GAP)
+        self.wfile.write(b"0\r\n\r\n")
+        self.wfile.flush()
+
+ThreadingHTTPServer(("127.0.0.1", int(sys.argv[1])), Handler).serve_forever()
+"#;
+
+/// Writes down *when* each token turned up, not just what it was. Same as the other
+/// agent otherwise: no noidroid import, no base_url.
+///
+/// The timings go outside the workspace on purpose. They are different on every run,
+/// so recording them into the sandbox would make the replay diverge on the clock —
+/// a true report about the wrong thing.
+const STREAMING_AGENT: &str = r#"
+import os, time
+import anthropic
+
+client = anthropic.Anthropic(api_key="not-a-real-key")
+start = time.monotonic()
+arrivals, text = [], []
+with client.messages.stream(
+    model="claude-opus-5",
+    max_tokens=64,
+    messages=[{"role": "user", "content": "count to six"}],
+) as stream:
+    for piece in stream.text_stream:
+        arrivals.append(time.monotonic() - start)
+        text.append(piece)
+
+with open("answer.txt", "w", encoding="utf-8") as handle:
+    handle.write("".join(text))
+with open(os.environ["ARRIVALS_PATH"], "w", encoding="utf-8") as handle:
+    handle.write(" ".join("%.3f" % a for a in arrivals))
 "#;
 
 /// No noidroid import, and no base_url — it comes from the environment.
@@ -72,21 +148,24 @@ fn client_path() -> PathBuf {
         .expect("the python client is part of the repository")
 }
 
-struct Provider(Child);
+struct Provider {
+    child: Child,
+    port: u16,
+}
 
 impl Provider {
-    fn start(script: &Path) -> Provider {
+    fn start(script: &Path, port: u16) -> Provider {
         let mut child = Command::new("python3")
             .arg(script)
-            .arg(PORT.to_string())
+            .arg(port.to_string())
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .spawn()
             .expect("the stand-in provider should start");
         let deadline = Instant::now() + Duration::from_secs(10);
         while Instant::now() < deadline {
-            if TcpStream::connect(("127.0.0.1", PORT)).is_ok() {
-                return Provider(child);
+            if TcpStream::connect(("127.0.0.1", port)).is_ok() {
+                return Provider { child, port };
             }
             std::thread::sleep(Duration::from_millis(50));
         }
@@ -96,11 +175,12 @@ impl Provider {
     }
 
     fn stop(mut self) {
-        let _ = self.0.kill();
-        let _ = self.0.wait();
+        let port = self.port;
+        let _ = self.child.kill();
+        let _ = self.child.wait();
         let deadline = Instant::now() + Duration::from_secs(5);
         while Instant::now() < deadline {
-            if TcpStream::connect(("127.0.0.1", PORT)).is_err() {
+            if TcpStream::connect(("127.0.0.1", port)).is_err() {
                 return;
             }
             std::thread::sleep(Duration::from_millis(50));
@@ -111,9 +191,22 @@ impl Provider {
 
 impl Drop for Provider {
     fn drop(&mut self) {
-        let _ = self.0.kill();
-        let _ = self.0.wait();
+        let _ = self.child.kill();
+        let _ = self.child.wait();
     }
+}
+
+fn scratch(label: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "noidroid-{label}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    fs::create_dir_all(&dir).unwrap();
+    dir
 }
 
 #[test]
@@ -123,15 +216,7 @@ fn an_agent_that_knows_nothing_about_us_records_and_replays() {
         return;
     }
 
-    let dir = std::env::temp_dir().join(format!(
-        "noidroid-proxy-{}-{}",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
-    fs::create_dir_all(&dir).unwrap();
+    let dir = scratch("proxy");
     let provider_script = dir.join("provider.py");
     fs::write(&provider_script, PROVIDER).unwrap();
     let agent = dir.join("agent.py");
@@ -162,7 +247,7 @@ fn an_agent_that_knows_nothing_about_us_records_and_replays() {
         watch: None,
     };
 
-    let provider = Provider::start(&provider_script);
+    let provider = Provider::start(&provider_script, PORT);
     let recorded = engine::run(&repo, &spec(Some("proxied")), Mode::Record, None)
         .expect("recording through the proxy should work")
         .trajectory
@@ -191,6 +276,125 @@ fn an_agent_that_knows_nothing_about_us_records_and_replays() {
     let report = engine::run(
         &repo,
         &spec(None),
+        Mode::Replay { live: Vec::new() },
+        Some(&recorded),
+    )
+    .expect("replay should run to completion");
+    assert!(report.faithful(), "{:?}", report.divergences);
+    assert_eq!(
+        report.delivery.get("executed").copied().unwrap_or(0),
+        0,
+        "nothing may be executed during a replay; the provider is not even running"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// The offset, in seconds from the request, at which each token reached the agent.
+fn arrivals(path: &Path) -> Vec<f64> {
+    fs::read_to_string(path)
+        .expect("the streaming agent should have written its arrival times")
+        .split_whitespace()
+        .map(|value| value.parse::<f64>().expect("an arrival offset in seconds"))
+        .collect()
+}
+
+/// The recording must not change how the agent experiences the response.
+///
+/// The provider takes 1.5s to emit six tokens. An agent talking to it directly sees
+/// them spread over that time; an agent behind a proxy that reads the whole body
+/// first sees all six at once at the end, which for a long generation is the
+/// difference between a progress bar and a client timeout. Same bytes either way —
+/// so the thing under test is arrival time, and nothing else would catch this.
+#[test]
+fn a_streamed_response_reaches_the_client_before_it_ends() {
+    if !sdk_available() {
+        eprintln!("SKIP: proxy test needs the anthropic SDK (pip install anthropic)");
+        return;
+    }
+
+    let dir = scratch("proxy-stream");
+    let provider_script = dir.join("provider.py");
+    fs::write(&provider_script, STREAMING_PROVIDER).unwrap();
+    let agent = dir.join("agent.py");
+    fs::write(&agent, STREAMING_AGENT).unwrap();
+    assert!(
+        !STREAMING_AGENT.contains("noidroid") && !STREAMING_AGENT.contains("base_url"),
+        "the agent must know nothing about us, or this proves nothing"
+    );
+
+    let repo = Repo::open(&dir).unwrap();
+    let spec = |name: Option<&str>, timings: &Path| RunSpec {
+        command: vec![
+            "python3".into(),
+            "-m".into(),
+            "noidroid.proxy".into(),
+            "--upstream".into(),
+            format!("http://127.0.0.1:{STREAM_PORT}"),
+            "--".into(),
+            "python3".into(),
+            agent.display().to_string(),
+        ],
+        launch_dir: dir.clone(),
+        name: name.map(str::to_string),
+        env: vec![
+            ("PYTHONPATH".into(), client_path().display().to_string()),
+            ("ARRIVALS_PATH".into(), timings.display().to_string()),
+        ],
+        auto: false,
+        watch: None,
+    };
+    let while_recording = dir.join("recorded-arrivals.txt");
+
+    let provider = Provider::start(&provider_script, STREAM_PORT);
+    let recorded = engine::run(
+        &repo,
+        &spec(Some("streamed"), &while_recording),
+        Mode::Record,
+        None,
+    )
+    .expect("recording a streamed response should work")
+    .trajectory
+    .expect("a recording produces a trajectory");
+
+    assert_eq!(
+        fs::read_to_string(repo.workspace_dir("streamed").join("answer.txt")).unwrap(),
+        "one two three four five six",
+        "every token should reach the agent"
+    );
+    let offsets = arrivals(&while_recording);
+    let spread = offsets.last().unwrap() - offsets.first().unwrap();
+    assert!(
+        spread > 0.5,
+        "the six tokens took the provider 1.5s to emit but reached the agent within \
+         {spread:.3}s of each other, so the proxy read the whole response before \
+         writing any of it back: {offsets:?}"
+    );
+
+    // And the trajectory still holds all of it, not just the piece that was in hand
+    // when the first byte went out.
+    let chain = repo.chain(&recorded).unwrap();
+    let effect = chain
+        .iter()
+        .find(|(_, s)| s.action.summary().contains("http.v1.messages"))
+        .and_then(|(_, s)| s.effects.first())
+        .expect("the streamed call should be in the trajectory");
+    let value: serde_json::Value = repo.store.get_json(&effect.value).unwrap();
+    let body = value["body"].as_str().expect("a recorded response body");
+    for marker in ["message_start", "message_stop", "one ", "six"] {
+        assert!(
+            body.contains(marker),
+            "the whole stream should have been recorded, but {marker:?} is missing \
+             from {body:?}"
+        );
+    }
+
+    // Take the provider away: whatever the replay serves came out of the recording.
+    provider.stop();
+
+    let report = engine::run(
+        &repo,
+        &spec(None, &dir.join("replayed-arrivals.txt")),
         Mode::Replay { live: Vec::new() },
         Some(&recorded),
     )


### PR DESCRIPTION
Closes #45

`clients/python/noidroid/proxy.py` read the whole upstream response before writing a byte back. The recording was faithful either way — same bytes, same status, same headers — but the agent behaved differently for being recorded: a streamed completion arrived as one block at the end instead of as tokens. For a long generation that is the difference between a progress bar and a client timeout, and an agent that only times out when recorded is not the agent you set out to record.

A `text/event-stream` response is now relayed chunk by chunk (`response.read1`, chunked transfer encoding, flushed after every write) while the concatenation is kept and handed to `session.call`, so the trajectory is unchanged and only the timing is repaired. Everything else still buffers, per the issue.

The ordering constraint the issue names holds and is written down in the module docstring and the changelog: the engine hears about a call only once it completes, so a passed-through stream is recorded after its last byte has already reached the agent. Fine for a recording; to be reconsidered if a replay ever streams.

## The test

`a_streamed_response_reaches_the_client_before_it_ends` in `crates/noidroid-core/tests/proxy_slice.rs`. A stand-in provider emits six `content_block_delta` events 250ms apart over real SSE; a real `anthropic` client behind the real proxy records the offset at which each token reached it. The assertion is on arrival time, because arrival time is the only thing that differs — the bytes are identical in both worlds.

It also checks the recorded body still holds the whole stream (`message_start` through `message_stop`), then shuts the provider down and replays: faithful, `executed == 0`.

The timings are written outside the workspace on purpose. They differ every run, so recording them into the sandbox would make the replay diverge on the clock.

## Verified

- Red without the fix: `the six tokens took the provider 1.5s to emit but reached the agent within 0.001s of each other`. Green with it, spread ~1.0s.
- `cargo fmt --all`, `cargo clippy --all-targets -- -D warnings`, `cargo test --all` — all clean, browser tests included (Chromium was present in this environment).
- By hand, outside the test: same agent against the same provider directly and through the proxy, arrival offsets within ~30ms of each other.

## Not verified

- Only against a stand-in provider on loopback, never against `api.anthropic.com`.
- OpenAI SSE was not exercised. The check is on `Content-Type: text/event-stream`, which both use, but nothing here proves it.
- Client disconnect mid-stream: the write raises, the call is recorded as an error, and the agent sees a truncated stream. That is what actually happened, so it is the honest outcome, but there is no test for it.

## Found on the way, not fixed here

#56 — the proxy strips `Content-Encoding` while forwarding the body verbatim, so a gzipped upstream response reaches the agent as garbage and lands in the trajectory as replacement characters. Pre-existing on `main`, untouched by this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)