### PR TITLE
fix(engine): name the clock or the random id that made a replay diverge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,20 @@ how the package version relates to `STEP_VERSION`, the on-disk object format.
 
 ### Changed
 
+- **A divergence caused by a clock or a random id now says so.** A timestamp or a UUID
+  in a call argument makes every replay diverge, and the report named two long values
+  and left the reader to notice that one of them was a clock — then guessed, wrongly,
+  that an interaction had been inserted, because nothing in the recording matches a
+  value that is new every run. The argument is now named at its full path, the source
+  is read off the value (`unix nanoseconds`, `ISO-8601`, a UUID, a random token) and
+  the remedy comes with the key already filled in: `volatile=["sent_at"]`, or route
+  the value through `nd.call()`. The same value written into the watched workspace
+  produces a `state_mismatch` that `volatile=` cannot reach at all, so that report now
+  names the file, names the value inside it, and says plainly that `volatile=` is not
+  the fix and why — the workspace is hashed whole. Detection only: the clock is not
+  frozen and nothing is suppressed. A freeze covers most clocks and not all, which
+  trades a loud mismatch for a quietly wrong value, and every claim here is worded as
+  a reading of the evidence because that is all it is. (#30)
 - **A divergence report now names an insertion, not just the fields that differ.** It
   could already say "this call is recorded at step N, it looks like interactions were
   removed" and had no symmetric sentence: add a call and the reader got a target and an

--- a/crates/noidroid-core/src/engine.rs
+++ b/crates/noidroid-core/src/engine.rs
@@ -30,7 +30,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use serde_json::{json, Value};
 
 use crate::checkpoint;
-use crate::env::{Environment, Grip, Situation, State, Workspace};
+use crate::env::{Environment, Grip, Situation, State, Workspace, WORLD_DIR};
 use crate::error::{Doing, Error, Result};
 use crate::hash::Digest;
 use crate::model::{
@@ -40,6 +40,7 @@ use crate::model::{
 use crate::proto::{Request, Response};
 use crate::repo::Repo;
 use crate::tree;
+use crate::volatility;
 
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 const POLL: Duration = Duration::from_millis(5);
@@ -1027,6 +1028,84 @@ impl<'a> Session<'a> {
         format!("{}:{kind}:{target}", self.index)
     }
 
+    /// Say what actually differs in the world, and — when a difference is a value no
+    /// re-execution could have reproduced — name it and name the remedy.
+    ///
+    /// Two tree addresses is a true report and an unreadable one. This is the state
+    /// mismatch's version of [`describe_mismatch`]. It is deliberately quiet when it
+    /// has nothing to say: a guess about which byte became which is the fuzzy
+    /// matching this project refuses everywhere else.
+    fn describe_state(&self, recorded: &Digest, observed: &Digest) -> Result<String> {
+        /// Enough to see the shape of the change without burying the divergence.
+        const SHOWN: usize = 6;
+
+        let was = tree::read(recorded, &self.repo.store)?;
+        let now = tree::read(observed, &self.repo.store)?;
+        let left: BTreeMap<&str, &Digest> = was
+            .entries
+            .iter()
+            .map(|e| (e.path.as_str(), &e.blob))
+            .collect();
+        let right: BTreeMap<&str, &Digest> = now
+            .entries
+            .iter()
+            .map(|e| (e.path.as_str(), &e.blob))
+            .collect();
+        let changed = tree::diff(&was, &now);
+
+        let mut lines: Vec<String> = Vec::new();
+        for (path, change) in changed.iter().take(SHOWN) {
+            let what = match change {
+                tree::Change::Added => "not in the recording",
+                tree::Change::Removed => "recorded, absent now",
+                tree::Change::Modified => "differs",
+            };
+            // A `.world/` entry is a program's report about a world we cannot see,
+            // not a file anyone can go and edit. Saying "differs" about it without
+            // saying that would send the reader looking for a path that is not there.
+            let kind = if is_reported_world(path) {
+                " (a world the program reports, not a file)"
+            } else {
+                ""
+            };
+            lines.push(format!("{path}: {what}{kind}"));
+        }
+        if changed.len() > SHOWN {
+            lines.push(format!("… and {} more", changed.len() - SHOWN));
+        }
+
+        // Only the workspace: a reported world has no bytes we could advise anyone
+        // to write differently.
+        let mut findings = Vec::new();
+        for (path, change) in &changed {
+            if !findings.is_empty() || *change != tree::Change::Modified || is_reported_world(path)
+            {
+                continue;
+            }
+            let (Some(before), Some(after)) = (left.get(path.as_str()), right.get(path.as_str()))
+            else {
+                continue;
+            };
+            findings = volatility::in_text(
+                path,
+                &self.repo.store.get(before)?,
+                &self.repo.store.get(after)?,
+            );
+        }
+        for finding in &findings {
+            lines.push(finding.line());
+            lines.push(format!("  {}", finding.source.why()));
+        }
+        if !findings.is_empty() {
+            lines.push(volatility::advice_for_workspace().to_string());
+        }
+
+        if lines.is_empty() {
+            return Ok(String::new());
+        }
+        Ok(format!("\n      {}", lines.join("\n      ")))
+    }
+
     /// Snapshot the workspace, build the step, store it, and — when reconstructing —
     /// check that it addresses the same object the recording did.
     fn commit(
@@ -1110,14 +1189,20 @@ impl<'a> Session<'a> {
                 if observed.root == rec.state_root {
                     self.report.state_verified += 1;
                 } else {
+                    let detail = format!(
+                        "the world hashes to {} but the recording says {}{}",
+                        observed.root.short(),
+                        rec.state_root.short(),
+                        // Best effort, and deliberately: the divergence is the
+                        // finding, the explanation is commentary, and commentary
+                        // that can fail must never take the finding down with it.
+                        self.describe_state(&rec.state_root, &observed.root)
+                            .unwrap_or_default()
+                    );
                     self.report.divergences.push(Divergence {
                         index: self.index,
                         kind: DivergenceKind::StateMismatch,
-                        detail: format!(
-                            "the world hashes to {} but the recording says {}",
-                            observed.root.short(),
-                            rec.state_root.short()
-                        ),
+                        detail,
                     });
                 }
                 observed.root
@@ -1243,6 +1328,10 @@ fn describe_mismatch(
     index: u64,
 ) -> String {
     let mut lines: Vec<String> = Vec::new();
+    // Values that changed for a reason that has nothing to do with what the program
+    // did. Found separately from the field diff because they change what the rest of
+    // this report is allowed to conclude.
+    let mut unreproducible: Vec<volatility::Finding> = Vec::new();
 
     match (recorded, incoming) {
         (
@@ -1267,7 +1356,18 @@ fn describe_mismatch(
                     now_effect.label()
                 ));
             }
-            lines.extend(diff_values("args", was_args, now_args));
+            unreproducible = volatility::find("args", was_args, now_args);
+            // A finding says everything the field diff for the same path says and
+            // then why, so the diff line for that path would only be read twice.
+            let superseded: Vec<String> = unreproducible
+                .iter()
+                .map(|f| format!("{}: ", f.path))
+                .collect();
+            lines.extend(
+                diff_values("args", was_args, now_args)
+                    .into_iter()
+                    .filter(|line| !superseded.iter().any(|p| line.starts_with(p))),
+            );
         }
         (
             Action::Decide {
@@ -1293,10 +1393,22 @@ fn describe_mismatch(
         )),
     }
 
+    // A clock or a fresh id in the arguments is the cause a positional report
+    // explains worst: every field diff is correct, nothing in the recording matches,
+    // and the reader is left to notice that one of the numbers is a timestamp. Say
+    // it — and skip the guesswork below, which would otherwise announce an inserted
+    // interaction that was never inserted.
+    if !unreproducible.is_empty() {
+        for finding in &unreproducible {
+            lines.push(finding.line());
+            lines.push(format!("  {}", finding.source.why()));
+        }
+        lines.push(volatility::advice_for_arguments(&unreproducible));
+    }
     // The most common cause of a mismatch is an inserted or removed interaction, not
     // a changed one. If what the run wants is sitting further along the recording,
     // say so — it turns a puzzle into a one-line explanation.
-    if let Some(found) = chain
+    else if let Some(found) = chain
         .iter()
         .enumerate()
         .skip(index as usize + 1)
@@ -1336,6 +1448,11 @@ fn describe_mismatch(
         return "the actions differ".to_string();
     }
     format!("\n      {}", lines.join("\n      "))
+}
+
+/// Whether a tree path holds a reported world rather than a workspace file.
+fn is_reported_world(path: &str) -> bool {
+    path == WORLD_DIR || path.starts_with(&format!("{WORLD_DIR}/"))
 }
 
 /// Field-by-field for objects; whole-value otherwise.

--- a/crates/noidroid-core/src/lib.rs
+++ b/crates/noidroid-core/src/lib.rs
@@ -23,6 +23,7 @@ pub mod proto;
 pub mod repo;
 pub mod store;
 pub mod tree;
+pub mod volatility;
 
 pub use env::{Environment, Grip};
 pub use error::{Doing, Error, Result};

--- a/crates/noidroid-core/src/volatility.rs
+++ b/crates/noidroid-core/src/volatility.rs
@@ -1,0 +1,409 @@
+//! Why a value differs between two runs.
+//!
+//! `args.sent_at: recorded 1787295011714313965, got 1787295011862833195` is true and
+//! leaves the reader to notice that one of those numbers is a clock, and then to
+//! work out which of two remedies applies. This module does that step: it reads a
+//! pair of differing values and, when the difference has an obvious non-deterministic
+//! source, names the source and the remedy.
+//!
+//! Detection, never suppression. The tempting fix for a clock is to freeze it, and
+//! it is the wrong one: no freeze covers every clock a program can reach, and one
+//! that covers most of them turns a *loud* mismatch into a *silently wrong value* —
+//! fail-open, which is the inversion this project must not make. So nothing here
+//! changes what a run observes. It only makes the loud failure legible. See #30.
+//!
+//! Every claim is a reading of the evidence and is worded as one. A number in the
+//! unix-seconds window is very probably a clock; it is not proof, and the report
+//! says "looks like" because that is all it knows.
+
+use serde_json::Value;
+
+use crate::model::compact_value;
+
+/// At most this many findings per report. Past a handful the reader stops reading,
+/// and the fourth timestamp says nothing the first did not.
+const MAX: usize = 4;
+
+/// Shorter than this, a run of hex digits is too easy to hit by accident to name.
+const MIN_TOKEN: usize = 16;
+
+/// The unit a clock reading appears to be in.
+///
+/// Named because `1787295011714313965` is not a readable date, and "unix
+/// nanoseconds" tells the reader which call to go and look for.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Unit {
+    Seconds,
+    Millis,
+    Micros,
+    Nanos,
+    Iso8601,
+}
+
+impl Unit {
+    pub fn label(self) -> &'static str {
+        match self {
+            Unit::Seconds => "unix seconds",
+            Unit::Millis => "unix milliseconds",
+            Unit::Micros => "unix microseconds",
+            Unit::Nanos => "unix nanoseconds",
+            Unit::Iso8601 => "ISO-8601",
+        }
+    }
+}
+
+/// What appears to have produced a value that changed without the program changing.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Source {
+    Clock(Unit),
+    Uuid,
+    /// Same-length hexadecimal that changed completely: a nonce, a session token, a
+    /// random id. The length is carried because it is most of the evidence.
+    Token(usize),
+}
+
+impl Source {
+    /// A reading of the evidence, worded as one.
+    pub fn reading(self) -> String {
+        match self {
+            Source::Clock(unit) => format!("looks like a clock reading ({})", unit.label()),
+            Source::Uuid => "looks like a UUID".to_string(),
+            Source::Token(len) => {
+                format!(
+                    "looks like a random token ({len} hexadecimal characters, wholly different)"
+                )
+            }
+        }
+    }
+
+    /// Why no re-execution can produce the recorded value.
+    pub fn why(self) -> &'static str {
+        match self {
+            Source::Clock(_) => {
+                "a clock advances between runs, so re-executing cannot land on the recorded value"
+            }
+            Source::Uuid => "a UUID is drawn fresh every time it is generated",
+            Source::Token(_) => "a random token is drawn fresh every time it is generated",
+        }
+    }
+}
+
+/// One value that changed for a reason that has nothing to do with what the program did.
+#[derive(Clone, Debug)]
+pub struct Finding {
+    /// Where it sits, for the reader: `args.meta.sent_at`, or a workspace path.
+    pub path: String,
+    /// The key `volatile=` would name. `None` when the value is not under a key.
+    pub key: Option<String>,
+    pub source: Source,
+    pub was: String,
+    pub now: String,
+}
+
+impl Finding {
+    pub fn line(&self) -> String {
+        format!(
+            "{} {}: recorded {}, got {}",
+            self.path,
+            self.source.reading(),
+            self.was,
+            self.now
+        )
+    }
+}
+
+/// Non-deterministic values among two versions of a structured value.
+///
+/// Walks both sides together, so a timestamp buried in a nested payload is named at
+/// its full path rather than as "this object changed". Positions that do not line up
+/// — an object that gained a key, arrays of different lengths — are left alone:
+/// nothing can be said about them without guessing which value corresponds to which.
+pub fn find(root: &str, was: &Value, now: &Value) -> Vec<Finding> {
+    let mut out = Vec::new();
+    walk(root, None, was, now, &mut out);
+    out
+}
+
+fn walk(path: &str, key: Option<&str>, was: &Value, now: &Value, out: &mut Vec<Finding>) {
+    if out.len() >= MAX || was == now {
+        return;
+    }
+    match (was, now) {
+        (Value::Object(a), Value::Object(b)) => {
+            for (name, left) in a {
+                if let Some(right) = b.get(name) {
+                    walk(&format!("{path}.{name}"), Some(name), left, right, out);
+                }
+            }
+        }
+        (Value::Array(a), Value::Array(b)) if a.len() == b.len() => {
+            // The enclosing key travels with the elements: `volatile=` names keys,
+            // and the key that holds a list of timestamps is the one to declare.
+            for (i, (left, right)) in a.iter().zip(b).enumerate() {
+                walk(&format!("{path}[{i}]"), key, left, right, out);
+            }
+        }
+        _ => {
+            if let Some(source) = classify(was, now) {
+                out.push(Finding {
+                    path: path.to_string(),
+                    key: key.map(str::to_string),
+                    source,
+                    was: compact_value(was),
+                    now: compact_value(now),
+                });
+            }
+        }
+    }
+}
+
+/// Non-deterministic values inside two versions of the same file.
+///
+/// The two versions are cut into tokens and compared position by position. When the
+/// token counts disagree the file changed shape as well as content, nothing lines
+/// up, and the honest output is nothing at all — a guess about which token became
+/// which is exactly the fuzzy matching this project refuses elsewhere.
+pub fn in_text(path: &str, was: &[u8], now: &[u8]) -> Vec<Finding> {
+    let (Ok(left), Ok(right)) = (std::str::from_utf8(was), std::str::from_utf8(now)) else {
+        return Vec::new();
+    };
+    let (left, right) = (tokens(left), tokens(right));
+    if left.len() != right.len() {
+        return Vec::new();
+    }
+    let mut out = Vec::new();
+    for (a, b) in left.iter().zip(&right) {
+        if out.len() >= MAX {
+            break;
+        }
+        if let Some(source) = classify_str(a, b) {
+            out.push(Finding {
+                path: path.to_string(),
+                key: None,
+                source,
+                was: format!("{a:?}"),
+                now: format!("{b:?}"),
+            });
+        }
+    }
+    out
+}
+
+/// Maximal runs of the characters a timestamp, a UUID or a token is written with, so
+/// that `"created": 1787295011714313965` and `2026-08-20T09:12:33` each stay whole.
+fn tokens(text: &str) -> Vec<&str> {
+    text.split(|c: char| !(c.is_ascii_alphanumeric() || matches!(c, '_' | '.' | ':' | '-' | '+')))
+        .filter(|t| !t.is_empty())
+        .collect()
+}
+
+/// What the caller can actually do about a non-deterministic call argument.
+///
+/// Both remedies are deliberate acts by the author, because the only automatic one
+/// would be a clock freeze.
+pub fn advice_for_arguments(findings: &[Finding]) -> String {
+    let mut keys: Vec<&str> = Vec::new();
+    for key in findings.iter().filter_map(|f| f.key.as_deref()) {
+        if !keys.contains(&key) {
+            keys.push(key);
+        }
+    }
+    let declared = if keys.is_empty() {
+        "volatile=[…]".to_string()
+    } else {
+        let list = keys
+            .iter()
+            .map(|k| format!("{k:?}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("volatile=[{list}]")
+    };
+    format!(
+        "this is not a change in what the program did. Either leave the value out of \
+         the call's identity — nd.call(…, {declared}) — or obtain it through nd.call() \
+         so the recording supplies it on replay."
+    )
+}
+
+/// The case `volatile=` cannot reach, said plainly instead of left to be discovered.
+///
+/// A reader who has just met `volatile=` will reach for it here first, spend an hour,
+/// and find that the argument list has nothing to do with it.
+pub fn advice_for_workspace() -> &'static str {
+    "volatile= cannot help here: it leaves an argument out of a call's identity, and \
+     this value is in the workspace, which is hashed whole. Write it through \
+     nd.call(…, effect=WRITE) instead, so the replay restores the recorded bytes \
+     rather than computing a new value — or, in a watched project, name the file in \
+     .noidroidignore so it is deliberately not recorded."
+}
+
+/// Read a pair of differing values. `None` when they agree, or when nothing about
+/// the difference points at a source.
+pub fn classify(was: &Value, now: &Value) -> Option<Source> {
+    match (was, now) {
+        (Value::Number(a), Value::Number(b)) if a != b => clock_band(a.as_f64()?, b.as_f64()?),
+        (Value::String(a), Value::String(b)) => classify_str(a, b),
+        _ => None,
+    }
+}
+
+fn classify_str(was: &str, now: &str) -> Option<Source> {
+    if was == now {
+        return None;
+    }
+    if is_uuid(was) && is_uuid(now) {
+        return Some(Source::Uuid);
+    }
+    if is_iso8601(was) && is_iso8601(now) {
+        return Some(Source::Clock(Unit::Iso8601));
+    }
+    if let (Ok(a), Ok(b)) = (was.trim().parse::<f64>(), now.trim().parse::<f64>()) {
+        if let Some(source) = clock_band(a, b) {
+            return Some(source);
+        }
+    }
+    if was.len() == now.len()
+        && was.len() >= MIN_TOKEN
+        && was.bytes().all(|c| c.is_ascii_hexdigit())
+        && now.bytes().all(|c| c.is_ascii_hexdigit())
+    {
+        return Some(Source::Token(was.len()));
+    }
+    None
+}
+
+/// Both readings inside the same epoch window.
+///
+/// The window for seconds runs from 2001 to 2033, and each larger unit is that
+/// window times a thousand. Wide enough to catch a real clock, narrow enough that an
+/// ordinary counter, an id or a size does not land in one — and requiring *both*
+/// sides to land in the *same* window is most of what keeps this from crying wolf.
+fn clock_band(was: f64, now: f64) -> Option<Source> {
+    const UNITS: [(f64, Unit); 4] = [
+        (1.0, Unit::Seconds),
+        (1e3, Unit::Millis),
+        (1e6, Unit::Micros),
+        (1e9, Unit::Nanos),
+    ];
+    UNITS
+        .iter()
+        .find(|(scale, _)| {
+            let window = (1e9 * scale)..(2e9 * scale);
+            window.contains(&was) && window.contains(&now)
+        })
+        .map(|(_, unit)| Source::Clock(*unit))
+}
+
+/// 8-4-4-4-12 hexadecimal. The version nibble is deliberately not read: a v1 UUID
+/// carries a clock and a v4 carries randomness, and both are equally unreproducible.
+fn is_uuid(text: &str) -> bool {
+    let mut parts = text.split('-');
+    for width in [8, 4, 4, 4, 12] {
+        match parts.next() {
+            Some(part) if part.len() == width && part.bytes().all(|c| c.is_ascii_hexdigit()) => {}
+            _ => return false,
+        }
+    }
+    parts.next().is_none()
+}
+
+/// `YYYY-MM-DD` then `T` or a space then `HH:MM`. Whatever follows — seconds, a
+/// fraction, an offset — does not change the reading.
+fn is_iso8601(text: &str) -> bool {
+    let b = text.as_bytes();
+    b.len() >= 16
+        && b[..4].iter().all(u8::is_ascii_digit)
+        && b[4] == b'-'
+        && b[5..7].iter().all(u8::is_ascii_digit)
+        && b[7] == b'-'
+        && b[8..10].iter().all(u8::is_ascii_digit)
+        && (b[10] == b'T' || b[10] == b' ')
+        && b[11..13].iter().all(u8::is_ascii_digit)
+        && b[13] == b':'
+        && b[14..16].iter().all(u8::is_ascii_digit)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn a_clock_is_read_in_the_unit_it_was_written_in() {
+        for (was, now, unit) in [
+            (json!(1787295011.0), json!(1787295012.5), Unit::Seconds),
+            (
+                json!(1787295011714u64),
+                json!(1787295011999u64),
+                Unit::Millis,
+            ),
+            (
+                json!(1787295011714313u64),
+                json!(1787295011862833u64),
+                Unit::Micros,
+            ),
+            (
+                json!(1787295011714313965u64),
+                json!(1787295011862833195u64),
+                Unit::Nanos,
+            ),
+        ] {
+            assert_eq!(classify(&was, &now), Some(Source::Clock(unit)));
+        }
+        assert_eq!(
+            classify(
+                &json!("2026-08-20T09:12:33Z"),
+                &json!("2026-08-20T09:12:41Z")
+            ),
+            Some(Source::Clock(Unit::Iso8601))
+        );
+    }
+
+    #[test]
+    fn an_ordinary_changed_value_is_not_called_a_clock() {
+        // Being wrong here is worse than saying nothing: a confident wrong cause
+        // sends the reader away from the real change.
+        for (was, now) in [
+            (json!(1), json!(2)),
+            (json!(41), json!(9001)),
+            (json!("paris"), json!("london")),
+            // In the seconds window, but so is anything counted in billions. Only
+            // one side is: nothing to read.
+            (json!(1787295011u64), json!(7)),
+            (json!("deadbeef"), json!("cafebabe")), // eight characters is not a token
+        ] {
+            assert_eq!(classify(&was, &now), None, "{was} -> {now}");
+        }
+    }
+
+    #[test]
+    fn a_buried_timestamp_is_named_at_its_full_path() {
+        let found = find(
+            "args",
+            &json!({"query": "flights", "meta": {"sent_at": 1787295011714313965u64}}),
+            &json!({"query": "flights", "meta": {"sent_at": 1787295011862833195u64}}),
+        );
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].path, "args.meta.sent_at");
+        assert_eq!(found[0].key.as_deref(), Some("sent_at"));
+        assert!(advice_for_arguments(&found).contains("volatile=[\"sent_at\"]"));
+    }
+
+    #[test]
+    fn text_that_changed_shape_is_not_guessed_at() {
+        // One version has a token the other does not, so no two tokens are known to
+        // correspond. Saying nothing is the honest answer.
+        assert!(in_text("a.log", b"started at 1787295011714313965", b"started").is_empty());
+    }
+
+    #[test]
+    fn a_timestamp_inside_a_file_is_found() {
+        let found = in_text(
+            "run.log",
+            b"started at 1787295011714313965\n",
+            b"started at 1787295011862833195\n",
+        );
+        assert_eq!(found.len(), 1);
+        assert!(matches!(found[0].source, Source::Clock(Unit::Nanos)));
+    }
+}

