### PR TITLE
feat(cli): per-branch cost accounting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,17 @@ how the package version relates to `STEP_VERSION`, the on-disk object format.
   example reports seventeen characters of unterminated JSON as seventeen flights, out
   loud, before anything goes wrong. The presets themselves shipped inside 0.3.0
   unannounced and with no test; they now have both. (#35)
+- **`noidroid cost` — what a trajectory bought, and what it did not.** Every recorded
+  model call already carried the provider's own token counts, and nothing added them
+  up, so the tool's most legible property was invisible: a branch whose model call
+  sits in the shared prefix executes nothing and therefore buys nothing. Tokens are
+  read back out of the recorded response and split by the step's delivery, which is
+  the recorded fact about whether a provider was reached. Money is not: there is no
+  built-in price list, `--price 'MODEL=IN/OUT'` is the only source of one, and without
+  it the output says which model it could not price rather than printing a figure it
+  made up. `$0.00` is the exception, because zero tokens cost nothing at every price
+  there is. An imported bundle carries content but not per-run notes, so it cannot say
+  how its calls were delivered — and says so instead of totalling to zero. (#36)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -328,6 +328,43 @@ step and calling it the cause.
 
 ---
 
+## What the exploring cost
+
+"They cost nothing" is a claim, so it is one the tool has to be able to show.
+
+```console
+$ noidroid cost --price 'fake-model-1=3/15'
+COST
+run-1              180 in / 24 out spent    $0.0009
+alt-1              0 in / 0 out spent       $0.00      — served from the recording
+```
+
+Token counts come out of the responses the recording already holds — they are read
+back, not estimated. Whether a token was *bought* is the step's delivery, which is
+recorded too: a branch whose model call sits in the shared prefix executes nothing,
+so it buys nothing.
+
+A price is not a recorded fact, and there is no built-in price list. Ask for one
+trajectory and, unless you supply the price, you get tokens and a reason:
+
+```console
+$ noidroid cost run-1
+COST run-1
+  model calls            1 executed
+  tokens spent           180 in / 24 out
+
+  cost: 180 in / 24 out spent. Money is not reported: no price was supplied for fake-model-1.
+        a price this tool invented would read exactly like one it measured
+        noidroid cost run-1 --price 'fake-model-1=<in>/<out>'   (US dollars per million tokens)
+```
+
+`$0.00` is the one figure that needs no price, because zero tokens cost nothing at
+every price there is. An imported bundle carries content but not per-run notes, so it
+cannot say how its calls were delivered — and it says that, rather than totalling to
+zero.
+
+---
+
 ## Rewinding the files, not the conversation
 
 The most-requested thing on coding-agent trackers is not undoing the chat — it is
@@ -429,6 +466,7 @@ noidroid diff run-1 alt-1
 | `noidroid checkout <traj>@<step> <dir>` | write out the workspace as it was |
 | `noidroid run --proxy -- <cmd>` | record an agent you did not write, in any language |
 | `noidroid bisect <traj>` | find which decision, changed, would have flipped the outcome |
+| `noidroid cost [<traj>]` | add up what the model calls used, and what was bought |
 | `noidroid restore <traj>@<step>` | put the files back as they were, keeping a way out |
 | `noidroid export` · `import` | move a trajectory between machines, as one committable file |
 | `noidroid tree` · `diff` · `verify` | the branch graph, a comparison, a store integrity check |

--- a/crates/noidroid-cli/src/main.rs
+++ b/crates/noidroid-cli/src/main.rs
@@ -10,6 +10,7 @@ use serde_json::Value;
 
 use noidroid_core::bundle;
 use noidroid_core::checkpoint;
+use noidroid_core::cost;
 use noidroid_core::engine::{self, Mode, Report, RunSpec};
 use noidroid_core::model::{Action, Failure, Intervention, Provenance, Step, Trajectory};
 use noidroid_core::repo::{self, Repo};
@@ -161,6 +162,17 @@ enum Command {
         #[arg(long = "as", value_name = "NAME")]
         rename: Option<String>,
     },
+    /// Add up what a trajectory's model calls used, and what that cost.
+    Cost {
+        /// Trajectory name. Omit to account for every one, side by side.
+        trajectory: Option<String>,
+        /// What a model charges, in US dollars per million tokens:
+        /// `--price 'claude-sonnet-4-5=3/15'`. Without one you get tokens and no
+        /// money: token counts are recorded facts, a price is not, and this does not
+        /// guess at yours.
+        #[arg(long, value_name = "MODEL=IN/OUT")]
+        price: Vec<String>,
+    },
     /// Show the branch graph.
     Tree,
     /// Compare two trajectories.
@@ -275,6 +287,7 @@ fn dispatch(cli: Cli) -> Result<ExitCode> {
         } => cmd_bisect(&repo, &cwd, &trajectory, goal, first, simulate),
         Command::Export { trajectory, output } => cmd_export(&repo, &trajectory, output),
         Command::Import { file, rename } => cmd_import(&repo, &file, rename.as_deref()),
+        Command::Cost { trajectory, price } => cmd_cost(&repo, trajectory, price),
         Command::Tree => cmd_tree(&repo),
         Command::Diff { a, b } => cmd_diff(&repo, &a, &b),
         Command::Verify => cmd_verify(&repo),
@@ -841,10 +854,11 @@ fn cmd_branch(
         );
     }
     println!(
-        "\n  {}\n    noidroid diff {} {}",
+        "\n  {}\n    noidroid diff {} {}\n    noidroid cost   {}",
         dim("compare:"),
         name,
-        branch.name
+        branch.name,
+        dim("— what each of them bought")
     );
     Ok(ExitCode::SUCCESS)
 }
