### PR TITLE
feat(branch): prove the named failures, and stop promising one that never existed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ how the package version relates to `STEP_VERSION`, the on-disk object format.
 
 ## [Unreleased]
 
+### Added
+
+- **The ways a world fails, named.** `noidroid branch --inject <kind>` writes the
+  intervention for you: `timeout`, `server-error`, `rate-limited`, `unauthorized`,
+  `malformed`, `empty`. Writing the payload by hand is the difference between a thing
+  people do and a thing people mean to. The first four raise where a client would
+  raise, and an agent with a `try` around the call survives them; `malformed` and
+  `empty` raise nothing at all, which is the case worth branching. An agent that does
+  not validate a tool result cannot tell a broken answer from a true one — the flight
+  example reports seventeen characters of unterminated JSON as seventeen flights, out
+  loud, before anything goes wrong. The presets themselves shipped inside 0.3.0
+  unannounced and with no test; they now have both. (#35)
+
 ### Changed
 
 - **A divergence report now names an insertion, not just the fields that differ.** It
@@ -20,6 +33,11 @@ how the package version relates to `STEP_VERSION`, the on-disk object format.
 
 ### Fixed
 
+- **`--inject all` was in the help and never in the binary.** It promised to branch
+  every failure in turn and refused the moment anyone tried it. The help now names
+  only what works, and a test through the real binary keeps it that way — a tool whose
+  own `--help` overstates it is the same failure as a trajectory that looks real,
+  scaled down. (#35)
 - **Two writers of the same object raced, and the loser said only `No such file or
   directory`.** `Store::put` wrote through a scratch file named after the object, so
   concurrent writers of identical bytes — which is the normal case in a

--- a/README.md
+++ b/README.md
@@ -151,6 +151,34 @@ $ noidroid diff run-1 alt-fl203
   workspace        + booking.json
 ```
 
+### Naming the ways it fails
+
+`--decide` and `--result` ask what the world could have said instead. `--inject <kind>`
+asks what happens when it goes wrong, and writes the payload for you: `timeout`,
+`server-error`, `rate-limited`, `unauthorized`, `malformed`, `empty`.
+
+```console
+$ noidroid branch run-1@1 --inject malformed
+
+│ found 17 flights under 800
+
+branched run-1~malformed-1 from run-1@1
+  intervention replace-result "{\"unterminated\": "
+  failure      malformed the answer was not the shape it should be
+  prefix       1 step(s) shared with run-1 — identical objects, stored once
+
+    0 ● genesis                                  real      replayed   a7df183d1f
+    1 ◆ call flights.search({"max_price":800})   simulated intervened eb3d4642f5
+```
+
+`malformed` and `empty` are why this exists. A timeout or a 429 raises where a client
+would raise, and any agent with a `try` around the call already handles them. These two
+raise nothing at all: the call returns, and an agent that does not validate its tool
+results carries the answer straight into what it does next. Above, seventeen characters
+of broken JSON were reported as seventeen flights, out loud and with confidence, before
+anything went wrong. As with every intervention the value is `simulated`, so nothing
+downstream of it may claim otherwise.
+
 ---
 
 ## The same thing in a real browser
@@ -397,7 +425,7 @@ noidroid diff run-1 alt-1
 | `noidroid log [<traj>]` | list trajectories, or show one as a timeline |
 | `noidroid show <traj>@<step>` | inspect a checkpoint and how to explore from it |
 | `noidroid replay <traj>` | re-derive a trajectory and check it still hashes the same |
-| `noidroid branch <traj>@<step>` | diverge: `--decide`, `--result` or `--fail` |
+| `noidroid branch <traj>@<step>` | diverge: `--decide`, `--result`, `--fail` or `--inject` |
 | `noidroid checkout <traj>@<step> <dir>` | write out the workspace as it was |
 | `noidroid run --proxy -- <cmd>` | record an agent you did not write, in any language |
 | `noidroid bisect <traj>` | find which decision, changed, would have flipped the outcome |

--- a/crates/noidroid-cli/src/main.rs
+++ b/crates/noidroid-cli/src/main.rs
@@ -103,8 +103,9 @@ enum Command {
         /// Make the interaction fail: `--fail 'message'`.
         #[arg(long, value_name = "MESSAGE")]
         fail: Option<String>,
-        /// A named way the world fails: timeout, server-error, rate-limited,
-        /// malformed, empty, unauthorized. `--inject all` branches each in turn.
+        /// A named way the world fails, with the payload written for you: timeout,
+        /// server-error (500), rate-limited (429), unauthorized (401), malformed,
+        /// empty. The last two raise nothing, which is what makes them interesting.
         #[arg(long, value_name = "KIND")]
         inject: Option<String>,
         /// Stated-simulated value for an irreversible effect past the divergence
@@ -692,14 +693,10 @@ fn cmd_branch(
     inject: Option<String>,
     simulate: Vec<String>,
 ) -> Result<ExitCode> {
-    let (name, index) = repo::parse_ref(reference);
-    let at = index.ok_or_else(|| {
-        Error::Refused("a branch needs a checkpoint: <trajectory>@<step>".to_string())
-    })?;
-    let parent = repo.load_trajectory(&name)?;
-
     // A named failure is just an intervention with the payload written for you —
     // which is the difference between a thing people do and a thing people mean to.
+    // Checked before anything is loaded: a name that does not exist is refused on its
+    // own terms, not behind whatever the rest of the command line turns out to mean.
     let injected = match &inject {
         Some(kind) => Some(Failure::parse(kind).ok_or_else(|| {
             Error::Refused(format!(
@@ -718,6 +715,12 @@ fn cmd_branch(
             "give exactly one of --decide, --result, --fail, --inject".into(),
         ));
     }
+
+    let (name, index) = repo::parse_ref(reference);
+    let at = index.ok_or_else(|| {
+        Error::Refused("a branch needs a checkpoint: <trajectory>@<step>".to_string())
+    })?;
+    let parent = repo.load_trajectory(&name)?;
 
     let intervention = match (decide, result, fail) {
         (Some(spec), None, None) => {

--- a/crates/noidroid-cli/tests/inject.rs
+++ b/crates/noidroid-cli/tests/inject.rs
@@ -1,0 +1,114 @@
+//! `noidroid branch --inject`, through the real binary.
+//!
+//! Branching could always replace a result or raise an error. Naming the ways a world
+//! fails is what turns that from a thing people mean to do into a thing they do, and
+//! the names only help if every one of them works and the help promises no others.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use noidroid_core::model::Failure;
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("the workspace root is two levels up")
+}
+
+fn workdir(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "noidroid-inject-{tag}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn noidroid(dir: &Path, args: &[&str]) -> (String, bool) {
+    let root = repo_root();
+    let output = Command::new(env!("CARGO_BIN_EXE_noidroid"))
+        .args(args)
+        .current_dir(dir)
+        .env("PYTHONPATH", root.join("clients/python"))
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("the binary should run");
+    let mut text = String::from_utf8_lossy(&output.stdout).to_string();
+    text.push_str(&String::from_utf8_lossy(&output.stderr));
+    (text, output.status.success())
+}
+
+#[test]
+fn every_named_failure_branches_and_says_it_was_simulated() {
+    let dir = workdir("named");
+    let agent = repo_root().join("examples/reference/agent.py");
+    let (recorded, ok) = noidroid(
+        &dir,
+        &[
+            "run",
+            "--name",
+            "shift",
+            "--",
+            "python3",
+            agent.to_str().unwrap(),
+        ],
+    );
+    assert!(ok, "recording failed: {recorded}");
+
+    for failure in Failure::ALL {
+        let label = failure.label();
+        let (out, ok) = noidroid(&dir, &["branch", "shift@1", "--inject", label]);
+        assert!(ok, "--inject {label} failed: {out}");
+        assert!(
+            out.contains(label) && out.contains(failure.describes()),
+            "--inject {label} must name the failure it stood in for: {out}"
+        );
+        // An injected value never happened, and the branch has to say so on the step
+        // that carries it. This is the same rule as every other intervention; a
+        // preset that quietly claimed `real` would be the worst version of it.
+        assert!(
+            out.contains("simulated"),
+            "--inject {label} must mark the value simulated: {out}"
+        );
+    }
+}
+
+/// The help is a promise. `--inject all` sat in it for a whole release without ever
+/// being in the binary, so the names it lists have to be exactly the names that work.
+#[test]
+fn the_help_lists_the_failures_and_promises_no_others() {
+    let dir = workdir("help");
+    let (help, ok) = noidroid(&dir, &["branch", "--help"]);
+    assert!(ok, "branch --help failed: {help}");
+
+    for failure in Failure::ALL {
+        assert!(
+            help.contains(failure.label()),
+            "the help must name {}: {help}",
+            failure.label()
+        );
+    }
+    assert!(
+        !help.contains("--inject all"),
+        "the help offered a sweep the binary refuses: {help}"
+    );
+}
+
+#[test]
+fn an_unnamed_failure_is_refused_with_the_names_that_exist() {
+    let dir = workdir("unknown");
+    let (out, ok) = noidroid(&dir, &["branch", "shift@1", "--inject", "meltdown"]);
+    assert!(!ok, "an unknown failure must be refused: {out}");
+    for failure in Failure::ALL {
+        assert!(
+            out.contains(failure.label()),
+            "the refusal must list {}: {out}",
+            failure.label()
+        );
+    }
+}

--- a/crates/noidroid-core/tests/vertical_slice.rs
+++ b/crates/noidroid-core/tests/vertical_slice.rs
@@ -9,7 +9,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use noidroid_core::engine::{self, DivergenceKind, Mode, Report, RunSpec};
-use noidroid_core::model::{Action, Intervention, Provenance, Trajectory};
+use noidroid_core::model::{Action, Failure, Intervention, Provenance, Trajectory};
 use noidroid_core::Repo;
 
 /// A program that interacts with the world, writes a file nobody mediates, makes a
@@ -67,6 +67,20 @@ else:
     nd.finish("success", {"chose": choice})
 "#;
 
+/// A program that does not check what came back.
+///
+/// Not a straw man — this is the ordinary agent. It asks the world something and uses
+/// the answer, which is exactly what the two interesting failures are aimed at:
+/// `malformed` and `empty` raise nothing, so the only thing between a bad answer and
+/// the verdict is validation this program does not do.
+const CREDULOUS: &str = r#"
+import noidroid
+
+nd = noidroid.connect()
+answer = nd.call("world.read", lambda: {"temp": 41}, args={})
+nd.finish("read", {"got": answer, "python_type": type(answer).__name__})
+"#;
+
 struct Fixture {
     dir: PathBuf,
     repo: Repo,
@@ -76,6 +90,10 @@ struct Fixture {
 
 impl Fixture {
     fn new(tag: &str) -> Fixture {
+        Fixture::with_agent(tag, AGENT)
+    }
+
+    fn with_agent(tag: &str, source: &str) -> Fixture {
         let dir = std::env::temp_dir().join(format!(
             "noidroid-it-{tag}-{}-{}",
             std::process::id(),
@@ -86,7 +104,7 @@ impl Fixture {
         ));
         fs::create_dir_all(&dir).unwrap();
         let agent = dir.join("agent.py");
-        fs::write(&agent, AGENT).unwrap();
+        fs::write(&agent, source).unwrap();
         let witness = dir.join("witness.log");
         let repo = Repo::open(&dir).unwrap();
         Fixture {
@@ -723,4 +741,140 @@ fn a_live_replay_reruns_only_what_it_was_asked_to() {
 
     // The recording it came from is untouched.
     assert_eq!(f.repo.load_trajectory("run-1").unwrap(), recorded);
+}
+
+// -- named failures -------------------------------------------------------------
+//
+// Branching could always replace a result or raise an error; the operator had to
+// write the payload. Naming the ways a world fails is what turns that into something
+// people actually reach for. Two of the six are the reason the feature exists:
+// `malformed` and `empty` raise nothing at all.
+
+/// Branch the credulous program at its one call, injecting a named failure.
+fn inject(f: &Fixture, parent: &Trajectory, failure: Failure) -> Trajectory {
+    engine::run(
+        &f.repo,
+        &f.spec(Some(&format!("alt-{}", failure.label())), &[]),
+        Mode::Branch {
+            at: 1,
+            intervention: failure.as_intervention(),
+            simulate: BTreeMap::new(),
+        },
+        Some(parent),
+    )
+    .expect("the branch itself runs to completion")
+    .trajectory
+    .expect("the checkpoint is reachable, so the branch is a trajectory")
+}
+
+#[test]
+fn an_injected_malformed_result_is_handed_to_the_agent_unvalidated() {
+    let f = Fixture::with_agent("malformed", CREDULOUS);
+    let parent = f.record();
+    assert_eq!(
+        parent.outcome.result["got"],
+        serde_json::json!({"temp": 41})
+    );
+
+    let branch = inject(&f, &parent, Failure::Malformed);
+
+    // Nothing threw, so the program reached its own verdict on an answer that is not
+    // the shape its recording says it should be. That is the finding: an agent that
+    // does not validate a tool result cannot tell this from ground truth.
+    assert_eq!(
+        branch.outcome.status, "read",
+        "malformed raises nothing, so the program must run on to its own finish"
+    );
+    assert_eq!(
+        branch.outcome.result["python_type"],
+        serde_json::json!("str"),
+        "the agent was handed a string where its recording had an object"
+    );
+    assert_eq!(
+        branch.outcome.result["got"],
+        serde_json::json!("{\"unterminated\": "),
+        "the payload arrives verbatim — unparsed, unchecked, and believed"
+    );
+
+    // And it stays simulated, because it never happened.
+    let chain = f.repo.chain(&branch).unwrap();
+    assert_eq!(chain[1].1.provenance, Provenance::Simulated);
+    assert_eq!(
+        chain.last().unwrap().1.provenance,
+        Provenance::Simulated,
+        "a verdict reached on an injected answer is not evidence about anything"
+    );
+}
+
+#[test]
+fn an_injected_empty_result_is_a_value_and_not_an_error() {
+    let f = Fixture::with_agent("empty", CREDULOUS);
+    let parent = f.record();
+
+    let branch = inject(&f, &parent, Failure::Empty);
+
+    // Well formed and says nothing. The client hands back `None` and the program
+    // carries it into the verdict, which is the whole point of naming this one.
+    assert_eq!(
+        branch.outcome.status, "read",
+        "empty raises nothing, so the program must run on to its own finish"
+    );
+    assert_eq!(
+        branch.outcome.result["python_type"],
+        serde_json::json!("NoneType")
+    );
+    assert_eq!(branch.outcome.result["got"], serde_json::Value::Null);
+    assert_eq!(
+        f.repo.chain(&branch).unwrap().last().unwrap().1.provenance,
+        Provenance::Simulated
+    );
+}
+
+#[test]
+fn no_named_failure_may_claim_to_have_really_happened() {
+    let f = Fixture::with_agent("named", CREDULOUS);
+    let parent = f.record();
+    assert_eq!(parent.outcome.status, "read");
+
+    for failure in Failure::ALL {
+        let label = failure.label();
+        let branch = inject(&f, &parent, failure);
+        let chain = f.repo.chain(&branch).unwrap();
+
+        assert_eq!(
+            chain[0].1.provenance,
+            Provenance::Real,
+            "{label}: the prefix really happened"
+        );
+        assert_eq!(
+            chain[1].1.effects[0].provenance,
+            Provenance::Simulated,
+            "{label}: the injected value is simulated"
+        );
+        assert_eq!(
+            chain[1].1.intervention.as_ref(),
+            Some(&failure.as_intervention()),
+            "{label}: the step records what was done to it"
+        );
+        assert_eq!(
+            chain.last().unwrap().1.provenance,
+            Provenance::Simulated,
+            "{label}: nothing downstream of an injection may improve"
+        );
+
+        // The two families are told apart by whether the program survives them. Four
+        // of these are raised at the call site; `malformed` and `empty` come back
+        // looking like answers, and the program finishes on them.
+        if matches!(failure.as_intervention(), Intervention::Fail { .. }) {
+            assert_ne!(
+                branch.outcome.status, "read",
+                "{label}: a raised failure must stop the program short of its verdict"
+            );
+        } else {
+            assert_eq!(
+                branch.outcome.status, "read",
+                "{label}: nothing throws, so the program reaches its own verdict"
+            );
+        }
+    }
 }


### PR DESCRIPTION
Closes #35

## What was actually there

The `--inject` presets already exist on `main`. They were swept into 69d6519
(`fix(auto): refuse to record around a hole…`) and shipped inside 0.3.0 with no test,
no changelog entry, and a help string offering `--inject all` — which the binary has
always refused with `unknown failure 'all'`. So this PR is the half of #35 that never
landed: the evidence and the honesty, not the mechanism.

## What changed

- **Three slice tests** in `crates/noidroid-core/tests/vertical_slice.rs`, driving a
  real Python child over the real protocol, against a new `CREDULOUS` fixture agent
  that uses what comes back without checking it:
  - `an_injected_malformed_result_is_handed_to_the_agent_unvalidated` — nothing throws,
    the program runs on to its own `finish`, and it finishes on a `str` where its
    recording had an object, verbatim and unparsed.
  - `an_injected_empty_result_is_a_value_and_not_an_error` — the same for `None`.
  - `no_named_failure_may_claim_to_have_really_happened` — over all six kinds: the
    prefix stays `real`, the injected effect and everything downstream are `simulated`,
    the step records the intervention, and the four raising kinds stop the program
    short of its verdict while the two silent ones do not.
- **Three CLI tests** in `crates/noidroid-cli/tests/inject.rs`, through the real binary:
  every kind branches and says `simulated`; the help names all six and no longer offers
  `--inject all`; an unknown kind is refused with the list of ones that exist.
- **The help text** no longer promises the sweep. It now says which kinds raise and
  which do not, because that distinction is the whole point of the flag.
- **The unknown-kind refusal moved above the trajectory load**, so a typo is refused on
  its own terms rather than behind `not found: trajectory 'shift'`.
- **README** gains a short `--inject` section, and **CHANGELOG** gains an Added entry
  for the presets and a Fixed entry for the help.

No change to the engine, the protocol or `STEP_VERSION`.

## Verified

- `cargo fmt --all`, `cargo clippy --all-targets -- -D warnings`, `cargo test --all` —
  all clean. 78 tests, including the browser slice, which ran rather than skipped here.
- **The new tests bite.** Mutating `Failure::Malformed` to raise instead of return
  fails the malformed test (`"aborted"` vs `"read"`); giving `Empty` a real payload
  fails the empty test (`"dict"` vs `"NoneType"`); marking the injected effect
  `Provenance::Real` in `engine.rs` fails the all-kinds test. Restoring the old help
  string fails the CLI help test.
- By hand against `examples/flight_agent`: `--inject malformed` makes the agent print
  `found 17 flights under 800` — seventeen characters of unterminated JSON, reported
  out loud as seventeen flights — before it falls over. That is the README example, and
  it is real output, not written by hand.

## Not done

- **`--inject all`.** Removed from the help rather than implemented; a sweep is a
  different feature from a preset. Filed as #59, with the argument for making it look
  like `bisect` rather than a flag.
- **A branch whose program aborted says nothing about it.** `noidroid branch --inject
  malformed` prints a timeline that just stops; `noidroid log` says `aborted` and the
  branch command does not, and the child's stderr is dropped entirely. It affects every
  intervention, not just the presets, so it is #58 rather than a second commit here.
- I did not test on macOS or without a browser present; CI covers both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)