--- a/crates/noidroid-core/tests/nondeterminism_slice.rs
+++ b/crates/noidroid-core/tests/nondeterminism_slice.rs
@@ -1,0 +1,208 @@
+//! A divergence caused by a clock or a random id explains itself.
+//!
+//! Both of these are loud already — a timestamp in a call argument mismatches, a
+//! timestamp in the workspace mismatches the state hash. Loud is not the problem.
+//! The problem is that the report names two hex digests and leaves the reader to
+//! work out that a clock got in, and which of the two remedies applies. One of them
+//! (`volatile=`) does not reach the workspace at all, and a report that does not say
+//! so sends the reader after a fix that cannot work.
+//!
+//! Detection and reporting, never suppression: freezing the clock would replace a
+//! loud mismatch with a quietly wrong value, which is the inversion this project
+//! must not make. See #30.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use noidroid_core::engine::{self, Divergence, DivergenceKind, Mode, RunSpec};
+use noidroid_core::Repo;
+
+/// A clock reading in a call argument. Nanoseconds, so two runs cannot collide.
+const CLOCK_IN_ARGS: &str = r#"
+import time
+import noidroid
+
+nd = noidroid.connect()
+nd.call(
+    "api.fetch",
+    lambda: {"ok": True},
+    args={"query": "flights", "meta": {"sent_at": time.time_ns()}},
+)
+nd.finish("success", {})
+"#;
+
+/// A fresh request id in a call argument.
+const UUID_IN_ARGS: &str = r#"
+import uuid
+import noidroid
+
+nd = noidroid.connect()
+nd.call(
+    "api.fetch",
+    lambda: {"ok": True},
+    args={"query": "flights", "request_id": str(uuid.uuid4())},
+)
+nd.finish("success", {})
+"#;
+
+/// A clock reading written straight into the watched workspace, outside any
+/// mediated call. `volatile=` has no purchase on this one.
+const CLOCK_IN_WORKSPACE: &str = r#"
+import pathlib, time
+import noidroid
+
+nd = noidroid.connect()
+pathlib.Path("run.log").write_text("started at %d\n" % time.time_ns())
+nd.call("api.fetch", lambda: {"ok": True}, args={"query": "flights"})
+nd.finish("success", {})
+"#;
+
+struct Fixture {
+    dir: PathBuf,
+    repo: Repo,
+    agent: PathBuf,
+}
+
+impl Fixture {
+    fn new(tag: &str, source: &str) -> Fixture {
+        let dir = std::env::temp_dir().join(format!(
+            "noidroid-nondet-{tag}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        let agent = dir.join("agent.py");
+        fs::write(&agent, source).unwrap();
+        let repo = Repo::open(&dir).unwrap();
+        Fixture { dir, repo, agent }
+    }
+
+    fn spec(&self, name: Option<&str>) -> RunSpec {
+        let client = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../clients/python")
+            .canonicalize()
+            .unwrap();
+        RunSpec {
+            command: vec!["python3".into(), self.agent.display().to_string()],
+            launch_dir: self.dir.clone(),
+            name: name.map(str::to_string),
+            env: vec![("PYTHONPATH".into(), client.display().to_string())],
+            auto: false,
+            watch: None,
+        }
+    }
+
+    /// Record once, replay once, and hand back the divergence of `kind`.
+    fn divergence(&self, kind: DivergenceKind) -> Divergence {
+        let recorded = engine::run(&self.repo, &self.spec(Some("run-1")), Mode::Record, None)
+            .unwrap()
+            .trajectory
+            .unwrap();
+        let report = engine::run(
+            &self.repo,
+            &self.spec(None),
+            Mode::Replay { live: Vec::new() },
+            Some(&recorded),
+        )
+        .unwrap();
+        report
+            .divergences
+            .iter()
+            .find(|d| d.kind == kind)
+            .cloned()
+            .unwrap_or_else(|| {
+                panic!(
+                    "expected a {} divergence, got {:?}",
+                    kind.label(),
+                    report.divergences
+                )
+            })
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.dir);
+    }
+}
+
+#[test]
+fn a_divergence_caused_by_a_timestamp_says_so() {
+    let f = Fixture::new("clock-args", CLOCK_IN_ARGS);
+    let d = f.divergence(DivergenceKind::KeyMismatch);
+
+    assert!(
+        d.detail.contains("sent_at"),
+        "the report has to name the argument that carries the clock, got {}",
+        d.detail
+    );
+    assert!(
+        d.detail.contains("clock"),
+        "the report has to name the cause, not just the two numbers, got {}",
+        d.detail
+    );
+    assert!(
+        d.detail.contains("volatile=[\"sent_at\"]"),
+        "the report has to name the remedy, with the key already filled in, got {}",
+        d.detail
+    );
+    // Positional matching cannot find this call anywhere in the recording, so the
+    // insertion heuristic would otherwise claim the interaction was added here. It
+    // was not; a clock got into it, and we know that.
+    assert!(
+        !d.detail.contains("added here"),
+        "a known cause must not be reported as a guess about an inserted call, got {}",
+        d.detail
+    );
+}
+
+#[test]
+fn a_divergence_caused_by_a_uuid_says_so() {
+    let f = Fixture::new("uuid-args", UUID_IN_ARGS);
+    let d = f.divergence(DivergenceKind::KeyMismatch);
+
+    assert!(
+        d.detail.contains("request_id") && d.detail.contains("UUID"),
+        "the report has to name the argument and say it is a UUID, got {}",
+        d.detail
+    );
+    assert!(
+        d.detail.contains("volatile=[\"request_id\"]"),
+        "the report has to name the remedy, got {}",
+        d.detail
+    );
+}
+
+#[test]
+fn a_timestamp_in_the_workspace_says_volatile_cannot_help() {
+    let f = Fixture::new("clock-state", CLOCK_IN_WORKSPACE);
+    let d = f.divergence(DivergenceKind::StateMismatch);
+
+    assert!(
+        d.detail.contains("run.log"),
+        "the report has to name the file that differs, not only the two tree \
+         addresses, got {}",
+        d.detail
+    );
+    assert!(
+        d.detail.contains("clock"),
+        "the report has to name the cause inside the file, got {}",
+        d.detail
+    );
+    // The remedy that works for a call argument does nothing here, and a reader who
+    // has just learned about `volatile=` will reach for it first.
+    assert!(
+        d.detail.contains("volatile= cannot help here"),
+        "the report has to say plainly that volatile= does not reach the workspace, \
+         got {}",
+        d.detail
+    );
+    assert!(
+        d.detail.contains("hashed whole"),
+        "and say why, got {}",
+        d.detail
+    );
+}


### PR DESCRIPTION
Closes #30

## What changed

A divergence caused by a value that is new every run now explains itself instead of printing two long values and leaving the reader to work it out.

New `crates/noidroid-core/src/volatility.rs` reads a *pair* of differing values and, when the difference has an obvious non-deterministic source, names it:

- a number in the unix seconds / milliseconds / microseconds / nanoseconds window **on both sides**
- an ISO-8601 pair
- a UUID pair (8-4-4-4-12 hex; the version nibble is not read — v1 carries a clock, v4 carries randomness, both are equally unreproducible)
- same-length hexadecimal, 16 characters or more, that changed completely

Two call sites in `engine.rs` use it.

**`key_mismatch`** — the argument is named at its full path, walking into nested payloads, and the remedy arrives with the key already filled in:

```
divergence at step 1 (key_mismatch):
      args.meta: recorded {"sent_at":1787295189527295309}, got {"sent_at":1787295189771043902}
      args.meta.sent_at looks like a clock reading (unix nanoseconds): recorded 1787295189527295309, got 1787295189771043902
        a clock advances between runs, so re-executing cannot land on the recorded value
      this is not a change in what the program did. Either leave the value out of the
      call's identity — nd.call(…, volatile=["sent_at"]) — or obtain it through
      nd.call() so the recording supplies it on replay.
```

When a cause is found, the insertion heuristic added in #34 is skipped. It was actively wrong here: a value that is new every run appears nowhere in the recording, so the report used to announce an inserted interaction that was never inserted.

**`state_mismatch`** — the case `volatile=` cannot reach, which needed the treatment more. `the world hashes to 20eadbe768 but the recording says c0c34297e0` is true and unusable. It now names the files that differ, finds the value inside the one that changed, and refuses to imply a remedy that does not work:

```
divergence at step 1 (state_mismatch): the world hashes to 20eadbe768 but the recording says c0c34297e0
      run.log: differs
      run.log looks like a clock reading (unix nanoseconds): recorded "1787295214910684357", got "1787295215204359988"
        a clock advances between runs, so re-executing cannot land on the recorded value
      volatile= cannot help here: it leaves an argument out of a call's identity, and this
      value is in the workspace, which is hashed whole. Write it through
      nd.call(…, effect=WRITE) instead, so the replay restores the recorded bytes
      rather than computing a new value — or, in a watched project, name the file in
      .noidroidignore so it is deliberately not recorded.
```

## What I deliberately did NOT build

**A clock freeze.** The issue rules it out and it is right to: freezegun searches module-level imports and misses values held inside objects, time-machine is CPython-only, and a freeze that covers most clocks converts a *loud* mismatch into a *silently wrong value*. That is fail-open, the one inversion docs/direction.md says this project cannot make. Nothing in this diff changes what a run observes, what a divergence is, or when `Report::faithful()` is false. `detail` strings got longer; that is the whole behavioural change.

**Any claim stronger than the evidence.** Every reading is worded `looks like`. Both sides must agree before anything is named — one number in the unix-seconds window and one that is not gets no claim, because in isolation a large integer is also an id or a byte count. Misaligned values get no claim at all: an object that gained a key, arrays of different lengths, and a file whose token count changed are all left alone rather than guessed at, which would be the fuzzy matching rejected in #39.

**Non-hex random tokens** (base64, base58, ULIDs). Too easy to confuse with ordinary content for the false-positive budget a confident cause deserves.

**Record-time detection.** This fires at replay, which is the wrong end of "say what is not captured *before* a recording is trusted". Left out on purpose rather than bolted on: the pair comparison is what keeps this honest, and at record time there is only one value, so it is a different problem with a different false-positive budget. Filed as #71 with the reasoning.

One hardening worth naming: `describe_state` is called with `.unwrap_or_default()`. The divergence is the finding, the explanation is commentary, and commentary that can fail must never take the finding down with it.

## Verified

`crates/noidroid-core/tests/nondeterminism_slice.rs` — three tests driving real `python3` child processes over the real protocol, record then replay, no mocks. All three fail on `main`:

- `a_divergence_caused_by_a_timestamp_says_so` — asserts the argument is named, the cause is named, `volatile=["sent_at"]` appears with the key filled in, and that the report does **not** say `added here`. That last one is the regression the insertion heuristic was producing.
- `a_divergence_caused_by_a_uuid_says_so`
- `a_timestamp_in_the_workspace_says_volatile_cannot_help` — asserts the file is named, the cause is named, and the report says `volatile= cannot help here` and `hashed whole`. Fails on `main` with the bare two-digest message.

Plus six unit tests in `volatility.rs`, including `an_ordinary_changed_value_is_not_called_a_clock` — a confident wrong cause sends the reader away from the real change, so that one is the invariant that matters most.

Full gate, read not assumed: `cargo fmt --all`, `cargo clippy --all-targets -- -D warnings` clean, `cargo test --all` 96 passed / 0 failed. Chromium was present in this environment, so `browser_slice` ran rather than skipped; I did not verify the skip-cleanly path.

`STEP_VERSION` is untouched — no hashed object changed shape.

## Not verified

The heuristics are calibrated against the shapes in the tests plus the unit fixtures. I have not run them over a corpus of real recordings, so I cannot put a number on the false-positive rate in the wild; the design leans on requiring agreement on both sides to keep it low.

🤖 Generated with [Claude Code](https://claude.com/claude-code)