@@ -1203,6 +1217,314 @@ fn human_size(bytes: usize) -> String {
     } else {
         format!("{size:.1} {}", UNITS[unit])
     }
+}
+
+/// Add up the model calls a trajectory recorded, and say what they cost.
+///
+/// Token counts come out of the responses the recording already holds, so they are
+/// facts. Whether a token was *bought* is the step's delivery, which is also a fact.
+/// The price is neither: it comes from the caller or the output says so and prints no
+/// money. The one exception is zero — no tokens costs nothing at every price there is,
+/// which is exactly what makes a replayed branch worth a sentence.
+fn cmd_cost(repo: &Repo, trajectory: Option<String>, price: Vec<String>) -> Result<ExitCode> {
+    let prices = parse_prices(&price)?;
+    match trajectory {
+        Some(name) => {
+            let t = repo.load_trajectory(&name)?;
+            print_ledger(&cost::account(repo, &t)?, &prices);
+        }
+        None => {
+            let all = repo.list_trajectories()?;
+            if all.is_empty() {
+                println!(
+                    "{}",
+                    dim("no trajectories yet — try: noidroid run -- <command>")
+                );
+                return Ok(ExitCode::SUCCESS);
+            }
+            println!("{}", shell("COST"));
+            let mut unpriced: Vec<String> = Vec::new();
+            for t in &all {
+                let ledger = cost::account(repo, t)?;
+                unpriced.extend(
+                    missing_prices(&ledger, &prices)
+                        .into_iter()
+                        .map(str::to_string),
+                );
+                print_ledger_line(t, &ledger, &prices);
+            }
+            unpriced.sort();
+            unpriced.dedup();
+            if !unpriced.is_empty() {
+                println!(
+                    "\n  {} {}",
+                    dim("tokens, not money — no price was supplied for"),
+                    unpriced.join(", ")
+                );
+                println!(
+                    "  {}",
+                    dim(&format!(
+                        "noidroid cost --price '{}=<in>/<out>'   (US dollars per million tokens)",
+                        unpriced[0]
+                    ))
+                );
+            }
+        }
+    }
+    Ok(ExitCode::SUCCESS)
+}
+
+fn parse_prices(specs: &[String]) -> Result<BTreeMap<String, cost::Price>> {
+    let mut out = BTreeMap::new();
+    for spec in specs {
+        let (model, rate) = split_kv(spec)?;
+        let price = cost::Price::parse(&rate).ok_or_else(|| {
+            Error::Refused(format!(
+                "--price '{spec}': a price is two non-negative numbers, \
+                 input/output in US dollars per million tokens, as in '{model}=3/15'"
+            ))
+        })?;
+        out.insert(model, price);
+    }
+    Ok(out)
+}
+
+fn print_ledger(ledger: &cost::Ledger, prices: &BTreeMap<String, cost::Price>) {
+    println!("{} {}", shell("COST"), bold(&ledger.trajectory));
+    if ledger.is_empty() {
+        println!(
+            "  {}",
+            dim("no model call here reported what it used; there is nothing to add up")
+        );
+        return;
+    }
+
+    let calls: Vec<String> = ledger
+        .by_delivery()
+        .iter()
+        .map(|(label, tally)| format!("{} {}", tally.calls, delivery_phrase(label)))
+        .collect();
+    if !calls.is_empty() {
+        println!("  {:<22} {}", dim("model calls"), calls.join(", "));
+    }
+
+    let spent = ledger.spent();
+    let kept = ledger.not_spent();
+    let unknown = ledger.undeliverable();
+    if unknown.usage.is_zero() {
+        println!("  {:<22} {}", dim("tokens spent"), usage_text(&spent.usage));
+    } else {
+        // Delivery is what says whether a token was bought. Without it, "0 spent" is
+        // a claim we cannot make, so the line says so instead of totalling to zero.
+        println!("  {:<22} {}", dim("tokens spent"), warn("cannot be said"));
+        println!(
+            "  {:<22} {}",
+            dim("tokens used"),
+            usage_text(&unknown.usage)
+        );
+    }
+    if !kept.usage.is_zero() {
+        println!(
+            "  {:<22} {} {}",
+            dim("tokens not spent"),
+            usage_text(&kept.usage),
+            dim("(used, but never bought)")
+        );
+    }
+    if !spent.usage.extra.is_empty() {
+        println!(
+            "  {:<22} {} {}",
+            dim("also spent"),
+            counters(&spent.usage.extra),
+            dim("(the provider's own counters, billed at their own rates)")
+        );
+    }
+    // One line per model per delivery, once there is more than one model to tell apart.
+    if ledger.models().len() > 1 {
+        for entry in &ledger.entries {
+            println!(
+                "  {:<22} {} {}",
+                dim(&entry.model),
+                usage_text(&entry.tally.usage),
+                dim(delivery_phrase(entry.delivery))
+            );
+        }
+    }
+    if ledger.calls_without_usage > 0 {
+        println!(
+            "  {:<22} {}",
+            dim("unaccounted"),
+            warn(&format!(
+                "{} model call(s) whose recorded response says nothing about what it used",
+                ledger.calls_without_usage
+            ))
+        );
+    }
+
+    println!();
+    print_verdict(ledger, prices);
+}
+
+/// The sentence. Either a figure that can be traced to something, or the reason there
+/// is no figure — never a number this tool made up.
+fn print_verdict(ledger: &cost::Ledger, prices: &BTreeMap<String, cost::Price>) {
+    let spent = ledger.spent();
+    let unknown = ledger.undeliverable();
+    if !unknown.usage.is_zero() {
+        println!(
+            "  {} {} were used, and nothing here records how they were delivered.",
+            warn("cost:"),
+            usage_text(&unknown.usage)
+        );
+        println!(
+            "        {}",
+            dim(
+                "a bundle carries content, not per-run notes, so whether these were \
+                 bought cannot be answered from here"
+            )
+        );
+        return;
+    }
+    if spent.usage.is_zero() {
+        println!(
+            "  {} {} — every model call was {}, so nothing was bought.",
+            ok("cost:"),
+            bold("$0.00"),
+            free_phrase(ledger)
+        );
+        return;
+    }
+
+    let missing = missing_prices(ledger, prices);
+    if missing.is_empty() {
+        println!(
+            "  {} {} {}",
+            ok("cost:"),
+            bold(&cost::dollars(priced_total(ledger, prices))),
+            dim(&format!(
+                "— {}, at the price you supplied",
+                usage_text(&spent.usage)
+            ))
+        );
+        if !spent.usage.extra.is_empty() {
+            println!(
+                "        {}",
+                warn(
+                    "the figure covers input and output only; nobody supplied a rate \
+                     for the other counters above"
+                )
+            );
+        }
+        return;
+    }
+    println!(
+        "  {} {} spent. Money is not reported: no price was supplied for {}.",
+        warn("cost:"),
+        usage_text(&spent.usage),
+        missing.join(", ")
+    );
+    println!(
+        "        {}",
+        dim("a price this tool invented would read exactly like one it measured")
+    );
+    println!(
+        "        {}",
+        dim(&format!(
+            "noidroid cost {} --price '{}=<in>/<out>'   (US dollars per million tokens)",
+            ledger.trajectory, missing[0]
+        ))
+    );
+}
+
+fn print_ledger_line(
+    t: &Trajectory,
+    ledger: &cost::Ledger,
+    prices: &BTreeMap<String, cost::Price>,
+) {
+    if ledger.is_empty() {
+        println!("{:<18} {}", bold(&t.name), dim("no model calls"));
+        return;
+    }
+    let spent = ledger.spent();
+    let money = if !ledger.undeliverable().usage.is_zero() {
+        warn("?")
+    } else if spent.usage.is_zero() {
+        ok("$0.00")
+    } else if missing_prices(ledger, prices).is_empty() {
+        bold(&cost::dollars(priced_total(ledger, prices)))
+    } else {
+        dim("—")
+    };
+    let note = if spent.usage.is_zero() {
+        format!("— {}", free_phrase(ledger))
+    } else {
+        String::new()
+    };
+    println!(
+        "{}",
+        format!(
+            "{:<18} {:<24} {:<10} {}",
+            bold(&t.name),
+            format!("{} spent", usage_text(&spent.usage)),
+            money,
+            dim(&note)
+        )
+        .trim_end()
+    );
+}
+
+/// The bill for what was bought, at the prices the caller supplied. Only ever called
+/// once every model that was bought from has one.
+fn priced_total(ledger: &cost::Ledger, prices: &BTreeMap<String, cost::Price>) -> f64 {
+    ledger
+        .spent_by_model()
+        .iter()
+        .filter_map(|(model, usage)| prices.get(*model).map(|price| price.of(usage)))
+        .sum()
+}
+
+/// Models this trajectory really bought tokens from and nobody priced.
+fn missing_prices<'a>(
+    ledger: &'a cost::Ledger,
+    prices: &BTreeMap<String, cost::Price>,
+) -> Vec<&'a str> {
+    ledger
+        .spent_by_model()
+        .into_iter()
+        .filter(|(model, _)| !prices.contains_key(*model))
+        .map(|(model, _)| model)
+        .collect()
+}
+
+/// How a trajectory that bought nothing got its tokens instead.
+fn free_phrase(ledger: &cost::Ledger) -> String {
+    let deliveries = ledger.by_delivery();
+    match deliveries.as_slice() {
+        [(label, _)] => delivery_phrase(label).to_string(),
+        _ => "delivered without executing".to_string(),
+    }
+}
+
+fn delivery_phrase(label: &str) -> &'static str {
+    match label {
+        "executed" => "executed",
+        "replayed" => "served from the recording",
+        "intervened" => "supplied by an intervention",
+        "denied" => "denied",
+        _ => "delivered in a way nothing wrote down",
+    }
+}
+
+fn usage_text(usage: &cost::Usage) -> String {
+    format!("{} in / {} out", usage.input, usage.output)
+}
+
+fn counters(extra: &BTreeMap<String, u64>) -> String {
+    extra
+        .iter()
+        .map(|(name, count)| format!("{count} {name}"))
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 fn cmd_tree(repo: &Repo) -> Result<ExitCode> {

--- a/crates/noidroid-cli/tests/cost.rs
+++ b/crates/noidroid-cli/tests/cost.rs
@@ -1,0 +1,160 @@
+//! `noidroid cost`, through the real binary.
+//!
+//! A trajectory already carries every model response it received, token counts and
+//! all. Adding them up is what makes the shape of the tool legible in one line: the
+//! branch you just explored bought nothing, because every model call in its prefix
+//! came off the tape.
+//!
+//! The other half of the claim is what is *not* printed. Token counts are recorded
+//! facts; a price is not one, and nothing here knows what a provider charges. A
+//! dollar figure appears only when the caller supplied the price, or when the tokens
+//! bought were zero — which costs nothing at every price there is.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("the workspace root is two levels up")
+}
+
+fn workdir(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "noidroid-cost-{tag}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn noidroid(dir: &Path, args: &[&str]) -> (String, bool) {
+    let root = repo_root();
+    let output = Command::new(env!("CARGO_BIN_EXE_noidroid"))
+        .args(args)
+        .current_dir(dir)
+        .env("PYTHONPATH", root.join("clients/python"))
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("the binary should run");
+    let mut text = String::from_utf8_lossy(&output.stdout).to_string();
+    text.push_str(&String::from_utf8_lossy(&output.stderr));
+    (text, output.status.success())
+}
+
+/// Record the example agent, then explore the model's tool choice. The model call
+/// sits in the shared prefix, so the branch never makes one.
+fn recorded_and_branched(tag: &str) -> PathBuf {
+    let dir = workdir(tag);
+    let agent = repo_root().join("examples/llm_agent/agent.py");
+    let (out, ok) = noidroid(&dir, &["run", "--", "python3", agent.to_str().unwrap()]);
+    assert!(ok, "recording failed: {out}");
+    let (out, ok) = noidroid(
+        &dir,
+        &[
+            "branch",
+            "run-1@2",
+            "--decide",
+            "tool_choice_1=lookup_charges",
+        ],
+    );
+    assert!(ok, "branching failed: {out}");
+    dir
+}
+
+#[test]
+fn a_replayed_branch_costs_nothing_and_says_so() {
+    let dir = recorded_and_branched("replayed");
+
+    // The recording really called the model, so it really bought those tokens.
+    let (live, ok) = noidroid(&dir, &["cost", "run-1"]);
+    assert!(ok, "{live}");
+    assert!(
+        live.contains("180 in / 24 out"),
+        "the recorded call's own token count should be totalled: {live}"
+    );
+    assert!(
+        live.contains("1 executed"),
+        "the recording executed its model call: {live}"
+    );
+
+    // The branch shares that step. Nothing was bought, and the reason is named.
+    let (branch, ok) = noidroid(&dir, &["cost", "alt-1"]);
+    assert!(ok, "{branch}");
+    assert!(
+        branch.contains("$0.00"),
+        "zero tokens cost zero at every price, so this figure is safe to print: {branch}"
+    );
+    assert!(
+        branch.contains("served from the recording"),
+        "the reason it cost nothing has to be in the sentence: {branch}"
+    );
+    assert!(
+        branch.contains("0 in / 0 out"),
+        "the branch bought no tokens: {branch}"
+    );
+    assert!(
+        branch.contains("180 in / 24 out"),
+        "the tokens it used are still reported, they were just not paid for: {branch}"
+    );
+
+    // And the two are legible side by side, which is the whole point.
+    let (both, ok) = noidroid(&dir, &["cost"]);
+    assert!(ok, "{both}");
+    assert!(
+        both.contains("run-1") && both.contains("alt-1"),
+        "listing should account for every trajectory: {both}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn a_dollar_figure_never_appears_without_a_price_somebody_supplied() {
+    let dir = recorded_and_branched("price");
+
+    let (unpriced, ok) = noidroid(&dir, &["cost", "run-1"]);
+    assert!(ok, "{unpriced}");
+    assert!(
+        !unpriced.contains('$'),
+        "nothing knows what fake-model-1 charges, so no money may be printed: {unpriced}"
+    );
+    assert!(
+        unpriced.contains("fake-model-1"),
+        "the model whose price is missing has to be named: {unpriced}"
+    );
+    assert!(
+        unpriced.contains("--price"),
+        "and the way to supply it: {unpriced}"
+    );
+
+    // Supplied by the caller, in dollars per million tokens: 180 in at 3, 24 out at 15.
+    let (priced, ok) = noidroid(&dir, &["cost", "run-1", "--price", "fake-model-1=3/15"]);
+    assert!(ok, "{priced}");
+    assert!(
+        priced.contains("$0.0009"),
+        "180 in at $3/M plus 24 out at $15/M is $0.0009: {priced}"
+    );
+
+    // A price for a model this trajectory never called buys nothing.
+    let (wrong, ok) = noidroid(&dir, &["cost", "run-1", "--price", "some-other-model=3/15"]);
+    assert!(ok, "{wrong}");
+    assert!(
+        !wrong.contains('$'),
+        "a price for a different model is not a price for this one: {wrong}"
+    );
+
+    // A malformed price is refused rather than quietly ignored.
+    let (bad, ok) = noidroid(&dir, &["cost", "run-1", "--price", "fake-model-1=free"]);
+    assert!(
+        !ok,
+        "a price that is not two numbers should be refused: {bad}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/crates/noidroid-core/src/cost.rs
+++ b/crates/noidroid-core/src/cost.rs
@@ -1,0 +1,460 @@
+//! What a trajectory bought.
+//!
+//! A recorded model call carries the provider's own `usage` block, so token counts
+//! are a recorded fact: they are read back out of the response object, never
+//! estimated. Whether those tokens were *bought* is a second recorded fact, and a
+//! different one — it is the step's [`Delivery`], which says whether this run
+//! executed the call or served it off the tape. A branch that shares its parent's
+//! model call spends nothing, and that is the sentence worth printing.
+//!
+//! A price is not a recorded fact. Nothing here has a default price list, because a
+//! default price list is a made-up number wearing a fact's clothes, and this is the
+//! project that refuses those. [`Price`] only ever comes from the caller. Money is
+//! reported when a price was supplied, and when zero tokens were bought — zero costs
+//! nothing at every price there is.
+
+use std::collections::BTreeMap;
+
+use serde_json::{Map, Value};
+
+use crate::error::Result;
+use crate::model::{Action, Delivery, Trajectory};
+use crate::repo::Repo;
+
+/// The delivery key for a step this run kept no note of. Not a [`Delivery`] label:
+/// a bundle carries content, not per-run notes, so an imported trajectory genuinely
+/// does not say whether its calls were executed. Saying so beats guessing.
+pub const UNRECORDED: &str = "unrecorded";
+
+/// Tokens a provider reported for one call, in its own vocabulary.
+#[derive(Clone, Default, PartialEq, Eq, Debug)]
+pub struct Usage {
+    pub input: u64,
+    pub output: u64,
+    /// Every other `*_tokens` counter the provider reported, under the provider's own
+    /// name for it. Anthropic's cache counters land here. They are never folded into
+    /// `input`: they are billed at a different rate, and averaging them in would be
+    /// inventing a price.
+    pub extra: BTreeMap<String, u64>,
+}
+
+impl Usage {
+    pub fn is_zero(&self) -> bool {
+        self.input == 0 && self.output == 0 && self.extra.values().all(|n| *n == 0)
+    }
+
+    pub fn add(&mut self, other: &Usage) {
+        self.input += other.input;
+        self.output += other.output;
+        for (name, count) in &other.extra {
+            *self.extra.entry(name.clone()).or_insert(0) += count;
+        }
+    }
+}
+
+/// One model's usage under one delivery.
+#[derive(Clone, Default, PartialEq, Eq, Debug)]
+pub struct Tally {
+    pub calls: u64,
+    pub usage: Usage,
+}
+
+impl Tally {
+    pub fn add(&mut self, usage: &Usage) {
+        self.calls += 1;
+        self.usage.add(usage);
+    }
+}
+
+/// What one model cost under one delivery, in one trajectory.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct Entry {
+    /// The provider's name for the model that answered.
+    pub model: String,
+    /// [`Delivery::label`], or [`UNRECORDED`].
+    pub delivery: &'static str,
+    pub tally: Tally,
+}
+
+impl Entry {
+    /// Only an executed call reaches a provider, and only a call that reaches a
+    /// provider is billed.
+    pub fn spent(&self) -> bool {
+        self.delivery == Delivery::Executed.label()
+    }
+}
+
+/// Every model call in a trajectory, split by model and by how this run got it.
+#[derive(Clone, Default, PartialEq, Eq, Debug)]
+pub struct Ledger {
+    pub trajectory: String,
+    /// Sorted by model, then delivery.
+    pub entries: Vec<Entry>,
+    /// Calls to a model whose recorded response carries no usage block we can read —
+    /// a streamed response, say. Counted so that they are visibly missing rather than
+    /// silently totalled as zero.
+    pub calls_without_usage: u64,
+}
+
+impl Ledger {
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty() && self.calls_without_usage == 0
+    }
+
+    /// What this run actually bought.
+    pub fn spent(&self) -> Tally {
+        self.fold(|e| e.spent())
+    }
+
+    /// What it used and demonstrably did not buy: served from the recording,
+    /// supplied by an intervention, or denied. Tokens whose delivery nothing recorded
+    /// are excluded — they belong to [`Ledger::undeliverable`], because calling them
+    /// "not spent" would be the same guess as calling them spent.
+    pub fn not_spent(&self) -> Tally {
+        self.fold(|e| !e.spent() && e.delivery != UNRECORDED)
+    }
+
+    /// Tokens whose delivery this run kept no note of. Nonzero means we cannot say
+    /// whether they were bought, and must not claim either way.
+    pub fn undeliverable(&self) -> Tally {
+        self.fold(|e| e.delivery == UNRECORDED)
+    }
+
+    /// Call counts by delivery, most calls first, then alphabetically.
+    pub fn by_delivery(&self) -> Vec<(&'static str, Tally)> {
+        let mut totals: BTreeMap<&'static str, Tally> = BTreeMap::new();
+        for entry in &self.entries {
+            let slot = totals.entry(entry.delivery).or_default();
+            slot.calls += entry.tally.calls;
+            slot.usage.add(&entry.tally.usage);
+        }
+        let mut out: Vec<(&'static str, Tally)> = totals.into_iter().collect();
+        out.sort_by(|a, b| b.1.calls.cmp(&a.1.calls).then(a.0.cmp(b.0)));
+        out
+    }
+
+    /// What each model was bought for, models with no executed call omitted.
+    pub fn spent_by_model(&self) -> Vec<(&str, Usage)> {
+        let mut totals: BTreeMap<&str, Usage> = BTreeMap::new();
+        for entry in self.entries.iter().filter(|e| e.spent()) {
+            totals
+                .entry(entry.model.as_str())
+                .or_default()
+                .add(&entry.tally.usage);
+        }
+        totals.into_iter().collect()
+    }
+
+    /// Every model this trajectory used, bought or not.
+    pub fn models(&self) -> Vec<&str> {
+        let mut names: Vec<&str> = self.entries.iter().map(|e| e.model.as_str()).collect();
+        names.sort_unstable();
+        names.dedup();
+        names
+    }
+
+    fn fold(&self, keep: impl Fn(&Entry) -> bool) -> Tally {
+        let mut out = Tally::default();
+        for entry in self.entries.iter().filter(|e| keep(e)) {
+            out.calls += entry.tally.calls;
+            out.usage.add(&entry.tally.usage);
+        }
+        out
+    }
+
+    fn add(&mut self, model: &str, delivery: &'static str, usage: &Usage) {
+        match self
+            .entries
+            .iter_mut()
+            .find(|e| e.model == model && e.delivery == delivery)
+        {
+            Some(entry) => entry.tally.add(usage),
+            None => {
+                let mut tally = Tally::default();
+                tally.add(usage);
+                self.entries.push(Entry {
+                    model: model.to_string(),
+                    delivery,
+                    tally,
+                });
+            }
+        }
+    }
+}
+
+/// Add up the model calls in one trajectory.
+pub fn account(repo: &Repo, t: &Trajectory) -> Result<Ledger> {
+    let delivered: BTreeMap<u64, Delivery> = repo
+        .load_notes(&t.name)?
+        .into_iter()
+        .map(|note| (note.index, note.delivery))
+        .collect();
+
+    let mut ledger = Ledger {
+        trajectory: t.name.clone(),
+        ..Ledger::default()
+    };
+    for (_, step) in repo.chain(t)? {
+        let Action::Call { target, args, .. } = &step.action else {
+            continue;
+        };
+        let delivery = match delivered.get(&step.index) {
+            Some(d) => d.label(),
+            None => UNRECORDED,
+        };
+        let mut accounted = false;
+        for effect in &step.effects {
+            let value: Value = repo.store.get_json(&effect.value)?;
+            let Some(reported) = reported_in(&value) else {
+                continue;
+            };
+            accounted = true;
+            let model = reported
+                .model
+                .or_else(|| named_model(args))
+                .unwrap_or_else(|| "unnamed model".to_string());
+            ledger.add(&model, delivery, &reported.usage);
+        }
+        // A call the adapter routed to a model, whose response says nothing about
+        // what it cost. Reporting it as zero would be the quiet lie.
+        if !accounted && target.starts_with("model.") {
+            ledger.calls_without_usage += 1;
+        }
+    }
+    ledger
+        .entries
+        .sort_by(|a, b| a.model.cmp(&b.model).then(a.delivery.cmp(b.delivery)));
+    Ok(ledger)
+}
+
+/// What a provider said about one call it answered.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct Reported {
+    pub usage: Usage,
+    pub model: Option<String>,
+}
+
+/// Read a provider's own account of a call out of a recorded response.
+///
+/// Two shapes, both of which this repository records today: the response object as
+/// the model adapter stores it, and the HTTP exchange the recording proxy stores,
+/// whose body is that same object still in a string.
+pub fn reported_in(value: &Value) -> Option<Reported> {
+    if let Some(reported) = direct(value) {
+        return Some(reported);
+    }
+    let body = value.as_object()?.get("body")?.as_str()?;
+    let parsed: Value = serde_json::from_str(body).ok()?;
+    direct(&parsed)
+}
+
+fn direct(value: &Value) -> Option<Reported> {
+    let object = value.as_object()?;
+    let usage = match object.get("usage") {
+        Some(Value::Object(usage)) => usage,
+        _ => return None,
+    };
+    Some(Reported {
+        usage: read_usage(usage),
+        model: named_model(value),
+    })
+}
+
+/// `input_tokens`/`output_tokens` (Anthropic) or `prompt_tokens`/`completion_tokens`
+/// (OpenAI); everything else that counts tokens is kept under its own name.
+fn read_usage(usage: &Map<String, Value>) -> Usage {
+    let mut out = Usage::default();
+    for (name, value) in usage {
+        let Some(count) = value.as_u64() else {
+            continue;
+        };
+        match name.as_str() {
+            "input_tokens" | "prompt_tokens" => out.input += count,
+            "output_tokens" | "completion_tokens" => out.output += count,
+            other if other.ends_with("_tokens") => {
+                *out.extra.entry(other.to_string()).or_insert(0) += count;
+            }
+            _ => {}
+        }
+    }
+    out
+}
+
+fn named_model(value: &Value) -> Option<String> {
+    value
+        .get("model")?
+        .as_str()
+        .filter(|name| !name.is_empty())
+        .map(str::to_string)
+}
+
+/// What a model charges, in US dollars per million tokens.
+///
+/// Supplied by whoever runs the command and by nobody else. There is no table of
+/// defaults here on purpose: prices change, differ by contract and by region, and a
+/// figure this tool made up would be indistinguishable in the output from one it
+/// measured.
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub struct Price {
+    pub input: f64,
+    pub output: f64,
+}
+
+impl Price {
+    /// `IN/OUT`, dollars per million tokens. `None` for anything that is not two
+    /// non-negative numbers, so a typo is refused rather than silently priced at nil.
+    pub fn parse(spec: &str) -> Option<Price> {
+        let (input, output) = spec.split_once('/')?;
+        let input = sane(input)?;
+        let output = sane(output)?;
+        Some(Price { input, output })
+    }
+
+    /// The bill for `usage`, covering input and output only. Anything in
+    /// [`Usage::extra`] is billed at a rate nobody gave us, so it is left out and the
+    /// caller is expected to say so.
+    pub fn of(&self, usage: &Usage) -> f64 {
+        (usage.input as f64 * self.input + usage.output as f64 * self.output) / 1_000_000.0
+    }
+}
+
+fn sane(number: &str) -> Option<f64> {
+    let value: f64 = number.trim().parse().ok()?;
+    (value.is_finite() && value >= 0.0).then_some(value)
+}
+
+/// Dollars, at enough decimal places that a real spend is never rounded into
+/// looking like nothing.
+pub fn dollars(amount: f64) -> String {
+    let places = if amount == 0.0 || amount >= 0.01 {
+        2
+    } else if amount >= 0.0001 {
+        4
+    } else {
+        6
+    };
+    format!("${amount:.places$}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn token_counts_are_read_from_the_response_not_estimated() {
+        let anthropic = json!({
+            "model": "claude-x",
+            "usage": { "input_tokens": 180, "output_tokens": 24 },
+        });
+        let reported = reported_in(&anthropic).expect("an Anthropic-shaped response");
+        assert_eq!(reported.model.as_deref(), Some("claude-x"));
+        assert_eq!(reported.usage.input, 180);
+        assert_eq!(reported.usage.output, 24);
+
+        let openai = json!({
+            "model": "gpt-x",
+            "usage": { "prompt_tokens": 7, "completion_tokens": 3 },
+        });
+        let reported = reported_in(&openai).expect("an OpenAI-shaped response");
+        assert_eq!(reported.usage.input, 7);
+        assert_eq!(reported.usage.output, 3);
+
+        assert_eq!(reported_in(&json!({ "model": "m" })), None);
+        assert_eq!(reported_in(&json!("just a string")), None);
+    }
+
+    #[test]
+    fn a_proxied_call_is_accounted_from_the_body_it_recorded() {
+        // What `noidroid run --proxy` stores: an HTTP exchange, body still a string.
+        let exchange = json!({
+            "status": 200,
+            "headers": { "content-type": "application/json" },
+            "body": r#"{"model":"claude-y","usage":{"input_tokens":9,"output_tokens":4}}"#,
+        });
+        let reported = reported_in(&exchange).expect("the body carries the usage");
+        assert_eq!(reported.model.as_deref(), Some("claude-y"));
+        assert_eq!(reported.usage.input, 9);
+
+        // A body that is not a model response is not a model call.
+        let other = json!({ "status": 200, "body": "not json at all" });
+        assert_eq!(reported_in(&other), None);
+    }
+
+    #[test]
+    fn a_token_counter_we_do_not_price_is_reported_rather_than_folded_in() {
+        // Cache tokens are billed at their own rate. Adding them to `input` would
+        // price them at the input rate, which is a number nobody gave us.
+        let response = json!({
+            "usage": {
+                "input_tokens": 10,
+                "output_tokens": 2,
+                "cache_read_input_tokens": 4096,
+                "service_tier": "standard",
+            },
+        });
+        let usage = reported_in(&response).unwrap().usage;
+        assert_eq!(usage.input, 10);
+        assert_eq!(usage.extra.get("cache_read_input_tokens"), Some(&4096));
+        assert!(!usage.extra.contains_key("service_tier"));
+    }
+
+    #[test]
+    fn a_price_is_two_numbers_or_it_is_refused() {
+        assert_eq!(
+            Price::parse("3/15"),
+            Some(Price {
+                input: 3.0,
+                output: 15.0
+            })
+        );
+        assert_eq!(
+            Price::parse("0/0"),
+            Some(Price {
+                input: 0.0,
+                output: 0.0
+            })
+        );
+        assert_eq!(Price::parse("free"), None);
+        assert_eq!(Price::parse("3"), None);
+        assert_eq!(Price::parse("-3/15"), None);
+        assert_eq!(Price::parse("3/nan"), None);
+    }
+
+    #[test]
+    fn a_real_spend_is_never_rounded_into_looking_like_nothing() {
+        let price = Price::parse("3/15").unwrap();
+        let usage = Usage {
+            input: 180,
+            output: 24,
+            extra: BTreeMap::new(),
+        };
+        assert_eq!(dollars(price.of(&usage)), "$0.0009");
+        assert_eq!(dollars(price.of(&Usage::default())), "$0.00");
+        assert_eq!(dollars(4.2), "$4.20");
+        // Two decimal places would print this as nothing, which it is not.
+        assert_eq!(dollars(0.000_003), "$0.000003");
+    }
+
+    #[test]
+    fn only_an_executed_call_counts_as_bought() {
+        let mut ledger = Ledger::default();
+        let usage = Usage {
+            input: 100,
+            output: 10,
+            extra: BTreeMap::new(),
+        };
+        ledger.add("m", Delivery::Executed.label(), &usage);
+        ledger.add("m", Delivery::Replayed.label(), &usage);
+        ledger.add("m", Delivery::Intervened.label(), &usage);
+        ledger.add("m", UNRECORDED, &usage);
+
+        assert_eq!(ledger.spent().calls, 1);
+        assert_eq!(ledger.spent().usage.input, 100);
+        assert_eq!(ledger.not_spent().calls, 2);
+        assert_eq!(ledger.not_spent().usage.input, 200);
+        assert_eq!(ledger.undeliverable().calls, 1);
+        assert_eq!(ledger.spent_by_model(), vec![("m", usage)]);
+        assert_eq!(ledger.models(), vec!["m"]);
+    }
+}

--- a/crates/noidroid-core/src/lib.rs
+++ b/crates/noidroid-core/src/lib.rs
@@ -13,6 +13,7 @@
 
 pub mod bundle;
 pub mod checkpoint;
+pub mod cost;
 pub mod engine;
 pub mod env;
 pub mod error;


### PR DESCRIPTION
Closes #36

A trajectory already recorded every model response it received, token counts
included, and nothing added them up. `noidroid cost` does, and the sentence it
prints is the one that makes the shape of the tool obvious:

```console
$ noidroid cost --price 'fake-model-1=3/15'
COST
run-1              180 in / 24 out spent    $0.0009
alt-1              0 in / 0 out spent       $0.00      — served from the recording
```

## Where the numbers come from

Two recorded facts, no estimates. Token counts are read back out of the stored
response object (`usage`, in either the Anthropic or the OpenAI shape). Whether
a token was *bought* is the step's `Delivery`: only `executed` reaches a
provider, so a branch whose model call sits in the shared prefix buys nothing.

## What is deliberately not printed

A price is not a recorded fact, so there is no built-in price list.
`--price 'MODEL=IN/OUT'` (US dollars per million tokens) is the only source of
one. Without it the output names the model it could not price and says why
rather than printing a number:

```console
$ noidroid cost run-1
COST run-1
  model calls            1 executed
  tokens spent           180 in / 24 out

  cost: 180 in / 24 out spent. Money is not reported: no price was supplied for fake-model-1.
        a price this tool invented would read exactly like one it measured
        noidroid cost run-1 --price 'fake-model-1=<in>/<out>'   (US dollars per million tokens)
```

`$0.00` is the one figure that needs no price: zero tokens cost nothing at every
price there is. Two further boundaries are stated rather than smoothed over — an
imported bundle carries content but not per-run notes, so it reports `cannot be
said` instead of totalling to zero; and counters a provider bills separately
(Anthropic's cache tokens) are reported under their own names and excluded from
any money figure, with a line saying so.

## Verified

- `cargo fmt --all`, `cargo clippy --all-targets -- -D warnings`, `cargo test --all`
  — all clean; browser tests skip cleanly, Chromium is absent here.
- New: `crates/noidroid-cli/tests/cost.rs`, driving the real binary and real
  Python child processes.
  - `a_replayed_branch_costs_nothing_and_says_so` — records the example agent,
    branches its tool choice, and asserts the recording bought 180 in / 24 out
    while the branch bought nothing and names the reason.
  - `a_dollar_figure_never_appears_without_a_price_somebody_supplied` — asserts
    no `$` appears anywhere in the unpriced output, that a price for a *different*
    model does not price this one, that a supplied price yields `$0.0009`, and
    that a malformed price is refused non-zero rather than ignored.
- Six unit tests in `crates/noidroid-core/src/cost.rs` cover the extractor
  (Anthropic and OpenAI shapes, the proxy's HTTP-exchange shape, unpriced
  counters), price parsing, and the rounding rule that stops a real spend
  printing as `$0.00`.
- By hand: a `--proxy` recording against a local stand-in provider, including a
  `cache_read_input_tokens` counter, and an exported/imported bundle to exercise
  the notes-less path.

## Not verified

- No real provider was called; the fixtures are the repository's fake model and
  a local stand-in. Streaming (SSE) responses are not parsed — a proxied stream
  carries its usage in `message_delta` events, so `cost` will not see it. Such a
  call is not claimed as a zero-token model call; it is simply not counted as a
  model call, which I did not want to fix by inventing an endpoint allowlist.
  Say the word and I will file it as its own issue.
- `STEP_VERSION` is untouched; nothing here writes objects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
