### PR TITLE
fix(cli): a branch whose program died says so, and says what it said

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,15 @@ how the package version relates to `STEP_VERSION`, the on-disk object format.
 
 ### Fixed
 
+- **A branch whose program died printed a timeline that just stopped.** `noidroid log`
+  called it `aborted` and `noidroid branch` never did, so the operator had to infer the
+  crash from a missing `finish` row — the inference this tool exists to remove, and the
+  whole result when the intervention was a failure the program was supposed to survive.
+  `branch` now states the outcome the way `log` does, and the child's stderr is printed
+  alongside its stdout, so the traceback that says *why* is on the screen instead of in
+  a log file nobody was told about. When the program said nothing on the way out, that
+  is what it says; the reason is never guessed at. This was never specific to
+  `--inject` — `--decide`, `--result` and `--fail` were all equally silent. (#58)
 - **`--inject all` was in the help and never in the binary.** It promised to branch
   every failure in turn and refused the moment anyone tried it. The help now names
   only what works, and a test through the real binary keeps it that way — a tool whose

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ $ noidroid branch run-1@2 --decide pick_flight=FL-203 \
 
 branched alt-1 from run-1@2
   intervention replace-decision pick_flight = "FL-203"
+  outcome      success
   prefix       2 step(s) shared with run-1 — identical objects, stored once
 
     0 ● genesis                                     real      replayed   2219c2d195
@@ -162,9 +163,16 @@ $ noidroid branch run-1@1 --inject malformed
 
 │ found 17 flights under 800
 
+│ stderr:
+│ Traceback (most recent call last):
+│   …
+│     ranked = sorted(flights, key=lambda f: f["price"])
+│ TypeError: string indices must be integers, not 'str'
+
 branched run-1~malformed-1 from run-1@1
   intervention replace-result "{\"unterminated\": "
   failure      malformed the answer was not the shape it should be
+  outcome      aborted — the program exited 1 without reaching a finish; its last words are above
   prefix       1 step(s) shared with run-1 — identical objects, stored once
 
     0 ● genesis                                  real      replayed   a7df183d1f
@@ -176,8 +184,10 @@ would raise, and any agent with a `try` around the call already handles them. Th
 raise nothing at all: the call returns, and an agent that does not validate its tool
 results carries the answer straight into what it does next. Above, seventeen characters
 of broken JSON were reported as seventeen flights, out loud and with confidence, before
-anything went wrong. As with every intervention the value is `simulated`, so nothing
-downstream of it may claim otherwise.
+anything went wrong. Then the program died on the next line, and the branch says so and
+shows what it said on the way out — "the run ended here" and "the run broke here" are
+different facts, and a timeline that stops does not distinguish them. As with every
+intervention the value is `simulated`, so nothing downstream of it may claim otherwise.
 
 ---
 

--- a/crates/noidroid-cli/src/main.rs
+++ b/crates/noidroid-cli/src/main.rs
@@ -840,6 +840,7 @@ fn cmd_branch(
             dim(failure.describes())
         );
     }
+    print_branch_outcome(&branch, &report);
     print_shared_prefix(repo, &parent, &branch, at)?;
     println!();
     print_timeline(repo, &branch)?;
@@ -1713,6 +1714,36 @@ fn print_timeline(repo: &Repo, t: &Trajectory) -> Result<()> {
     Ok(())
 }
 
