### PR TITLE
fix(proxy): never write bytes into a trajectory that cannot be read back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,21 @@ how the package version relates to `STEP_VERSION`, the on-disk object format.
   a log file nobody was told about. When the program said nothing on the way out, that
   is what it says; the reason is never guessed at. This was never specific to
   `--inject` — `--decide`, `--result` and `--fail` were all equally silent. (#58)
+- **The proxy recorded a gzipped reply as a wall of replacement characters.** It
+  forwarded the agent's `accept-encoding` upstream, so a real provider compressed;
+  it then stripped `Content-Encoding` and passed the compressed bytes through, so the
+  agent could not parse them — and `decode("utf-8", "replace")` wrote them into the
+  trajectory with every unreadable byte swapped for U+FFFD. The recording was lossy,
+  irreversible, and said nothing about it, which is the one failure this project
+  cannot survive: not a crash, a trajectory that looks real. The proxy now asks
+  upstream only for `identity`, inflates gzip or deflate if a provider compresses
+  anyway, and records the plain body — so the stripped header is finally an honest
+  description of the bytes under it. Anything it still cannot read back, another
+  content coding or a body that is not UTF-8, fails the call with the reason, in the
+  agent's error and in the trajectory, instead of being written down wrong. The
+  stand-in provider that catches this compresses whether or not it was asked to,
+  because a recorder that only copes when it opted in is one that lies the first time
+  a provider changes its mind. (#56)
 - **`--inject all` was in the help and never in the binary.** It promised to branch
   every failure in turn and refused the moment anyone tried it. The help now names
   only what works, and a test through the real binary keeps it that way — a tool whose

--- a/clients/python/noidroid/proxy.py
+++ b/clients/python/noidroid/proxy.py
@@ -24,6 +24,14 @@ response. **What it does not**: anything the agent does that is not that request
 files it writes, commands it runs, other services it calls. Those are invisible here,
 and a replay will not reproduce them.
 
+A trajectory holds bodies as text, so a body that is not text cannot go into one. We
+ask the provider for `identity` rather than the codings the agent's SDK would have
+offered, and inflate gzip or deflate if it compresses anyway; anything else — another
+content coding, a body that is not valid UTF-8 — fails the call with the reason
+instead of being written down with the bad bytes replaced. A recording you cannot read
+back is only useful if it admits that, and one that quietly swaps the unreadable parts
+for U+FFFD does not.
+
 **A server-sent event stream is passed through as it arrives**, chunk by chunk, while
 the concatenation is kept for the trajectory. An agent under recording therefore sees
 its tokens on the same schedule as one that is not being recorded — which matters,
@@ -49,6 +57,7 @@ import sys
 import threading
 import urllib.error
 import urllib.request
+import zlib
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 from . import READ, connect
@@ -59,19 +68,53 @@ BASE_URL_VARS = {
     "openai": "OPENAI_BASE_URL",
 }
 
-#: Not forwarded upstream: hop-by-hop, or ours to set.
+#: Not forwarded upstream: hop-by-hop, or ours to set. `accept-encoding` is ours
+#: because we are the one that has to read the answer -- see ACCEPT_ENCODING.
 SKIP_REQUEST_HEADERS = {"host", "connection", "proxy-connection", "keep-alive",
-                        "transfer-encoding", "upgrade", "content-length"}
+                        "transfer-encoding", "upgrade", "content-length",
+                        "accept-encoding"}
 SKIP_RESPONSE_HEADERS = {"connection", "keep-alive", "transfer-encoding", "upgrade",
                          "content-encoding", "content-length"}
+
+#: What we ask the provider for, in place of whatever the agent asked for. The
+#: agent's SDK offers `gzip, deflate, br, zstd`; we can inflate two of those, and
+#: asking for a coding we cannot read is asking to be handed something we can only
+#: mangle. The SDK is none the wiser: it decompresses transparently, so identity
+#: reaches it as the same object either way.
+ACCEPT_ENCODING = "identity"
+
+#: Content codings we can turn back into the bytes the provider meant, and the zlib
+#: window that does it. A provider that compresses regardless of what we asked for
+#: is still readable; one that uses anything else is refused, not guessed at.
+INFLATE = {
+    "gzip": 16 + zlib.MAX_WBITS,
+    "x-gzip": 16 + zlib.MAX_WBITS,
+    "deflate": zlib.MAX_WBITS,
+}
 
 #: How much to ask upstream for at a time; it returns whatever has arrived.
 CHUNK = 64 * 1024
 
 
+class Unrecordable(Exception):
+    """This body cannot be written into a trajectory without lying about it.
+
+    Raised instead of storing something lossy. A recording that cannot be read back
+    is worth less than nothing if it does not say so: the caller turns this into a
+    recorded error and a 502, so the gap is in the trajectory under its own name.
+    """
+
+
 def _target(path: str) -> str:
     """Name a call after its endpoint, so a timeline reads as something recognisable."""
     return "http" + path.split("?", 1)[0].replace("/", ".").rstrip(".")
+
+
+def _header(headers: dict, name: str) -> str:
+    for key, value in headers.items():
+        if key.lower() == name:
+            return value.strip()
+    return ""
 
 
 def _is_stream(headers: dict) -> bool:
@@ -80,10 +123,56 @@ def _is_stream(headers: dict) -> bool:
     Only server-sent events. A JSON body is one value that exists all at once, and
     handing it over in pieces buys the agent nothing.
     """
-    for key, value in headers.items():
-        if key.lower() == "content-type":
-            return value.split(";", 1)[0].strip().lower() == "text/event-stream"
-    return False
+    kind = _header(headers, "content-type").split(";", 1)[0].strip().lower()
+    return kind == "text/event-stream"
+
+
+def _inflate(payload: bytes, headers: dict) -> bytes:
+    """Undo the content coding, or refuse to pretend there was not one.
+
+    The coding is a property of this hop, not of what the provider said, so the
+    trajectory holds the plain body and the header stays stripped -- which is then
+    an honest description of the bytes underneath it. Recording the compressed form
+    instead would put a body in the trajectory that nobody can read without knowing
+    a header we threw away, and would make the content address depend on the
+    provider's compression level.
+    """
+    coding = _header(headers, "content-encoding").lower()
+    if coding in ("", "identity"):
+        return payload
+    if coding not in INFLATE:
+        raise Unrecordable(
+            f"the provider answered with content-encoding {coding!r}, which this "
+            f"proxy cannot decode. Recording it would store bytes that no longer "
+            f"say how to read them."
+        )
+    try:
+        return zlib.decompress(payload, INFLATE[coding])
+    except zlib.error:
+        # Some servers send raw deflate under the same name; RFC 9110 allows both.
+        if coding == "deflate":
+            try:
+                return zlib.decompress(payload, -zlib.MAX_WBITS)
+            except zlib.error:
+                pass
+        raise Unrecordable(
+            f"the provider labelled its body {coding!r} but it did not decompress"
+        ) from None
+
+
+def _text(payload: bytes, what: str) -> str:
+    """Decode for the trajectory, strictly.
+
+    `errors="replace"` is how a recording ends up full of U+FFFD that nothing in it
+    admits to. Bytes we cannot represent are a gap, and a gap gets said out loud.
+    """
+    try:
+        return payload.decode("utf-8")
+    except UnicodeDecodeError as failure:
+        raise Unrecordable(
+            f"the {what} is not valid UTF-8 (byte {failure.start} of "
+            f"{len(payload)}), so it cannot be recorded without losing bytes"
+        ) from None
 
 
 class _Handler(BaseHTTPRequestHandler):
@@ -104,6 +193,7 @@ class _Handler(BaseHTTPRequestHandler):
             k: v for k, v in self.headers.items()
             if k.lower() not in SKIP_REQUEST_HEADERS
         }
+        headers["Accept-Encoding"] = ACCEPT_ENCODING
 
         # The body is what identifies the call, so it is what a replay matches on.
         # Parsed when it is JSON, because a dict diffs field by field and a blob does
@@ -111,7 +201,10 @@ class _Handler(BaseHTTPRequestHandler):
         try:
             body = json.loads(raw) if raw else None
         except ValueError:
-            body = {"__raw__": raw.decode("utf-8", "replace")}
+            try:
+                body = {"__raw__": _text(raw, "request body")}
+            except Unrecordable as refusal:
+                return self._refuse(refusal)
 
         # Set by perform() when the response has already gone back to the agent a
         # chunk at a time. Only a recording gets there: a reconstruction serves the
@@ -130,31 +223,49 @@ class _Handler(BaseHTTPRequestHandler):
                     status = response.status
                     got = dict(response.headers)
                     if _is_stream(got):
+                        # Inflating as it arrives would work; inflating it *and*
+                        # keeping the tokens on their original schedule is a second
+                        # machine nobody has needed yet. We asked for identity, so a
+                        # compressed stream means the provider ignored us — say so
+                        # before a single byte goes back.
+                        if _header(got, "content-encoding").lower() not in (
+                            "", "identity",
+                        ):
+                            raise Unrecordable(
+                                "the provider compressed an event stream; this proxy "
+                                "passes streams through untouched and will not record "
+                                "bytes it cannot read"
+                            )
                         payload = self._pass_through(status, got, response)
                         passed_through.append(True)
                     else:
-                        payload = response.read()
+                        payload = _inflate(response.read(), got)
             except urllib.error.HTTPError as failure:
                 # A provider error is part of what happened, not a reason to stop.
-                payload = failure.read()
                 status = failure.code
                 got = dict(failure.headers)
+                payload = _inflate(failure.read(), got)
             return {
                 "status": status,
                 "headers": {k: v for k, v in got.items()
                             if k.lower() not in SKIP_RESPONSE_HEADERS},
-                "body": payload.decode("utf-8", "replace"),
+                "body": _text(payload, "response body"),
             }
 
         # One conversation with the engine at a time: the protocol is request and
         # response over a single socket, and an agent may well be concurrent.
-        with self.lock:
-            recorded = self.session.call(
-                _target(self.path),
-                perform,
-                args={"method": method, "path": self.path, "body": body},
-                effect=READ,
-            )
+        try:
+            with self.lock:
+                recorded = self.session.call(
+                    _target(self.path),
+                    perform,
+                    args={"method": method, "path": self.path, "body": body},
+                    effect=READ,
+                )
+        except Unrecordable as refusal:
+            # The engine already has this as a failed step, with the reason. All that
+            # is left is to tell the agent, unless the stream beat us to the socket.
+            return self._refuse(refusal, answered=bool(passed_through))
 
         if passed_through:
             return  # the agent already has every byte of it
@@ -164,6 +275,22 @@ class _Handler(BaseHTTPRequestHandler):
         for key, value in (recorded.get("headers") or {}).items():
             if key.lower() not in SKIP_RESPONSE_HEADERS:
                 self.send_header(key, value)
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def _refuse(self, refusal: Unrecordable, answered: bool = False) -> None:
+        """Fail the call loudly rather than record something lossy.
+
+        The trajectory keeps the refusal as an error effect, so the gap is named in
+        the recording as well as on the terminal.
+        """
+        print(f"[noidroid.proxy] refusing to record: {refusal}", file=sys.stderr)
+        if answered:
+            return  # the agent has the whole body already; nothing left to send
+        payload = f"noidroid.proxy: {refusal}\n".encode()
+        self.send_response(502)
+        self.send_header("Content-Type", "text/plain; charset=utf-8")
         self.send_header("Content-Length", str(len(payload)))
         self.end_headers()
         self.wfile.write(payload)

--- a/crates/noidroid-core/tests/proxy_slice.rs
+++ b/crates/noidroid-core/tests/proxy_slice.rs
@@ -17,10 +17,17 @@ use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
 
 use noidroid_core::engine::{self, Mode, RunSpec};
+use noidroid_core::model::EffectOutcome;
 use noidroid_core::Repo;
 
 const PORT: u16 = 8791;
 const STREAM_PORT: u16 = 8792;
+const GZIP_PORT: u16 = 8793;
+const OPAQUE_PORT: u16 = 8794;
+
+/// The replacement character. Its presence in a recorded body means bytes were
+/// dropped on the way in and nothing said so.
+const LOST: char = '\u{fffd}';
 
 const PROVIDER: &str = r#"
 import json, sys
@@ -119,6 +126,58 @@ with open(os.environ["ARRIVALS_PATH"], "w", encoding="utf-8") as handle:
     handle.write(" ".join("%.3f" % a for a in arrivals))
 "#;
 
+/// Answers the same message as PROVIDER, gzipped — and gzips whether or not it was
+/// asked to, because a proxy that only copes when it opted in is a proxy that lies
+/// the first time a provider changes its mind. It also reports back what it was
+/// asked for, so the recording shows which codings the proxy put its name to.
+const GZIP_PROVIDER: &str = r#"
+import gzip, json, sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *a): pass
+    def do_POST(self):
+        self.rfile.read(int(self.headers.get("Content-Length") or 0))
+        body = gzip.compress(json.dumps({
+            "id": "msg_local", "type": "message", "role": "assistant",
+            "model": "claude-opus-5", "stop_reason": "end_turn", "stop_sequence": None,
+            "content": [{"type": "text", "text": "four"}],
+            "usage": {"input_tokens": 11, "output_tokens": 2},
+            "asked_for": self.headers.get("Accept-Encoding", ""),
+        }).encode())
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Encoding", "gzip")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+ThreadingHTTPServer(("127.0.0.1", int(sys.argv[1])), Handler).serve_forever()
+"#;
+
+/// Answers in a content coding the proxy has no way to undo, with bytes that are not
+/// text either. There is nothing honest to record here, so the only right answer is
+/// to say so.
+const OPAQUE_PROVIDER: &str = r#"
+import sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+BODY = bytes(range(200, 256)) * 8
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *a): pass
+    def do_POST(self):
+        self.rfile.read(int(self.headers.get("Content-Length") or 0))
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Encoding", "br")
+        self.send_header("Content-Length", str(len(BODY)))
+        self.end_headers()
+        self.wfile.write(BODY)
+
+ThreadingHTTPServer(("127.0.0.1", int(sys.argv[1])), Handler).serve_forever()
+"#;
+
 /// No noidroid import, and no base_url — it comes from the environment.
 const AGENT: &str = r#"
 import anthropic
@@ -131,6 +190,25 @@ reply = client.messages.create(
 )
 with open("answer.txt", "w", encoding="utf-8") as handle:
     handle.write(f"{reply.content[0].text}:{type(reply).__name__}")
+"#;
+
+/// Same as AGENT, but writes down what it was told instead of dying of it — a
+/// refusal is only a feature if the agent can see the reason.
+const REPORTING_AGENT: &str = r#"
+import anthropic
+
+client = anthropic.Anthropic(api_key="not-a-real-key", max_retries=0)
+try:
+    reply = client.messages.create(
+        model="claude-opus-5",
+        max_tokens=16,
+        messages=[{"role": "user", "content": "what is two plus two?"}],
+    )
+    outcome = "answered:" + reply.content[0].text
+except Exception as failure:
+    outcome = "%s: %s" % (type(failure).__name__, failure)
+with open("answer.txt", "w", encoding="utf-8") as handle:
+    handle.write(outcome)
 "#;
 
 fn sdk_available() -> bool {
@@ -404,6 +482,196 @@ fn a_streamed_response_reaches_the_client_before_it_ends() {
         report.delivery.get("executed").copied().unwrap_or(0),
         0,
         "nothing may be executed during a replay; the provider is not even running"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// Every response body the recording holds, as it would be read back.
+fn recorded_bodies(
+    repo: &Repo,
+    trajectory: &noidroid_core::model::Trajectory,
+) -> Vec<(EffectOutcome, serde_json::Value)> {
+    repo.chain(trajectory)
+        .unwrap()
+        .iter()
+        .flat_map(|(_, step)| step.effects.clone())
+        .map(|effect| {
+            (
+                effect.outcome,
+                repo.store
+                    .get_json(&effect.value)
+                    .expect("a recorded value"),
+            )
+        })
+        .collect()
+}
+
+/// A trajectory must never contain a body the recorder could not read.
+///
+/// The proxy asked upstream for `gzip` and stripped `Content-Encoding` on the way
+/// back while forwarding the compressed bytes, so the agent got gzip labelled as
+/// plain text — and, far worse, `decode("utf-8", "replace")` wrote those bytes into
+/// the trajectory as U+FFFD. Lossy, irreversible, and nothing in the recording said
+/// so. The provider here compresses no matter what was asked for, so the fix has to
+/// be in what gets recorded and not only in what gets requested.
+#[test]
+fn a_compressed_response_is_never_recorded_as_replacement_characters() {
+    if !sdk_available() {
+        eprintln!("SKIP: proxy test needs the anthropic SDK (pip install anthropic)");
+        return;
+    }
+
+    let dir = scratch("proxy-gzip");
+    let provider_script = dir.join("provider.py");
+    fs::write(&provider_script, GZIP_PROVIDER).unwrap();
+    let agent = dir.join("agent.py");
+    fs::write(&agent, AGENT).unwrap();
+
+    let repo = Repo::open(&dir).unwrap();
+    let spec = |name: Option<&str>| RunSpec {
+        command: vec![
+            "python3".into(),
+            "-m".into(),
+            "noidroid.proxy".into(),
+            "--upstream".into(),
+            format!("http://127.0.0.1:{GZIP_PORT}"),
+            "--".into(),
+            "python3".into(),
+            agent.display().to_string(),
+        ],
+        launch_dir: dir.clone(),
+        name: name.map(str::to_string),
+        env: vec![("PYTHONPATH".into(), client_path().display().to_string())],
+        auto: false,
+        watch: None,
+    };
+
+    let provider = Provider::start(&provider_script, GZIP_PORT);
+    let recorded = engine::run(&repo, &spec(Some("gzipped")), Mode::Record, None)
+        .expect("recording through the proxy should work")
+        .trajectory
+        .expect("a recording produces a trajectory");
+
+    let bodies = recorded_bodies(&repo, &recorded);
+    for (outcome, value) in &bodies {
+        assert_eq!(
+            *outcome,
+            EffectOutcome::Value,
+            "the call should have succeeded: {value}"
+        );
+        assert!(
+            !value.to_string().contains(LOST),
+            "the recording holds bytes the recorder could not read: {value}"
+        );
+    }
+    let body = bodies
+        .iter()
+        .find_map(|(_, value)| value["body"].as_str())
+        .expect("the wire response should be in the trajectory");
+    let parsed: serde_json::Value =
+        serde_json::from_str(body).expect("a recorded body should be readable as it stands");
+    assert_eq!(
+        parsed["content"][0]["text"], "four",
+        "the trajectory should hold the reply, not a compressed copy of it"
+    );
+    assert_eq!(
+        parsed["asked_for"], "identity",
+        "the proxy should not ask upstream for a coding it cannot read back"
+    );
+
+    assert_eq!(
+        fs::read_to_string(repo.workspace_dir("gzipped").join("answer.txt")).unwrap(),
+        "four:Message",
+        "the agent should have received a real SDK object, not gzip bytes"
+    );
+
+    // Take the provider away: whatever the replay serves came out of the recording.
+    provider.stop();
+
+    let report = engine::run(
+        &repo,
+        &spec(None),
+        Mode::Replay { live: Vec::new() },
+        Some(&recorded),
+    )
+    .expect("replay should run to completion");
+    assert!(report.faithful(), "{:?}", report.divergences);
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// When the body cannot be recorded, the recording says so instead of guessing.
+///
+/// Requesting only `identity` stops this happening by accident, but a provider is
+/// free to ignore that, and the recorder is the last place a lie can be caught. A
+/// content coding we cannot undo — over bytes that are not text either — has no
+/// honest representation in a trajectory, so the call fails with the reason in it.
+#[test]
+fn a_content_coding_we_cannot_decode_fails_the_call_instead_of_being_recorded() {
+    if !sdk_available() {
+        eprintln!("SKIP: proxy test needs the anthropic SDK (pip install anthropic)");
+        return;
+    }
+
+    let dir = scratch("proxy-opaque");
+    let provider_script = dir.join("provider.py");
+    fs::write(&provider_script, OPAQUE_PROVIDER).unwrap();
+    let agent = dir.join("agent.py");
+    fs::write(&agent, REPORTING_AGENT).unwrap();
+
+    let repo = Repo::open(&dir).unwrap();
+    let spec = RunSpec {
+        command: vec![
+            "python3".into(),
+            "-m".into(),
+            "noidroid.proxy".into(),
+            "--upstream".into(),
+            format!("http://127.0.0.1:{OPAQUE_PORT}"),
+            "--".into(),
+            "python3".into(),
+            agent.display().to_string(),
+        ],
+        launch_dir: dir.clone(),
+        name: Some("opaque".into()),
+        env: vec![("PYTHONPATH".into(), client_path().display().to_string())],
+        auto: false,
+        watch: None,
+    };
+
+    let provider = Provider::start(&provider_script, OPAQUE_PORT);
+    let recorded = engine::run(&repo, &spec, Mode::Record, None)
+        .expect("the run itself should complete; only the call fails")
+        .trajectory
+        .expect("a refused call is still part of what happened");
+    provider.stop();
+
+    let answer = fs::read_to_string(repo.workspace_dir("opaque").join("answer.txt")).unwrap();
+    assert!(
+        !answer.starts_with("answered:"),
+        "the agent must not be handed a body the recorder could not read: {answer}"
+    );
+    assert!(
+        answer.contains("content-encoding") && answer.contains("br"),
+        "a refusal is only a feature if it says why: {answer}"
+    );
+
+    let bodies = recorded_bodies(&repo, &recorded);
+    for (_, value) in &bodies {
+        assert!(
+            !value.to_string().contains(LOST),
+            "the recording holds bytes the recorder could not read: {value}"
+        );
+    }
+    let refusal = bodies
+        .iter()
+        .filter(|(outcome, _)| *outcome == EffectOutcome::Error)
+        .filter_map(|(_, value)| value["error"].as_str().map(str::to_string))
+        .next()
+        .unwrap_or_else(|| panic!("the refusal should be in the trajectory: {bodies:?}"));
+    assert!(
+        refusal.contains("content-encoding") && refusal.contains("br"),
+        "the recorded failure should name what could not be decoded: {refusal}"
     );
 
     let _ = fs::remove_dir_all(&dir);


### PR DESCRIPTION
Closes #56

## The bug

`clients/python/noidroid/proxy.py` forwarded the agent's `accept-encoding` upstream, then stripped `Content-Encoding` from the response while forwarding the compressed body verbatim. Two consequences:

1. The agent got `JSONDecodeError` on a gzipped reply.
2. `perform()` stored `payload.decode("utf-8", "replace")`, so the compressed bytes went into the trajectory as U+FFFD replacement characters — lossy, irreversible, unlabelled, and indistinguishable from a real recording.

The second is the one this project cannot survive. A recording that cannot be read back is only survivable if it says so.

## The fix

**Ask for what we can read.** `accept-encoding` joins `SKIP_REQUEST_HEADERS` and the upstream request sends `Accept-Encoding: identity`. The SDK is none the wiser — it decompresses transparently, so it gets the same object either way.

**Record the plain body, not the wire bytes.** If a provider compresses regardless, `_inflate()` undoes gzip / x-gzip / deflate (both zlib-wrapped and raw) before anything is recorded. The trajectory then holds a body you can read as it stands, and the stripped `Content-Encoding` header is finally an honest description of the bytes under it. Recording the compressed form instead would store a body nobody can read without a header we threw away, and would make the content address depend on the provider's compression level.

**Refuse the rest, loudly, with the reason.** `_text()` decodes strictly; `errors="replace"` is gone from the recording path, request side included, because undecodable bytes reaching a trajectory unlabelled is a hole independent of gzip. A content coding we do not implement, a body that is not valid UTF-8, or a compressed event stream (which we cannot inflate without buffering, and buffering breaks `a_streamed_response_reaches_the_client_before_it_ends`) raises `Unrecordable`. That becomes an error effect in the trajectory *and* a `502` whose body carries the reason, so the agent sees it too:

```
InternalServerError: noidroid.proxy: the provider answered with content-encoding 'br',
which this proxy cannot decode. Recording it would store bytes that no longer say how
to read them.
```

## What the tests prove

Both drive real processes over the real protocol — a stand-in provider, the real proxy, the real Anthropic SDK, the real engine.

`a_compressed_response_is_never_recorded_as_replacement_characters` — the provider gzips **whether or not it was asked to**, because a recorder that only copes when it opted in lies the first time a provider changes its mind. It asserts no recorded effect value contains a replacement character, that the recorded body parses as JSON on its own, that the provider saw `Accept-Encoding: identity`, that the agent got a real `Message`, and that the replay is faithful with the provider shut down.

`a_content_coding_we_cannot_decode_fails_the_call_instead_of_being_recorded` — the provider answers `Content-Encoding: br` over bytes that are not text. It asserts no recorded value contains a replacement character, that the trajectory holds an `EffectOutcome::Error` naming the coding, and that the agent was told why.

Verified both fail on `main`'s proxy — with the assertion firing on the corrupted body itself, not on a downstream symptom. The failure message printed the recorded body as a wall of replacement characters, which is exactly the trajectory this change makes impossible.

The two pre-existing proxy tests still pass unchanged.

## Verified

- `cargo fmt --all`, `cargo clippy --all-targets -- -D warnings`, `cargo test --all` — all clean, 90 tests, 0 failures.
- Both new tests fail without the proxy change (stashed it and reran).
- The refusal reaching the agent, by running `python -m noidroid.proxy` by hand against a `br` provider.

## Not verified

- **No real provider.** Everything is against stand-ins. I did not put this in front of `api.anthropic.com`, so I have not confirmed a real endpoint honours `Accept-Encoding: identity` — though the inflate path exists precisely because it might not.
- **Brotli and zstd bodies are refused on the label**, before any decode is attempted. The opaque stand-in therefore sends non-brotli bytes; the refusal does not depend on them.
- **Deflate** is covered by code, not by a test. Only gzip has a stand-in.
- **Existing trajectories may already be corrupt.** Any recording made through `--proxy` against a provider that compressed holds mangled bodies today, and nothing detects or reports that — the trajectory reads as valid. Nothing here repairs or flags them; that is a separate problem, filed as #70. No trajectories are committed to this repo, so nothing in-tree is affected.
- **A body that is not text can no longer be recorded at all** (file downloads, audio). This is now a loud refusal rather than a silent corruption, which is the right trade, but it is a real narrowing of what the proxy accepts. Filed as #72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
