### PR TITLE
feat(cli): noidroid doctor says what a recording would not cover

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,10 @@ jobs:
             echo "::error::auto-capture test skipped on the job that installs the SDK"
             exit 1
           fi
+          if grep -q "SKIP: doctor SDK test" test-output.txt; then
+            echo "::error::doctor SDK test skipped on the job that installs the SDK"
+            exit 1
+          fi
 
   test-without-browser:
     name: tests (no browser installed)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ how the package version relates to `STEP_VERSION`, the on-disk object format.
 
 ### Added
 
+- **`noidroid doctor` — what a recording would and would not cover, before one is
+  made.** Automatic capture fails open by construction: every patching mechanism can
+  miss a surface, and a recording that missed one still looks real. `--auto` already
+  refused when it found a hole, but only for the holes it knew to look for and only at
+  the moment of recording, which is after the decision to trust it has been made. The
+  doctor asks first, and it answers with five words that are not interchangeable: `ok`
+  (we looked, it is covered), `absent` (we looked, there is nothing here to cover),
+  `not captured` (we looked, it is not — with the issue that tracks it), `not
+  determined` (we could not look, which is never a pass), and `blocked` (a recording
+  made now would be refused or would miss something, and the command exits non-zero).
+  Every answer is something the tool did rather than something it meant to do: the SDK
+  request surfaces are enumerated out of `_base_client` *after* running the real
+  installer, so a client class this build has never heard of appears unhooked rather
+  than invisible to both; the egress fence is ticked only once it has actually refused
+  a connection to a reserved address. `noidroid doctor -- python3 agent.py` also parses
+  the program and names, with file and line, the clock and randomness reads (#30) and
+  the subprocess launches (#31) it cannot capture — and because it does not follow
+  imports, a file with nothing in it is reported as `not determined` rather than as a
+  clean program. The async SDK surface (#33) and the hardcoded `AF_UNIX` (#32) are
+  named as the known limitations they are instead of being left to look covered. There
+  is no score, no percentage and no readiness grade. (#29)
 - **The ways a world fails, named.** `noidroid branch --inject <kind>` writes the
   intervention for you: `timeout`, `server-error`, `rate-limited`, `unauthorized`,
   `malformed`, `empty`. Writing the payload by hand is the difference between a thing

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -829,6 +829,7 @@ dependencies = [
  "clap",
  "noidroid-core",
  "ratatui",
+ "serde",
  "serde_json",
 ]
 

--- a/README.md
+++ b/README.md
@@ -469,6 +469,7 @@ noidroid diff run-1 alt-1
 | Command | |
 |---|---|
 | `noidroid run -- <cmd>` | run a program and record its trajectory |
+| `noidroid doctor [-- <cmd>]` | say what a recording would and would not cover, before making one |
 | `noidroid log [<traj>]` | list trajectories, or show one as a timeline |
 | `noidroid show <traj>@<step>` | inspect a checkpoint and how to explore from it |
 | `noidroid replay <traj>` | re-derive a trajectory and check it still hashes the same |
@@ -567,6 +568,55 @@ connections opened before the client loaded.
 replaying it makes the same one. Refusing costs you a run; recording anyway costs the
 trust in every run, because a trajectory that missed the model calls still looks real
 and still claims to replay faithfully.
+
+### Finding out before you record
+
+`--auto` refuses at the moment of recording, and only for the holes it knows to look
+for. `noidroid doctor` asks the same questions first:
+
+```console
+$ noidroid doctor -- python3 agent.py
+DOCTOR  what a recording made now would and would not cover
+
+  THE TOOL
+    python3       ok              3.12.3 at /usr/bin/python3
+    client        ok              importable from …/clients/python/noidroid/__init__.py
+    version       not determined  importable from source, not installed as a distribution
+    transport     ok              AF_UNIX on linux
+      · limit       Windows is excluded: the socket is hardcoded (#32)
+
+  CAPTURE SURFACES
+    anthropic     blocked         0.122.0 is installed, and 1 request surface present here is not hooked
+      · NOT hooked  anthropic._base_client.AsyncAPIClient.request (#33)
+      · hooked      anthropic._base_client.SyncAPIClient.request
+
+  THE PROGRAM
+    clock         not captured    2 sites in the 1 file scanned reach the clock or randomness (#30)
+      · agent.py:9  uuid.uuid4
+      · agent.py:9  time.time
+    subprocess    not captured    2 sites in the 1 file scanned start a child process (#31)
+
+  THE FENCE
+    egress        ok              installed on socket.socket.connect, and a connect to 203.0.113.1:80 was refused
+      · blind to    subprocesses (#31), C extensions that bypass Python's socket module, …
+```
+
+The five words are the feature, and they are not interchangeable. **ok** — we looked,
+and it is covered. **absent** — we looked, and there is nothing here to cover. **not
+captured** — we looked, and it is not, with the issue that tracks it. **not
+determined** — we could not look, which is never a pass. **blocked** — a recording made
+now would be refused or would miss something, and the command exits non-zero.
+
+Everything in it is something the tool did rather than something it intends: the
+surfaces are read back out of the SDK *after* running the real installer, so a class
+this build has never heard of shows up unhooked instead of being invisible to both; the
+fence is ticked only after it actually refused a connection to a reserved address. The
+scan of your program reads the files you named and does not follow imports, so a clean
+one reports *not determined* rather than a tick it did not earn.
+
+There is no score, no percentage and no readiness grade. A number nobody measured is
+the one failure this project cannot survive, and a green tick the tool did not earn is
+worse than no doctor at all.
 
 ## Integrating it by hand
 

--- a/clients/python/noidroid/doctor.py
+++ b/clients/python/noidroid/doctor.py
@@ -1,0 +1,307 @@
+"""What a recording would and would not cover, probed rather than assumed.
+
+`noidroid doctor` needs answers about a Python process it is not inside: which SDKs
+are importable, which of their request surfaces automatic capture actually patched,
+whether the egress fence really refuses a connection. Deciding any of that from Rust
+would produce a report about *intent* — the list of things we meant to hook — and the
+whole point of a preflight here is that automatic capture fails open, so intent is
+exactly the thing that must not be trusted.
+
+So this module runs the real `noidroid.auto.install` and `noidroid.fence.install` in a
+throwaway process, then reads back what is actually patched and whether a connect is
+actually refused. It also parses the program you are about to record, looking for the
+clock, randomness and subprocesses — the three holes that make a replay diverge or,
+worse, quietly miss what a child process did.
+
+It reports facts and no verdicts. Whether a fact is a pass, a known hole, or something
+nobody looked at is decided in one place, by the doctor, because that judgement is the
+part that has to stay honest.
+
+Output is one JSON object on stdout, behind a sentinel so that an SDK which prints on
+import cannot corrupt it. Run it as `python3 -m noidroid.doctor [command...]`.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import json
+import os
+import socket
+import sys
+from typing import Any, Optional
+
+__all__ = ["main", "SENTINEL"]
+
+#: The report is the last line beginning with this. Anything an SDK printed on import
+#: lands above it and is ignored rather than parsed as half a report.
+SENTINEL = "__noidroid_doctor__ "
+
+#: An address in TEST-NET-3 (RFC 5737), which is reserved for documentation and is not
+#: routed. The fence is supposed to refuse it before a packet exists; the short timeout
+#: is what keeps a *broken* fence from hanging this probe for a minute.
+_FENCE_TARGET = ("203.0.113.1", 80)
+_FENCE_TIMEOUT = 0.2
+
+# --------------------------------------------------------------- non-determinism
+
+#: Calls whose value differs between two runs of the same program. Named exactly,
+#: because `x.now()` on something that is not a datetime is not a clock read.
+_CLOCK = {
+    "time.time",
+    "time.time_ns",
+    "time.monotonic",
+    "time.monotonic_ns",
+    "time.perf_counter",
+    "time.perf_counter_ns",
+    "time.localtime",
+    "time.gmtime",
+    "time.asctime",
+    "time.ctime",
+    "time.strftime",
+    "datetime.datetime.now",
+    "datetime.datetime.utcnow",
+    "datetime.datetime.today",
+    "datetime.datetime.fromtimestamp",
+    "datetime.date.today",
+}
+_RANDOM = {"uuid.uuid1", "uuid.uuid4", "os.urandom", "os.getpid"}
+_RANDOM_PREFIX = ("random.", "secrets.")
+_SUBPROCESS = {"os.system", "os.popen", "multiprocessing.Process", "pty.spawn"}
+_SUBPROCESS_PREFIX = ("subprocess.", "asyncio.create_subprocess", "os.spawn", "os.exec")
+#: Importing one of these is itself the signal (#31): a child process is neither
+#: recorded nor fenced, so it does not have to be called to be worth reporting.
+_SUBPROCESS_MODULES = {"subprocess", "pty"}
+
+
+def _classify(name: str) -> Optional[str]:
+    if name in _CLOCK:
+        return "clock"
+    if name in _RANDOM or name.startswith(_RANDOM_PREFIX):
+        return "randomness"
+    if name in _SUBPROCESS or name.startswith(_SUBPROCESS_PREFIX):
+        return "subprocess"
+    return None
+
+
+class _Sites(ast.NodeVisitor):
+    """Every site in one file where a value we do not capture enters the program.
+
+    Import bindings are tracked so that `from uuid import uuid4` and `import uuid`
+    resolve to the same name. Without that, a scan either misses the first form or
+    flags every bare `uuid4` a program happens to define, and a preflight full of
+    false alarms gets ignored, which is the same outcome as not having one.
+    """
+
+    def __init__(self, path: str) -> None:
+        self.path = path
+        self.alias: dict[str, str] = {}
+        self.findings: list[dict[str, Any]] = []
+
+    def _record(self, line: int, name: str, kind: str) -> None:
+        self.findings.append(
+            {"file": self.path, "line": line, "name": name, "kind": kind}
+        )
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for entry in node.names:
+            root = entry.name.split(".")[0]
+            self.alias[entry.asname or root] = entry.name if entry.asname else root
+            if root in _SUBPROCESS_MODULES:
+                self._record(node.lineno, f"import {entry.name}", "subprocess")
+        self.generic_visit(node)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        module = node.module or ""
+        for entry in node.names:
+            if entry.name == "*":
+                continue
+            self.alias[entry.asname or entry.name] = (
+                f"{module}.{entry.name}" if module else entry.name
+            )
+        if module.split(".")[0] in _SUBPROCESS_MODULES:
+            self._record(node.lineno, f"from {module} import …", "subprocess")
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        name = self._resolve(node.func)
+        if name is not None:
+            kind = _classify(name)
+            if kind is not None:
+                self._record(node.lineno, name, kind)
+        self.generic_visit(node)
+
+    def _resolve(self, node: ast.expr) -> Optional[str]:
+        parts: list[str] = []
+        while isinstance(node, ast.Attribute):
+            parts.append(node.attr)
+            node = node.value
+        if not isinstance(node, ast.Name):
+            return None
+        parts.append(node.id)
+        parts.reverse()
+        head = self.alias.get(parts[0], parts[0])
+        return ".".join([head] + parts[1:])
+
+
+def _scan(arguments: list) -> dict:
+    """Parse whichever arguments name a readable Python file.
+
+    Imports are deliberately not followed. Doing so means resolving a package layout
+    we do not own and reporting on files the user did not point at; not doing so means
+    a clean result covers one file and no more. The second is a smaller lie, and the
+    doctor states the boundary rather than hiding it.
+    """
+    scanned: list[str] = []
+    unreadable: list[dict[str, str]] = []
+    findings: list[dict[str, Any]] = []
+    for argument in arguments:
+        if not argument.endswith(".py") or not os.path.isfile(argument):
+            continue
+        try:
+            with open(argument, "r", encoding="utf-8") as handle:
+                source = handle.read()
+            tree = ast.parse(source, filename=argument)
+        except (OSError, SyntaxError, ValueError) as exc:
+            unreadable.append({"file": argument, "error": f"{type(exc).__name__}: {exc}"})
+            continue
+        sites = _Sites(argument)
+        sites.visit(tree)
+        scanned.append(argument)
+        findings.extend(sites.findings)
+    return {"scanned": scanned, "unreadable": unreadable, "findings": findings}
+
+
+# ------------------------------------------------------------------- the client
+
+
+def _client() -> dict:
+    import noidroid
+
+    info: dict[str, Any] = {"path": getattr(noidroid, "__file__", None), "version": None}
+    try:
+        from importlib.metadata import version
+
+        info["version"] = version("noidroid")
+    except Exception:
+        # Importable from a source tree on PYTHONPATH rather than installed. The
+        # version is then genuinely unknown, and the doctor says so rather than
+        # assuming it matches.
+        pass
+    return info
+
+
+# ---------------------------------------------------------------- the surfaces
+
+
+def _providers() -> list:
+    """Run the real installer, then read back which surfaces carry the patch.
+
+    Enumerating `*APIClient` classes rather than trusting `auto`'s own list is the
+    point: a surface this build has never heard of still shows up here, unhooked,
+    instead of being invisible to both the patcher and the report.
+    """
+    from noidroid import auto
+
+    out = []
+    for provider in auto.PROVIDERS:
+        info: dict[str, Any] = {
+            "name": provider,
+            "installed": False,
+            "version": None,
+            "surfaces": [],
+            "error": None,
+        }
+        try:
+            module = importlib.import_module(provider)
+        except ImportError:
+            out.append(info)
+            continue
+        info["installed"] = True
+        info["version"] = getattr(module, "__version__", None)
+        try:
+            auto.install((provider,))
+        except Exception as exc:  # noqa: BLE001
+            info["error"] = f"{type(exc).__name__}: {exc}"
+        try:
+            base = importlib.import_module(f"{provider}._base_client")
+        except ImportError as exc:
+            info["error"] = info["error"] or f"{type(exc).__name__}: {exc}"
+            out.append(info)
+            continue
+        for attribute in sorted(dir(base)):
+            if not attribute.endswith("APIClient"):
+                continue
+            client_cls = getattr(base, attribute)
+            if not isinstance(client_cls, type):
+                continue
+            request = getattr(client_cls, "request", None)
+            if request is None:
+                continue
+            info["surfaces"].append(
+                {
+                    "name": f"{provider}._base_client.{attribute}.request",
+                    "hooked": bool(getattr(request, "__noidroid_wrapped__", False)),
+                }
+            )
+        out.append(info)
+    return out
+
+
+# -------------------------------------------------------------------- the fence
+
+
+def _fence() -> dict:
+    """Install the fence for real and check it refuses a connection.
+
+    Reporting that the module imported would be reporting on intent. The fence is
+    only worth anything if a non-local connect raises, so that is what is tested —
+    and the guard raises before the real `connect`, so nothing leaves the machine.
+    """
+    result: dict[str, Any] = {
+        "installed": False,
+        "refused": None,
+        "target": f"{_FENCE_TARGET[0]}:{_FENCE_TARGET[1]}",
+        "error": None,
+    }
+    try:
+        from noidroid import fence
+
+        fence.install(strict=True)
+        result["installed"] = bool(
+            getattr(socket.socket.connect, "__noidroid_fenced__", False)
+        )
+        probe = socket.socket()
+        probe.settimeout(_FENCE_TIMEOUT)
+        try:
+            probe.connect(_FENCE_TARGET)
+            result["refused"] = False
+        except fence.Escaped:
+            result["refused"] = True
+        except OSError as exc:
+            result["refused"] = False
+            result["error"] = f"{type(exc).__name__}: {exc}"
+        finally:
+            probe.close()
+    except Exception as exc:  # noqa: BLE001
+        result["error"] = f"{type(exc).__name__}: {exc}"
+    return result
+
+
+def main(argv: Optional[list] = None) -> int:
+    arguments = list(sys.argv[1:] if argv is None else argv)
+    report = {
+        "client": _client(),
+        "providers": _providers(),
+        "scan": _scan(arguments),
+        # Last, because it patches this process's sockets and everything above it
+        # may legitimately want one.
+        "fence": _fence(),
+    }
+    sys.stdout.write(SENTINEL + json.dumps(report) + "\n")
+    sys.stdout.flush()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/crates/noidroid-cli/Cargo.toml
+++ b/crates/noidroid-cli/Cargo.toml
@@ -14,5 +14,6 @@ path = "src/main.rs"
 [dependencies]
 noidroid-core = { path = "../noidroid-core", version = "0.3.0" }
 clap = { version = "4", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 ratatui = "0.30.2"

--- a/crates/noidroid-cli/src/doctor.rs
+++ b/crates/noidroid-cli/src/doctor.rs
@@ -1,0 +1,719 @@
+//! `noidroid doctor` — what a recording made now would and would not cover.
+//!
+//! Automatic capture fails open. Every patching mechanism can miss a surface, and a
+//! recording that missed one still looks real — so the question worth answering is not
+//! "did it work" after the fact, but "what will this not see" before anything is
+//! written. That is the whole job here.
+//!
+//! The report has five words and they are not interchangeable:
+//!
+//! | word | what it claims |
+//! |------|----------------|
+//! | `ok` | we looked, and this is covered |
+//! | `absent` | we looked, and there is nothing here to cover |
+//! | `not captured` | we looked, and it is **not** covered — a known hole, with its issue |
+//! | `not determined` | we could not look; this is not a pass |
+//! | `blocked` | we looked, and a recording made now would be refused or would lie |
+//!
+//! The two amber ones are the point. "We looked and it is not captured" and "we did
+//! not look" are different claims about the world, and a tool whose thesis is that a
+//! reconstruction either is faithful or says exactly why it is not cannot afford to
+//! print the same word for both. There is deliberately no score, no percentage and no
+//! readiness grade: a number nobody measured is the one failure this project cannot
+//! survive.
+//!
+//! Facts come from this module's Python counterpart, `noidroid.doctor`, which
+//! runs the real installer and the real fence in a throwaway process. Verdicts are
+//! decided here, in one place, because that judgement is the part that has to stay
+//! honest.
+
+use std::path::Path;
+use std::process::{Command, ExitCode, Stdio};
+
+use serde::Deserialize;
+
+use crate::palette::{bad, dim, ok as tick, shell, warn};
+
+/// The probe hides its report behind this so that an SDK printing on import cannot
+/// corrupt it. Must match `SENTINEL` in `clients/python/noidroid/doctor.py`.
+const SENTINEL: &str = "__noidroid_doctor__ ";
+
+// ------------------------------------------------------------------ probe facts
+
+#[derive(Deserialize)]
+struct Probe {
+    client: ClientFacts,
+    providers: Vec<ProviderFacts>,
+    scan: ScanFacts,
+    fence: FenceFacts,
+}
+
+#[derive(Deserialize)]
+struct ClientFacts {
+    path: Option<String>,
+    version: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct ProviderFacts {
+    name: String,
+    installed: bool,
+    version: Option<String>,
+    surfaces: Vec<SurfaceFacts>,
+    error: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct SurfaceFacts {
+    name: String,
+    hooked: bool,
+}
+
+#[derive(Deserialize)]
+struct ScanFacts {
+    scanned: Vec<String>,
+    unreadable: Vec<UnreadableFacts>,
+    findings: Vec<Finding>,
+}
+
+#[derive(Deserialize)]
+struct UnreadableFacts {
+    file: String,
+    error: String,
+}
+
+#[derive(Deserialize)]
+struct Finding {
+    file: String,
+    line: u32,
+    name: String,
+    kind: String,
+}
+
+#[derive(Deserialize)]
+struct FenceFacts {
+    installed: bool,
+    /// `None` when the fence never went up, so there was nothing to try.
+    refused: Option<bool>,
+    target: String,
+    error: Option<String>,
+}
+
+/// Why the probe could not answer. Kept apart from "it answered badly" because the
+/// three have different fixes and only one of them is the user's Python being broken.
+enum Blind {
+    NoPython(String),
+    NoClient(String),
+    Broken(String),
+}
+
+impl Blind {
+    fn detail(&self) -> String {
+        match self {
+            Blind::NoPython(why) => format!("python3 was not found, so nothing could be checked: {why}"),
+            Blind::NoClient(_) => "the noidroid Python client is not importable, so nothing in the recorded process could be checked".to_string(),
+            Blind::Broken(why) => format!("the probe did not report: {why}"),
+        }
+    }
+}
+
+// --------------------------------------------------------------------- verdicts
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Verdict {
+    /// We looked, and this is covered.
+    Ok,
+    /// We looked, and there is nothing here to cover.
+    Absent,
+    /// We looked, and it is not covered.
+    NotCaptured,
+    /// We could not look. Never a pass.
+    NotDetermined,
+    /// We looked, and a recording made now would be refused or would lie.
+    Blocked,
+}
+
+impl Verdict {
+    fn label(self) -> &'static str {
+        match self {
+            Verdict::Ok => "ok",
+            Verdict::Absent => "absent",
+            Verdict::NotCaptured => "not captured",
+            Verdict::NotDetermined => "not determined",
+            Verdict::Blocked => "blocked",
+        }
+    }
+
+    fn paint(self) -> String {
+        match self {
+            Verdict::Ok => tick(self.label()),
+            Verdict::Absent => dim(self.label()),
+            Verdict::NotCaptured | Verdict::NotDetermined => warn(self.label()),
+            Verdict::Blocked => bad(self.label()),
+        }
+    }
+}
+
+/// One line of the report, plus whatever evidence it rests on.
+struct Check {
+    name: String,
+    verdict: Verdict,
+    detail: String,
+    notes: Vec<(String, String)>,
+}
+
+impl Check {
+    fn new(name: impl Into<String>, verdict: Verdict, detail: impl Into<String>) -> Check {
+        Check {
+            name: name.into(),
+            verdict,
+            detail: detail.into(),
+            notes: Vec::new(),
+        }
+    }
+
+    fn note(mut self, label: impl Into<String>, text: impl Into<String>) -> Check {
+        self.notes.push((label.into(), text.into()));
+        self
+    }
+}
+
+// ------------------------------------------------------------------ the command
+
+pub fn run(command: &[String]) -> ExitCode {
+    let python = python_version();
+    let probe = python.as_ref().map(|_| probe(command));
+
+    let sections: Vec<(&str, Vec<Check>)> = match &probe {
+        Some(Ok(facts)) => vec![
+            ("THE TOOL", tool_checks(&python, Ok(facts))),
+            ("CAPTURE SURFACES", surface_checks(Ok(&facts.providers))),
+            ("THE PROGRAM", program_checks(command, Ok(&facts.scan))),
+            ("THE FENCE", vec![fence_check(Ok(&facts.fence))]),
+        ],
+        Some(Err(blind)) => vec![
+            ("THE TOOL", tool_checks(&python, Err(blind))),
+            ("CAPTURE SURFACES", surface_checks(Err(blind))),
+            ("THE PROGRAM", program_checks(command, Err(blind))),
+            ("THE FENCE", vec![fence_check(Err(blind))]),
+        ],
+        None => {
+            let blind = Blind::NoPython("python3 is not on PATH".into());
+            vec![
+                ("THE TOOL", tool_checks(&python, Err(&blind))),
+                ("CAPTURE SURFACES", surface_checks(Err(&blind))),
+                ("THE PROGRAM", program_checks(command, Err(&blind))),
+                ("THE FENCE", vec![fence_check(Err(&blind))]),
+            ]
+        }
+    };
+
+    println!(
+        "{}  {}",
+        shell("DOCTOR"),
+        dim("what a recording made now would and would not cover")
+    );
+    for (title, checks) in &sections {
+        println!("\n  {}", shell(title));
+        for check in checks {
+            print_check(check);
+        }
+    }
+    let all: Vec<&Check> = sections.iter().flat_map(|(_, c)| c.iter()).collect();
+    print_summary(&all);
+
+    if all.iter().any(|c| c.verdict == Verdict::Blocked) {
+        ExitCode::from(1)
+    } else {
+        ExitCode::SUCCESS
+    }
+}
+
+fn print_check(check: &Check) {
+    // The verdict carries colour, so it is padded by hand: formatting a painted string
+    // to a width counts the escape bytes and the columns come apart on a terminal.
+    let pad = " ".repeat(15usize.saturating_sub(check.verdict.label().len()));
+    println!(
+        "    {:<13} {}{} {}",
+        check.name,
+        check.verdict.paint(),
+        pad,
+        check.detail
+    );
+    for (label, text) in &check.notes {
+        println!("      {} {:<11} {}", dim("·"), dim(label), text);
+    }
+}
+
+fn print_summary(all: &[&Check]) {
+    let names = |verdict: Verdict| -> Vec<&str> {
+        all.iter()
+            .filter(|c| c.verdict == verdict)
+            .map(|c| c.name.as_str())
+            .collect()
+    };
+    let blocked = names(Verdict::Blocked);
+    let uncaptured = names(Verdict::NotCaptured);
+    let unknown = names(Verdict::NotDetermined);
+
+    if !(blocked.is_empty() && uncaptured.is_empty() && unknown.is_empty()) {
+        println!("\n  {}", shell("IN SHORT"));
+    }
+    for (verdict, entries) in [
+        (Verdict::Blocked, &blocked),
+        (Verdict::NotCaptured, &uncaptured),
+        (Verdict::NotDetermined, &unknown),
+    ] {
+        if entries.is_empty() {
+            continue;
+        }
+        let pad = " ".repeat(15usize.saturating_sub(verdict.label().len()));
+        println!("    {}{} {}", verdict.paint(), pad, entries.join(", "));
+    }
+
+    println!();
+    if !blocked.is_empty() {
+        println!(
+            "  {} fix these before recording. Each one means a recording made now \
+             would be refused, or would miss something without saying so.",
+            bad("blocked:")
+        );
+    }
+    if !unknown.is_empty() {
+        println!(
+            "  {} it means nothing looked. A recording made now carries the same \
+             gap and will not name it.",
+            warn("not determined is not a pass:")
+        );
+    }
+    if blocked.is_empty() && uncaptured.is_empty() && unknown.is_empty() {
+        println!(
+            "  {} every check above was looked at and passed.",
+            tick("ok:")
+        );
+    }
+    println!(
+        "  {}",
+        dim(
+            "this checks automatic capture in Python. --proxy and hand-written nd.call() \
+             are different paths, and are not checked here."
+        )
+    );
+}
+
+// ----------------------------------------------------------------- the sections
+
+fn tool_checks(python: &Option<(String, String)>, probe: Result<&Probe, &Blind>) -> Vec<Check> {
+    let mut checks = Vec::new();
+
+    checks.push(match python {
+        Some((version, executable)) => {
+            Check::new("python3", Verdict::Ok, format!("{version} at {executable}"))
+        }
+        None => Check::new(
+            "python3",
+            Verdict::Blocked,
+            "not on PATH — --auto, the client and this report all need it",
+        ),
+    });
+
+    let cli = env!("CARGO_PKG_VERSION");
+    match probe {
+        Ok(facts) => {
+            let path = facts.client.path.as_deref().unwrap_or("an unknown path");
+            checks.push(Check::new(
+                "client",
+                Verdict::Ok,
+                format!("importable from {path}"),
+            ));
+            checks.push(match &facts.client.version {
+                Some(version) if version == cli => Check::new(
+                    "version",
+                    Verdict::Ok,
+                    format!("client {version}, the same as this CLI"),
+                ),
+                Some(version) => Check::new(
+                    "version",
+                    Verdict::Blocked,
+                    format!(
+                        "client {version}, this CLI {cli} — one records the format the \
+                         other reads, so a mismatch is not a comparison"
+                    ),
+                ),
+                // Importable off a source tree rather than installed. The version is
+                // then genuinely unreadable, and an unreadable version is not a
+                // matching one.
+                None => Check::new(
+                    "version",
+                    Verdict::NotDetermined,
+                    format!(
+                        "importable from source, not installed as a distribution — this \
+                         CLI is {cli} and there is nothing to compare it with"
+                    ),
+                ),
+            });
+        }
+        Err(Blind::NoClient(why)) => {
+            checks.push(
+                Check::new(
+                    "client",
+                    Verdict::Blocked,
+                    "not importable, so nothing can be recorded from Python",
+                )
+                .note("python said", why.clone())
+                .note("fix", "pip install -e clients/python"),
+            );
+            checks.push(Check::new(
+                "version",
+                Verdict::NotDetermined,
+                format!("the client did not import, so this CLI's {cli} matches nothing yet"),
+            ));
+        }
+        Err(blind) => {
+            checks.push(Check::new("client", Verdict::NotDetermined, blind.detail()));
+            checks.push(Check::new(
+                "version",
+                Verdict::NotDetermined,
+                "the probe did not report, so the client version was never read",
+            ));
+        }
+    }
+
+    // Not a probe answer: this is what this binary was built for, and it is the
+    // engine's socket rather than the client's that excludes Windows.
+    checks.push(if cfg!(windows) {
+        Check::new(
+            "transport",
+            Verdict::Blocked,
+            "the engine and client talk over AF_UNIX, which this platform does not have (#32)",
+        )
+    } else {
+        Check::new(
+            "transport",
+            Verdict::Ok,
+            format!("AF_UNIX on {}", std::env::consts::OS),
+        )
+        .note(
+            "limit",
+            "Windows is excluded: the socket is hardcoded (#32)",
+        )
+    });
+
+    checks
+}
+
+fn surface_checks(providers: Result<&[ProviderFacts], &Blind>) -> Vec<Check> {
+    let providers = match providers {
+        Ok(list) => list,
+        Err(blind) => {
+            return vec![Check::new("sdks", Verdict::NotDetermined, blind.detail())];
+        }
+    };
+    providers
+        .iter()
+        .map(|provider| {
+            let version = provider.version.as_deref().unwrap_or("an unknown version");
+            if !provider.installed {
+                return Check::new(
+                    &provider.name,
+                    Verdict::Absent,
+                    "not installed, so no call in this program goes through it",
+                );
+            }
+            if let Some(error) = &provider.error {
+                return Check::new(
+                    &provider.name,
+                    Verdict::Blocked,
+                    format!("{version} is installed and automatic capture could not patch it"),
+                )
+                .note("python said", error.clone());
+            }
+            if provider.surfaces.is_empty() {
+                return Check::new(
+                    &provider.name,
+                    Verdict::NotDetermined,
+                    format!(
+                        "{version} is installed, and no request surface was found in \
+                         {}._base_client — this build does not know where to look",
+                        provider.name
+                    ),
+                );
+            }
+            let missed = provider.surfaces.iter().filter(|s| !s.hooked).count();
+            let mut check = if missed == 0 {
+                Check::new(
+                    &provider.name,
+                    Verdict::Ok,
+                    format!("{version} is installed, and every request surface found is hooked"),
+                )
+            } else {
+                Check::new(
+                    &provider.name,
+                    Verdict::Blocked,
+                    format!(
+                        "{version} is installed, and {missed} request {} present here \
+                         {} not hooked",
+                        if missed == 1 { "surface" } else { "surfaces" },
+                        if missed == 1 { "is" } else { "are" }
+                    ),
+                )
+            };
+            for surface in &provider.surfaces {
+                if surface.hooked {
+                    check = check.note("hooked", surface.name.clone());
+                } else {
+                    // Naming the issue is the difference between "this is not covered"
+                    // and "this is not covered and nobody knows".
+                    let filed = if surface.name.contains("Async") {
+                        " (#33)"
+                    } else {
+                        ""
+                    };
+                    check = check.note("NOT hooked", format!("{}{filed}", surface.name));
+                }
+            }
+            check.note(
+                "read from",
+                format!(
+                    "{}._base_client, after running the installer — a client class \
+                     defined elsewhere is not found",
+                    provider.name
+                ),
+            )
+        })
+        .collect()
+}
+
+fn program_checks(command: &[String], scan: Result<&ScanFacts, &Blind>) -> Vec<Check> {
+    let unlooked = |detail: String| {
+        vec![
+            Check::new("clock", Verdict::NotDetermined, detail.clone()),
+            Check::new("subprocess", Verdict::NotDetermined, detail),
+        ]
+    };
+    if command.is_empty() {
+        return unlooked(
+            "no program given — pass the command you mean to record, after --".to_string(),
+        );
+    }
+    let scan = match scan {
+        Ok(facts) => facts,
+        Err(blind) => return unlooked(blind.detail()),
+    };
+    if scan.scanned.is_empty() {
+        let mut checks = unlooked(
+            "the command names no readable Python file, so nothing was parsed".to_string(),
+        );
+        for bad_file in &scan.unreadable {
+            for check in &mut checks {
+                check
+                    .notes
+                    .push((bad_file.file.clone(), bad_file.error.clone()));
+            }
+        }
+        return checks;
+    }
+
+    let files = scan.scanned.len();
+    let plural = if files == 1 { "file" } else { "files" };
+    let mut checks = Vec::new();
+    for (name, kinds, what, issue, advice) in [
+        (
+            "clock",
+            &["clock", "randomness"][..],
+            "reach the clock or randomness, which is not captured",
+            "#30",
+            "mark the argument volatile=, or route the value through nd.call()",
+        ),
+        (
+            "subprocess",
+            &["subprocess"][..],
+            "start a child process, which is not captured",
+            "#31",
+            "a child inherits neither the patch nor the fence: what it does is not \
+             recorded, not fenced, and not reported during the run",
+        ),
+    ] {
+        let found: Vec<&Finding> = scan
+            .findings
+            .iter()
+            .filter(|f| kinds.contains(&f.kind.as_str()))
+            .collect();
+        if found.is_empty() {
+            // A file with nothing in it is a fact about that file. The scan does not
+            // follow imports, so it is not a fact about the program.
+            checks.push(Check::new(
+                name,
+                Verdict::NotDetermined,
+                format!(
+                    "nothing found in the {files} {plural} scanned; imports are not \
+                     followed, so the rest of the program was not looked at"
+                ),
+            ));
+            continue;
+        }
+        let sites = found.len();
+        let mut check = Check::new(
+            name,
+            Verdict::NotCaptured,
+            format!(
+                "{sites} {} in the {files} {plural} scanned {what} ({issue})",
+                if sites == 1 { "site" } else { "sites" }
+            ),
+        );
+        for finding in found.iter().take(6) {
+            check = check.note(
+                short_path(&finding.file, finding.line),
+                finding.name.clone(),
+            );
+        }
+        if found.len() > 6 {
+            check = check.note("and", format!("{} more", found.len() - 6));
+        }
+        checks.push(check.note("what to do", advice));
+    }
+    checks
+}
+
+/// `agent.py:6` — the file as the user typed it, not as we canonicalised it.
+fn short_path(file: &str, line: u32) -> String {
+    let name = Path::new(file)
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| file.to_string());
+    format!("{name}:{line}")
+}
+
+fn fence_check(fence: Result<&FenceFacts, &Blind>) -> Check {
+    let fence = match fence {
+        Ok(facts) => facts,
+        Err(blind) => return Check::new("egress", Verdict::NotDetermined, blind.detail()),
+    };
+    let blind_spots = (
+        "blind to".to_string(),
+        "subprocesses (#31), C extensions that bypass Python's socket module, and \
+         connections opened before it went up"
+            .to_string(),
+    );
+    let mut check = match (fence.installed, fence.refused) {
+        (true, Some(true)) => Check::new(
+            "egress",
+            Verdict::Ok,
+            format!(
+                "installed on socket.socket.connect, and a connect to {} was refused",
+                fence.target
+            ),
+        ),
+        (true, Some(false)) => Check::new(
+            "egress",
+            Verdict::Blocked,
+            format!(
+                "installed, and it did not stop a connect to {} — a reconstruction \
+                 could reach the world without saying so",
+                fence.target
+            ),
+        ),
+        _ => Check::new(
+            "egress",
+            Verdict::Blocked,
+            "could not be installed, so a replay could reach the world unnoticed",
+        ),
+    };
+    if let Some(error) = &fence.error {
+        check = check.note("python said", error.clone());
+    }
+    check.notes.push(blind_spots);
+    check
+}
+
+// ---------------------------------------------------------------- running python
+
+fn python_version() -> Option<(String, String)> {
+    let output = Command::new("python3")
+        .args([
+            "-c",
+            "import sys; print(sys.version.split()[0]); print(sys.executable)",
+        ])
+        .stderr(Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&output.stdout);
+    let mut lines = text.lines();
+    let version = lines.next()?.trim().to_string();
+    let executable = lines.next().unwrap_or("python3").trim().to_string();
+    Some((version, executable))
+}
+
+/// Run the real installer and the real fence in a throwaway process, and read back
+/// what happened. Anything the SDKs printed on import lands above the sentinel.
+fn probe(command: &[String]) -> Result<Probe, Blind> {
+    let output = Command::new("python3")
+        .args(["-m", "noidroid.doctor"])
+        .args(command)
+        .output()
+        .map_err(|e| Blind::NoPython(e.to_string()))?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    match stdout.lines().rev().find(|l| l.starts_with(SENTINEL)) {
+        Some(line) => serde_json::from_str(&line[SENTINEL.len()..])
+            .map_err(|e| Blind::Broken(format!("its report did not parse: {e}"))),
+        None if stderr.contains("No module named 'noidroid'") => {
+            Blind::NoClient(last_meaningful(&stderr)).into_err()
+        }
+        None => Blind::Broken(last_meaningful(&stderr)).into_err(),
+    }
+}
+
+impl Blind {
+    fn into_err<T>(self) -> Result<T, Blind> {
+        Err(self)
+    }
+}
+
+/// A traceback's last line is the one that says what went wrong.
+fn last_meaningful(stderr: &str) -> String {
+    stderr
+        .lines()
+        .map(str::trim)
+        .rfind(|l| !l.is_empty())
+        .unwrap_or("nothing on stderr")
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_five_verdicts_are_five_different_words() {
+        // `ok` and `not captured` and `not determined` are three claims about the
+        // world, and the report is worthless the moment two of them print the same.
+        let words: Vec<&str> = [
+            Verdict::Ok,
+            Verdict::Absent,
+            Verdict::NotCaptured,
+            Verdict::NotDetermined,
+            Verdict::Blocked,
+        ]
+        .iter()
+        .map(|v| v.label())
+        .collect();
+        let mut unique = words.clone();
+        unique.sort_unstable();
+        unique.dedup();
+        assert_eq!(words.len(), unique.len(), "{words:?}");
+        assert!(!words.contains(&"ok "), "no verdict may be a prefix trick");
+    }
+
+    #[test]
+    fn a_check_that_could_not_look_never_says_ok() {
+        let blind = Blind::NoPython("python3 is not on PATH".into());
+        let checks = program_checks(&["python3".to_string()], Err(&blind));
+        assert!(checks
+            .iter()
+            .all(|c| c.verdict == Verdict::NotDetermined && c.detail.contains("python3")));
+    }
+}

--- a/crates/noidroid-cli/src/main.rs
+++ b/crates/noidroid-cli/src/main.rs
@@ -16,6 +16,7 @@ use noidroid_core::model::{Action, Failure, Intervention, Provenance, Step, Traj
 use noidroid_core::repo::{self, Repo};
 use noidroid_core::{tree, Error, Result};
 
+mod doctor;
 mod palette;
 mod stand;
 mod tui;
@@ -179,6 +180,13 @@ enum Command {
     Diff { a: String, b: String },
     /// Re-hash every object and check nothing has been edited underneath us.
     Verify,
+    /// Say what a recording would and would not cover, before making one.
+    Doctor {
+        /// The program you mean to record, after `--`. Without it, the checks that
+        /// need to read your program report that nothing looked at it.
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        command: Vec<String>,
+    },
     /// Browse trajectories and explore from a checkpoint, interactively.
     Tui {
         /// Start on this trajectory.
@@ -220,6 +228,12 @@ fn restore_default_sigpipe() {
 }
 
 fn dispatch(cli: Cli) -> Result<ExitCode> {
+    // Answered before anything is opened, deliberately: a preflight is about the
+    // environment rather than about a repository, and asking what a recording would
+    // cover must not create a store as a side effect of asking.
+    if let Command::Doctor { command } = &cli.command {
+        return Ok(doctor::run(command));
+    }
     let cwd = std::env::current_dir()?;
     let repo = Repo::discover(&cwd)?;
     match cli.command {
@@ -291,6 +305,8 @@ fn dispatch(cli: Cli) -> Result<ExitCode> {
         Command::Tree => cmd_tree(&repo),
         Command::Diff { a, b } => cmd_diff(&repo, &a, &b),
         Command::Verify => cmd_verify(&repo),
+        // Already answered above, without the repository this arm now has.
+        Command::Doctor { command } => Ok(doctor::run(&command)),
         Command::Tui { trajectory, plain } => tui::run(&repo, &cwd, trajectory, plain),
         Command::Stand => {
             stand::print_profile();

--- a/crates/noidroid-cli/tests/doctor.rs
+++ b/crates/noidroid-cli/tests/doctor.rs
@@ -1,0 +1,341 @@
+//! `noidroid doctor`, through the real binary.
+//!
+//! Automatic capture fails open by construction: every patching mechanism can miss a
+//! surface, and a recording that missed one still looks real. The doctor exists to say
+//! so *before* a recording is made, which means the claim worth testing is not that it
+//! prints a lot of ticks. It is that it never prints one it did not earn.
+//!
+//! So these tests are all about the same distinction: **we looked and it is not
+//! captured** is a different sentence from **we did not look**, and neither of them is
+//! `ok`. A doctor that collapses the three is worse than no doctor, because it launders
+//! an unexamined surface into a green tick.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("the workspace root is two levels up")
+}
+
+fn workdir(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "noidroid-doctor-{tag}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn noidroid(dir: &Path, args: &[&str]) -> (String, bool) {
+    let root = repo_root();
+    let output = Command::new(env!("CARGO_BIN_EXE_noidroid"))
+        .args(args)
+        .current_dir(dir)
+        .env("PYTHONPATH", root.join("clients/python"))
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("the binary should run");
+    let mut text = String::from_utf8_lossy(&output.stdout).to_string();
+    text.push_str(&String::from_utf8_lossy(&output.stderr));
+    (text, output.status.success())
+}
+
+/// The one line of the report about `name`, so a test can assert on what that line
+/// does *not* say as well as what it does.
+fn line_about<'a>(report: &'a str, name: &str) -> &'a str {
+    report
+        .lines()
+        .map(str::trim_end)
+        .find(|line| line.trim_start().starts_with(name))
+        .unwrap_or_else(|| panic!("no line about '{name}' in:\n{report}"))
+}
+
+fn write(dir: &Path, name: &str, source: &str) -> PathBuf {
+    let path = dir.join(name);
+    std::fs::write(&path, source).unwrap();
+    path
+}
+
+fn python_can(expression: &str) -> bool {
+    let root = repo_root();
+    matches!(
+        Command::new("python3")
+            .args(["-c", expression])
+            .env("PYTHONPATH", root.join("clients/python"))
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status(),
+        Ok(status) if status.success()
+    )
+}
+
+#[test]
+fn a_surface_we_did_not_look_at_is_never_reported_as_covered() {
+    let dir = workdir("unlooked");
+
+    // No program named, so nothing about the program can have been examined.
+    let (report, _) = noidroid(&dir, &["doctor"]);
+
+    for check in ["clock", "subprocess"] {
+        let line = line_about(&report, check);
+        assert!(
+            line.contains("not determined"),
+            "'{check}' was not looked at, so it may not be reported as anything else: {line}"
+        );
+        assert!(
+            !line.contains(" ok "),
+            "'{check}' must never be ticked when nothing examined it: {line}"
+        );
+    }
+    assert!(
+        report.contains("no program given"),
+        "the report has to say why it could not look: {report}"
+    );
+    // The reader must be told that the amber lines are not passes, in the report and
+    // not only in the documentation.
+    assert!(
+        report.contains("not determined is not a pass"),
+        "an unexamined surface has to be called what it is: {report}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn a_clean_scan_is_not_reported_as_a_clean_program() {
+    let dir = workdir("clean");
+    let agent = write(
+        &dir,
+        "agent.py",
+        "import json\n\n\ndef main():\n    return json.dumps({\"ok\": True})\n",
+    );
+
+    let (report, _) = noidroid(&dir, &["doctor", "--", "python3", agent.to_str().unwrap()]);
+
+    // One file was parsed and had nothing in it. That is a fact about one file, not a
+    // clean bill of health for the program: the scan does not follow imports, so the
+    // rest of it was never opened.
+    let line = line_about(&report, "clock");
+    assert!(
+        line.contains("not determined"),
+        "a scan that read one file cannot clear a program: {line}"
+    );
+    assert!(
+        report.contains("imports are not followed"),
+        "the boundary of the scan has to be stated: {report}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn the_clock_and_randomness_are_named_with_the_line_they_appear_on() {
+    let dir = workdir("clock");
+    let agent = write(
+        &dir,
+        "agent.py",
+        "import time\nfrom uuid import uuid4\n\n\ndef go(client):\n    \
+         return client.messages.create(id=str(uuid4()), at=time.time())\n",
+    );
+
+    let (report, _) = noidroid(&dir, &["doctor", "--", "python3", agent.to_str().unwrap()]);
+
+    let line = line_about(&report, "clock");
+    assert!(
+        line.contains("not captured"),
+        "this one we looked at and found, which is not the same as not looking: {line}"
+    );
+    assert!(
+        report.contains("uuid.uuid4") && report.contains("time.time"),
+        "the report must name the call, not just its module: {report}"
+    );
+    assert!(
+        report.contains("agent.py:6"),
+        "and where it is, so it can be marked volatile= without a search: {report}"
+    );
+    assert!(
+        report.contains("#30"),
+        "a known, filed hole is named as one: {report}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn a_subprocess_is_reported_as_a_known_hole_not_as_covered() {
+    let dir = workdir("subprocess");
+    let agent = write(
+        &dir,
+        "agent.py",
+        "import subprocess\n\n\ndef build():\n    \
+         return subprocess.run([\"make\"], check=True)\n",
+    );
+
+    let (report, _) = noidroid(&dir, &["doctor", "--", "python3", agent.to_str().unwrap()]);
+
+    let line = line_about(&report, "subprocess");
+    assert!(
+        line.contains("not captured"),
+        "a child process is neither recorded nor fenced, and the doctor says so: {line}"
+    );
+    assert!(
+        report.contains("subprocess.run"),
+        "the call has to be named: {report}"
+    );
+    assert!(
+        report.contains("#31"),
+        "the filed issue is named rather than the surface implied to be covered: {report}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn an_installed_sdk_names_every_request_surface_and_whether_it_is_hooked() {
+    if !python_can("import anthropic") {
+        eprintln!("SKIP: doctor SDK test — the Anthropic SDK is not installed");
+        return;
+    }
+    let dir = workdir("sdk");
+
+    let (report, ok) = noidroid(&dir, &["doctor"]);
+
+    // Both surfaces are read back out of the SDK after running the real installer, so
+    // this is what is patched rather than what we meant to patch.
+    assert!(
+        report.contains("anthropic._base_client.SyncAPIClient.request"),
+        "the hooked surface is named: {report}"
+    );
+    assert!(
+        report.contains("anthropic._base_client.AsyncAPIClient.request"),
+        "and so is the one that is present and not hooked: {report}"
+    );
+    assert!(
+        report.contains("NOT hooked"),
+        "an unhooked surface has to be unmissable: {report}"
+    );
+    assert!(
+        report.contains("#33"),
+        "the async hole is filed, and is named rather than implied covered: {report}"
+    );
+    let line = line_about(&report, "anthropic");
+    assert!(
+        line.contains("blocked"),
+        "an installed SDK with an unpatched surface is a hard fail: {line}"
+    );
+    assert!(
+        !ok,
+        "and a blocked check must not exit zero, or CI would not notice it: {report}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn the_fence_is_reported_only_after_it_actually_refuses_a_connection() {
+    let dir = workdir("fence");
+
+    let (report, _) = noidroid(&dir, &["doctor"]);
+
+    let line = line_about(&report, "egress");
+    assert!(
+        line.contains(" ok"),
+        "the fence really did stop a connect, so it may be ticked: {line}"
+    );
+    assert!(
+        report.contains("203.0.113.1:80"),
+        "the tick is earned by a named, refused connection, not by an import: {report}"
+    );
+    assert!(
+        report.contains("blind to"),
+        "what the fence cannot see is printed next to what it can: {report}"
+    );
+    assert!(
+        report.contains("#31"),
+        "including the filed one — a fence blind to subprocesses is not a fence: {report}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn a_client_version_that_cannot_be_read_is_not_reported_as_matching() {
+    if python_can("from importlib.metadata import version; version('noidroid')") {
+        eprintln!("SKIP: doctor version test — the client is installed, so its version reads");
+        return;
+    }
+    let dir = workdir("version");
+
+    let (report, _) = noidroid(&dir, &["doctor"]);
+
+    let line = line_about(&report, "version");
+    assert!(
+        line.contains("not determined"),
+        "a version nothing could read is not a version that matches: {line}"
+    );
+    assert!(
+        !line.contains("matches"),
+        "and must not be described as one: {line}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn the_report_never_prints_a_score_a_percentage_or_a_grade() {
+    let dir = workdir("score");
+
+    // No program named, so no filesystem paths land in the output to confuse this.
+    let (report, _) = noidroid(&dir, &["doctor"]);
+
+    assert!(
+        !report.contains('%'),
+        "a percentage of a program's surfaces is a number nobody measured: {report}"
+    );
+    for word in ["score", "grade", "readiness", "healthy", "confidence"] {
+        assert!(
+            !report.to_lowercase().contains(word),
+            "'{word}' turns a list of findings into fidelity theatre: {report}"
+        );
+    }
+    // Filesystem paths carry slashes of their own, and none of them is a grade.
+    let root = repo_root().display().to_string();
+    let ratio = report
+        .lines()
+        .filter(|line| !line.contains(&root))
+        .flat_map(|line| {
+            line.chars()
+                .collect::<Vec<_>>()
+                .windows(3)
+                .map(|w| w[0].is_ascii_digit() && w[1] == '/' && w[2].is_ascii_digit())
+                .collect::<Vec<_>>()
+        })
+        .any(|hit| hit);
+    assert!(
+        !ratio,
+        "'4 of 6 checks passed' is a grade with extra steps: {report}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn a_preflight_does_not_create_a_repository_just_by_asking() {
+    let dir = workdir("norepo");
+
+    let (report, _) = noidroid(&dir, &["doctor"]);
+
+    assert!(
+        !dir.join(".noidroid").exists(),
+        "asking what would be recorded must record nothing, not even a store: {report}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
Closes #29

`noidroid doctor` is a preflight that answers, before anything is recorded, what a
recording made now would and would not cover. `--auto` already refused when it found a
hole, but only for the holes it knew to look for and only at the moment of recording.
This asks first.

## The five words

They are deliberately not interchangeable, and the report never collapses two of them:

| word | the claim |
|---|---|
| `ok` | we looked, and it is covered |
| `absent` | we looked, and there is nothing here to cover |
| `not captured` | we looked, and it is **not** — named with the issue that tracks it |
| `not determined` | we could not look; never a pass |
| `blocked` | a recording made now would be refused or would miss something; exits non-zero |

## What it checks

- **The tool** — `python3` and its version; whether the client imports and from where;
  the client's version against this CLI's (a mismatch is `blocked`, an unreadable
  version is `not determined`); `AF_UNIX`, with Windows named as excluded (#32).
- **Capture surfaces** — for each supported SDK: installed or not, its version, and
  every `*APIClient.request` surface with whether it is actually hooked. An installed
  SDK with an unhooked surface is `blocked`, and the async one is named as #33.
- **The program** — `noidroid doctor -- python3 agent.py` parses the files named on the
  command line and reports, with file and line, every clock/randomness read (#30) and
  every subprocess launch (#31).
- **The fence** — whether the egress fence installs *and* refuses a connection.

## What it refuses to claim

- **No score, no percentage, no readiness grade.** A number nobody measured is fidelity
  theatre, which is what the doctor exists to prevent. A test asserts the output
  contains no `%`, no ratio, and none of "score", "grade", "readiness", "healthy",
  "confidence".
- **A clean scan is not a clean program.** The scan does not follow imports, so a file
  with nothing in it is `not determined`, not `ok`.
- **Nothing is reported from intent.** Surfaces are enumerated out of the SDK's
  `_base_client` *after* running the real `auto.install`, so a client class this build
  has never heard of appears unhooked rather than invisible to both the patcher and the
  report. The fence is ticked only after it actually refused a connect to 203.0.113.1
  (RFC 5737, reserved and unrouted — the guard raises before the real `connect`, so
  nothing leaves the machine).
- **A known hole is named, not implied covered.** #30, #31, #32 and #33 appear in the
  report where they apply. This PR fixes none of them.
- **It does not check every path.** The closing line says so: this covers automatic
  capture in Python; `--proxy` and hand-written `nd.call()` are different paths.

## Verified

`cargo fmt --all`, `cargo clippy --all-targets -- -D warnings`, `cargo test --all` —
16 suites, all green, no skips on this machine.

Nine new tests in `crates/noidroid-cli/tests/doctor.rs` drive the real binary and prove
the invariants rather than the formatting: an unexamined surface is never ticked; a
clean one-file scan is reported as unlooked-at; the clock and randomness are named with
their line; a subprocess is a named known hole; an installed SDK names every request
surface and its hooked state and exits non-zero; the fence is ticked only after a real
refusal; an unreadable client version is not reported as matching; the report carries no
score; and asking what would be recorded creates no `.noidroid` store. Two unit tests in
`doctor.rs` pin that the five verdicts are five distinct words and that a check which
could not look never says `ok`.

Verified by hand: the degraded path with the client off `PYTHONPATH` reports `blocked`
on the client and `not determined` for everything downstream, with nothing claiming
`ok`.

## Not verified

- **Windows.** The `transport` check is `cfg!(windows)` and has never run there — no
  Windows machine and no CI job for it. Everything else was exercised on Linux only;
  the macOS CI job is the first run there.
- **`openai` installed.** Only `anthropic` is installed in this environment, so the
  hooked/unhooked enumeration was exercised against one SDK. The `openai` path is the
  same code and reports `absent` here.
- **The client version match.** `noidroid` is importable from source rather than
  installed as a distribution everywhere I ran it, so the `blocked`-on-mismatch branch
  was never taken for real — only the `not determined` branch it produces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