+/// How the branch ended, in the words `log` already uses.
+///
+/// A branch whose program died prints a timeline with no `finish` row, and nothing
+/// distinguishes that from a timeline that simply ended — so the status is said out
+/// loud. When it is `aborted` the reason is whatever the program said on its way out,
+/// which `print_child_output` has already put on the screen. When it said nothing,
+/// this says that instead: a guess at the reason would be worse than the silence.
+fn print_branch_outcome(branch: &Trajectory, report: &Report) {
+    let status = &branch.outcome.status;
+    let line = if status == "aborted" {
+        let exit = match branch.outcome.exit_code {
+            Some(code) => format!("the program exited {code}"),
+            None => "the program was killed".to_string(),
+        };
+        let why = if child_stream(report.stderr_path.as_deref()).is_some() {
+            "its last words are above"
+        } else {
+            "it said nothing on the way out, so nothing here says why"
+        };
+        format!(
+            "{} {}",
+            warn(status),
+            dim(&format!("— {exit} without reaching a finish; {why}"))
+        )
+    } else {
+        status_text(status)
+    };
+    println!("  {:<12} {}", dim("outcome"), line);
+}
+
 fn print_shared_prefix(
     repo: &Repo,
     parent: &Trajectory,
@@ -1773,18 +1804,36 @@ fn provenance_rank(label: &str) -> u8 {
     }
 }
 
+/// Everything the child said, on both of its streams. A program that dies explains
+/// itself on stderr, so reading only stdout drops the one line that says why the
+/// timeline stops where it does.
 fn print_child_output(report: &Report) {
-    if let Some(path) = &report.stdout_path {
-        if let Ok(text) = std::fs::read_to_string(path) {
-            let text = text.trim_end();
-            if !text.is_empty() {
-                for line in text.lines() {
-                    println!("{} {line}", dim("│"));
-                }
-                println!();
-            }
-        }
+    print_child_stream(report.stdout_path.as_deref(), None);
+    print_child_stream(report.stderr_path.as_deref(), Some("stderr"));
+}
+
+/// One of the child's streams, gutter-marked so it cannot be read as the tool's own
+/// words. stderr is labelled rather than merely tinted: "the program printed this"
+/// and "the program broke here" are different facts, and the difference has to
+/// survive being piped into a file.
+fn print_child_stream(path: Option<&Path>, name: Option<&str>) {
+    let Some(text) = child_stream(path) else {
+        return;
+    };
+    if let Some(name) = name {
+        println!("{}", dim(&format!("│ {name}:")));
     }
+    for line in text.lines() {
+        println!("{} {line}", dim("│"));
+    }
+    println!();
+}
+
+/// What a stream holds, or `None` when it holds nothing worth printing.
+fn child_stream(path: Option<&Path>) -> Option<String> {
+    let text = std::fs::read_to_string(path?).ok()?;
+    let text = text.trim_end().to_string();
+    (!text.trim().is_empty()).then_some(text)
 }
 
 fn head_provenance(repo: &Repo, t: &Trajectory) -> Result<Provenance> {

--- a/crates/noidroid-cli/tests/branch_outcome.rs
+++ b/crates/noidroid-cli/tests/branch_outcome.rs
@@ -1,0 +1,106 @@
+//! What `noidroid branch` says about how the branch ended, through the real binary.
+//!
+//! A branch that died is a result, and for an intervention it is often *the* result.
+//! A timeline that simply stops is not: the reader cannot tell "it ended here" from
+//! "it broke here", which is the failure mode this project exists to refuse.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("the workspace root is two levels up")
+}
+
+fn workdir(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "noidroid-outcome-{tag}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn noidroid(dir: &Path, args: &[&str]) -> (String, bool) {
+    let root = repo_root();
+    let output = Command::new(env!("CARGO_BIN_EXE_noidroid"))
+        .args(args)
+        .current_dir(dir)
+        .env("PYTHONPATH", root.join("clients/python"))
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("the binary should run");
+    let mut text = String::from_utf8_lossy(&output.stdout).to_string();
+    text.push_str(&String::from_utf8_lossy(&output.stderr));
+    (text, output.status.success())
+}
+
+fn record_shift(dir: &Path) {
+    let agent = repo_root().join("examples/reference/agent.py");
+    let (out, ok) = noidroid(
+        dir,
+        &[
+            "run",
+            "--name",
+            "shift",
+            "--",
+            "python3",
+            agent.to_str().unwrap(),
+        ],
+    );
+    assert!(ok, "recording failed: {out}");
+}
+
+/// Feeding the reference agent a reading it cannot index kills it on the next line.
+/// Both spellings of that intervention — the named preset and the raw value — have to
+/// report the death and show the traceback that says what it was, because the child
+/// wrote it to stderr and the engine keeps the log.
+#[test]
+fn a_branch_that_aborted_says_so_and_shows_why() {
+    let dir = workdir("aborted");
+    record_shift(&dir);
+
+    for intervention in [
+        vec!["--inject", "malformed"],
+        vec!["--result", "\"not a reading\""],
+    ] {
+        let mut args = vec!["branch", "shift@1"];
+        args.extend(intervention.iter().copied());
+        let (out, ok) = noidroid(&dir, &args);
+        assert!(ok, "branch {intervention:?} failed outright: {out}");
+        assert!(
+            out.contains("aborted"),
+            "branch {intervention:?} left the timeline stopping for no stated reason: {out}"
+        );
+        assert!(
+            out.contains("TypeError: string indices must be integers"),
+            "branch {intervention:?} dropped the child's traceback, \
+             which is the one line saying why it died: {out}"
+        );
+    }
+}
+
+/// The other half of the claim: `aborted` has to mean something. A branch that ran to
+/// a `finish` says how it ended and never wears the word.
+#[test]
+fn a_branch_that_finished_is_not_reported_as_aborted() {
+    let dir = workdir("finished");
+    record_shift(&dir);
+
+    let (out, ok) = noidroid(&dir, &["branch", "shift@8", "--decide", "move=insert"]);
+    assert!(ok, "branching the saved shift failed: {out}");
+    assert!(
+        out.contains("success"),
+        "a branch that finished must say how it ended: {out}"
+    );
+    assert!(
+        !out.contains("aborted"),
+        "a branch that reached its finish must not be called aborted: {out}"
+    );
+}


### PR DESCRIPTION
Closes #58

`noidroid branch` printed a timeline that stopped and said nothing about why. `noidroid log` already called that branch `aborted`; `branch` did not, and `print_child_output` read only `report.stdout_path`, so a Python traceback — stderr — never reached the screen. The reader could not tell "it ended here" from "it broke here".

## What changed

- `print_branch_outcome` states the branch's outcome in the same words `log` uses. When it is `aborted` it names the exit code and points at the program's last words. When the child said nothing at all, it says that instead — it does not guess at a reason it does not have.
- `print_child_output` now prints both of the child's streams. stderr is labelled `│ stderr:` rather than only tinted, because the distinction has to survive `NO_COLOR` and being piped into a file. `noidroid run` gets the same benefit for free: a recording of a program that crashed now shows the traceback.
- README: the two branch samples were regenerated against the current binary, including the `--inject malformed` one, which is the case in the issue.

## The test

`crates/noidroid-cli/tests/branch_outcome.rs`, driving the real binary against the real reference agent:

- `a_branch_that_aborted_says_so_and_shows_why` — branches `shift@1` twice, once with `--inject malformed` and once with a raw `--result '"not a reading"'`, and requires both to print `aborted` and the child's `TypeError` traceback. Two spellings because the issue is a property of every intervention, not of the presets. It fails on `main` on the first assertion.
- `a_branch_that_finished_is_not_reported_as_aborted` — the other half: `aborted` has to mean something, so a branch that reaches a `finish` reports `success` and never wears the word.

## Verified

`cargo fmt --all`, `cargo clippy --all-targets -- -D warnings`, and `cargo test --all` all clean locally (Linux). Browser tests ran rather than skipped here, and passed. I also ran the CI example script's branch steps by hand against the flight agent and the reference agent, and read the output.

## Not verified

- macOS. Nothing in the change is platform-specific, but I only ran Linux.
- The exit code of `noidroid branch` is unchanged: a branch whose program aborted still exits 0, because producing the branch succeeded and a dead program is a legitimate result. Say so if you want that to change; it would be a separate issue.
- `noidroid run` still does not state the recording's outcome — a recording of a crashed program prints `recorded <name>` with no status, though it now shows the traceback. That is the same shape of bug one command over and is filed separately rather than smuggled in here.