### PR TITLE
fix(test): stand-in providers bind port 0 and report back what they got

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,23 @@ how the package version relates to `STEP_VERSION`, the on-disk object format.
 
 ### Fixed
 
+- **The proxy test suite bound fixed ports, so a stale provider could be recorded
+  instead of the one under test.** `Provider::start` polled `TcpStream::connect` and
+  returned as soon as *something* answered on `8791`-`8794` — never checking that the
+  answerer was the process it had just spawned. A provider left behind by a killed
+  run, or a second worktree of this repository running its suite at the same time,
+  meant the next test recorded against someone else's server. For
+  `a_streamed_response_reaches_the_client_before_it_ends` that produced the wrong
+  verdict rather than a loud failure: a stale non-streaming provider on the port made
+  the arrival-spread assertion fail on a proxy fix that was fine, which is exactly
+  what happened once during #30. Two worktrees running `cargo test --all` at once is
+  now the ordinary case, not the exotic one, so every stand-in provider in
+  `proxy_slice.rs` and `auto_slice.rs`, and the example site `browser_slice.rs`
+  drives, now binds port 0 and reports back the port the OS actually gave it, the
+  same remedy `unique_socket_path` has always used and #44 already applied to
+  `Store::put`'s scratch name and `watch_slice`'s fixture directory. A new test,
+  `a_provider_never_adopts_a_server_it_did_not_start`, starts two providers back to
+  back and proves that killing the second one only takes down its own port. (#74)
 - **A branch whose program died printed a timeline that just stopped.** `noidroid log`
   called it `aborted` and `noidroid branch` never did, so the operator had to infer the
   crash from a missing `finish` row — the inference this tool exists to remove, and the

--- a/crates/noidroid-core/tests/auto_slice.rs
+++ b/crates/noidroid-core/tests/auto_slice.rs
@@ -42,6 +42,11 @@ class Handler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(body)
 
+# ThreadingHTTPServer.server_bind() calls socket.getfqdn(host), a reverse DNS
+# lookup that has stalled for tens of seconds on some CI hosts and delayed the
+# print() the Rust side waits on for a port number.
+import socket
+socket.getfqdn = lambda *a, **k: "localhost"
 server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
 print(server.server_address[1], flush=True)
 server.serve_forever()

--- a/crates/noidroid-core/tests/auto_slice.rs
+++ b/crates/noidroid-core/tests/auto_slice.rs
@@ -13,18 +13,18 @@
 //! Skipped with a note when the Anthropic SDK is not installed.
 
 use std::fs;
+use std::io::{BufRead, BufReader};
 use std::net::TcpStream;
 use std::path::{Path, PathBuf};
-use std::process::{Child, Command, Stdio};
+use std::process::{Child, ChildStdout, Command, Stdio};
+use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
 use noidroid_core::engine::{self, Mode, RunSpec};
 use noidroid_core::Repo;
 
-const PORT: u16 = 8789;
-
 const FAKE_API: &str = r#"
-import json, sys
+import json
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 class Handler(BaseHTTPRequestHandler):
@@ -42,7 +42,9 @@ class Handler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(body)
 
-ThreadingHTTPServer(("127.0.0.1", int(sys.argv[1])), Handler).serve_forever()
+server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+print(server.server_address[1], flush=True)
+server.serve_forever()
 "#;
 
 /// Contains no reference to noidroid. That is the point.
@@ -83,35 +85,49 @@ fn bootstrap_path() -> PathBuf {
     client_path().join("noidroid/_bootstrap")
 }
 
-struct Api(Child);
+struct Api {
+    child: Child,
+    port: u16,
+}
 
 impl Api {
+    /// Starts the stand-in on a port the OS picked, and reads that port back from the
+    /// child listening on it.
+    ///
+    /// A fixed port is a shared name: `connect` answering on one says only that
+    /// *something* is listening, so a stand-in left behind by a killed run -- or a
+    /// second worktree of this repository running the same suite -- would be recorded
+    /// in place of the one this test started, and `stop` could not take it away. See
+    /// #74, and `unique_socket_path` in the engine for the same remedy.
     fn start(script: &Path) -> Api {
         let mut child = Command::new("python3")
             .arg(script)
-            .arg(PORT.to_string())
-            .stdout(Stdio::null())
+            .stdout(Stdio::piped())
             .stderr(Stdio::null())
             .spawn()
             .expect("the stand-in API should start");
-        let deadline = Instant::now() + Duration::from_secs(10);
-        while Instant::now() < deadline {
-            if TcpStream::connect(("127.0.0.1", PORT)).is_ok() {
-                return Api(child);
+        let stdout = child.stdout.take().expect("the child's stdout is a pipe");
+        match announced_port(stdout) {
+            Some(port) => Api { child, port },
+            None => {
+                let _ = child.kill();
+                let _ = child.wait();
+                panic!("the stand-in API never announced a port");
             }
-            std::thread::sleep(Duration::from_millis(50));
         }
-        let _ = child.kill();
-        let _ = child.wait();
-        panic!("the stand-in API never came up");
+    }
+
+    fn endpoint(&self) -> String {
+        format!("http://127.0.0.1:{}", self.port)
     }
 
     fn stop(mut self) {
-        let _ = self.0.kill();
-        let _ = self.0.wait();
+        let port = self.port;
+        let _ = self.child.kill();
+        let _ = self.child.wait();
         let deadline = Instant::now() + Duration::from_secs(5);
         while Instant::now() < deadline {
-            if TcpStream::connect(("127.0.0.1", PORT)).is_err() {
+            if TcpStream::connect(("127.0.0.1", port)).is_err() {
                 return;
             }
             std::thread::sleep(Duration::from_millis(50));
@@ -122,9 +138,23 @@ impl Api {
 
 impl Drop for Api {
     fn drop(&mut self) {
-        let _ = self.0.kill();
-        let _ = self.0.wait();
+        let _ = self.child.kill();
+        let _ = self.child.wait();
     }
+}
+
+/// The port the child announced on its first line of stdout, or `None` if it said
+/// something else or nothing at all. Bounded, because a stand-in that never speaks
+/// would otherwise hang the suite instead of failing it.
+fn announced_port(stdout: ChildStdout) -> Option<u16> {
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let mut line = String::new();
+        let _ = BufReader::new(stdout).read_line(&mut line);
+        let _ = tx.send(line);
+    });
+    let line = rx.recv_timeout(Duration::from_secs(10)).ok()?;
+    line.trim().parse().ok()
 }
 
 #[test]
@@ -154,13 +184,16 @@ fn a_program_with_no_noidroid_code_records_and_replays() {
 
     let repo = Repo::open(&dir).unwrap();
     let pythonpath = format!("{}:{}", bootstrap_path().display(), client_path().display());
+    // 1. Record against the live stand-in.
+    let api = Api::start(&api_script);
+    let endpoint = api.endpoint();
     let spec = |name: Option<&str>| RunSpec {
         command: vec!["python3".into(), agent.display().to_string()],
         launch_dir: dir.clone(),
         name: name.map(str::to_string),
         env: vec![
             ("PYTHONPATH".into(), pythonpath.clone()),
-            ("FAKE_API".into(), format!("http://127.0.0.1:{PORT}")),
+            ("FAKE_API".into(), endpoint.clone()),
             // This agent only uses the sync client, and the async surface we cannot
             // cover would otherwise refuse the recording — which is the point of the
             // refusal, and why saying so explicitly is the honest way past it.
@@ -170,8 +203,6 @@ fn a_program_with_no_noidroid_code_records_and_replays() {
         watch: None,
     };
 
-    // 1. Record against the live stand-in.
-    let api = Api::start(&api_script);
     let recorded = engine::run(&repo, &spec(Some("auto-1")), Mode::Record, None)
         .expect("recording an uninstrumented program should work")
         .trajectory

--- a/crates/noidroid-core/tests/browser_slice.rs
+++ b/crates/noidroid-core/tests/browser_slice.rs
@@ -9,9 +9,11 @@
 
 use std::collections::BTreeMap;
 use std::fs;
+use std::io::{BufRead, BufReader};
 use std::net::TcpStream;
 use std::path::{Path, PathBuf};
-use std::process::{Child, Command, Stdio};
+use std::process::{Child, ChildStdout, Command, Stdio};
+use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
 use noidroid_core::engine::{self, Mode, RunSpec};
@@ -125,24 +127,32 @@ struct Site {
 }
 
 impl Site {
-    fn start(root: &Path, port: u16) -> Site {
+    /// Starts the example site on a port the OS picked, and reads that port back
+    /// from the child serving on it.
+    ///
+    /// A fixed port is a shared name: `connect` answering on one says only that
+    /// *something* is listening, so a site left behind by a killed run -- or a second
+    /// worktree of this repository running the same suite -- would be recorded in
+    /// place of the one this test started, and `stop` could not take it away. The
+    /// whole proof here is that the site is gone before the branch runs. See #74, and
+    /// `unique_socket_path` in the engine for the same remedy.
+    fn start(root: &Path) -> Site {
         let mut child = Command::new("python3")
             .arg(root.join("examples/browser_agent/site.py"))
-            .arg(port.to_string())
-            .stdout(Stdio::null())
+            .arg("0")
+            .stdout(Stdio::piped())
             .stderr(Stdio::null())
             .spawn()
             .expect("the example site should start");
-        let deadline = Instant::now() + Duration::from_secs(10);
-        while Instant::now() < deadline {
-            if TcpStream::connect(("127.0.0.1", port)).is_ok() {
-                return Site { child, port };
+        let stdout = child.stdout.take().expect("the child's stdout is a pipe");
+        match announced_port(stdout) {
+            Some(port) => Site { child, port },
+            None => {
+                let _ = child.kill();
+                let _ = child.wait();
+                panic!("the example site never announced a port");
             }
-            std::thread::sleep(Duration::from_millis(50));
         }
-        let _ = child.kill();
-        let _ = child.wait();
-        panic!("the example site never came up on port {port}");
     }
 
     fn stop(mut self) {
@@ -165,6 +175,21 @@ impl Drop for Site {
         let _ = self.child.kill();
         let _ = self.child.wait();
     }
+}
+
+/// The port the site announced on its first line of stdout -- `serving on
+/// http://127.0.0.1:<port>` -- or `None` if it said something else or nothing at all.
+/// Bounded, because a site that never speaks would otherwise hang the suite instead
+/// of failing it.
+fn announced_port(stdout: ChildStdout) -> Option<u16> {
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let mut line = String::new();
+        let _ = BufReader::new(stdout).read_line(&mut line);
+        let _ = tx.send(line);
+    });
+    let line = rx.recv_timeout(Duration::from_secs(10)).ok()?;
+    line.trim().rsplit(':').next()?.parse().ok()
 }
 
 struct Fixture {
@@ -294,10 +319,9 @@ fn a_browser_session_reconstructs_from_recorded_responses_alone() {
         return;
     }
 
-    let f = Fixture::new(8712);
-
     // 1. Record against the live site.
-    let site = Site::start(&f.root, f.port);
+    let site = Site::start(&repo_root());
+    let f = Fixture::new(site.port);
     let recorded = engine::run(&f.repo, &f.spec("web-1", true), Mode::Record, None)
         .expect("recording should succeed")
         .trajectory
@@ -392,8 +416,8 @@ fn a_browser_branch_can_reach_a_different_outcome() {
         return;
     }
 
-    let f = Fixture::new(8713);
-    let site = Site::start(&f.root, f.port);
+    let site = Site::start(&repo_root());
+    let f = Fixture::new(site.port);
 
     let recorded = engine::run(&f.repo, &f.spec("web-1", true), Mode::Record, None)
         .unwrap()
@@ -426,8 +450,8 @@ fn a_page_that_cannot_be_reproduced_makes_everything_after_it_unknown() {
         return;
     }
 
-    let f = Fixture::new(8714);
-    let site = Site::start(&f.root, f.port);
+    let site = Site::start(&repo_root());
+    let f = Fixture::new(site.port);
     let agent = f.dir.join("volatile_agent.py");
     fs::write(&agent, VOLATILE_AGENT).unwrap();
 

--- a/crates/noidroid-core/tests/proxy_slice.rs
+++ b/crates/noidroid-core/tests/proxy_slice.rs
@@ -11,9 +11,11 @@
 //! anything that still works came out of the recording.
 
 use std::fs;
+use std::io::{BufRead, BufReader};
 use std::net::TcpStream;
 use std::path::{Path, PathBuf};
-use std::process::{Child, Command, Stdio};
+use std::process::{Child, ChildStdout, Command, Stdio};
+use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
 use noidroid_core::engine::{self, Mode, RunSpec};
@@ -21,18 +23,12 @@ use noidroid_core::intact::Reading;
 use noidroid_core::model::EffectOutcome;
 use noidroid_core::Repo;
 
-const PORT: u16 = 8791;
-const STREAM_PORT: u16 = 8792;
-const GZIP_PORT: u16 = 8793;
-const OPAQUE_PORT: u16 = 8794;
-const LEGACY_GZIP_PORT: u16 = 8795;
-
 /// The replacement character. Its presence in a recorded body means bytes were
 /// dropped on the way in and nothing said so.
 const LOST: char = '\u{fffd}';
 
 const PROVIDER: &str = r#"
-import json, sys
+import json
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 class Handler(BaseHTTPRequestHandler):
@@ -50,13 +46,15 @@ class Handler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(body)
 
-ThreadingHTTPServer(("127.0.0.1", int(sys.argv[1])), Handler).serve_forever()
+server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+print(server.server_address[1], flush=True)
+server.serve_forever()
 "#;
 
 /// Emits a message stream the way a provider does: an event, a pause, another event.
 /// The pauses are the point — a proxy that buffers collapses them all to the end.
 const STREAMING_PROVIDER: &str = r#"
-import json, sys, time
+import json, time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 DELTAS = ["one ", "two ", "three ", "four ", "five ", "six"]
@@ -97,7 +95,9 @@ class Handler(BaseHTTPRequestHandler):
         self.wfile.write(b"0\r\n\r\n")
         self.wfile.flush()
 
-ThreadingHTTPServer(("127.0.0.1", int(sys.argv[1])), Handler).serve_forever()
+server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+print(server.server_address[1], flush=True)
+server.serve_forever()
 "#;
 
 /// Writes down *when* each token turned up, not just what it was. Same as the other
@@ -133,7 +133,7 @@ with open(os.environ["ARRIVALS_PATH"], "w", encoding="utf-8") as handle:
 /// the first time a provider changes its mind. It also reports back what it was
 /// asked for, so the recording shows which codings the proxy put its name to.
 const GZIP_PROVIDER: &str = r#"
-import gzip, json, sys
+import gzip, json
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 class Handler(BaseHTTPRequestHandler):
@@ -154,14 +154,15 @@ class Handler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(body)
 
-ThreadingHTTPServer(("127.0.0.1", int(sys.argv[1])), Handler).serve_forever()
+server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+print(server.server_address[1], flush=True)
+server.serve_forever()
 "#;
 
 /// Answers in a content coding the proxy has no way to undo, with bytes that are not
 /// text either. There is nothing honest to record here, so the only right answer is
 /// to say so.
 const OPAQUE_PROVIDER: &str = r#"
-import sys
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 BODY = bytes(range(200, 256)) * 8
@@ -177,7 +178,9 @@ class Handler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(BODY)
 
-ThreadingHTTPServer(("127.0.0.1", int(sys.argv[1])), Handler).serve_forever()
+server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+print(server.server_address[1], flush=True)
+server.serve_forever()
 "#;
 
 /// No noidroid import, and no base_url — it comes from the environment.
@@ -518,30 +521,58 @@ fn client_path() -> PathBuf {
         .expect("the python client is part of the repository")
 }
 
+/// The port the child announced on its first line of stdout, or `None` if it said
+/// something else or nothing at all. Bounded, because a provider that never speaks
+/// would otherwise hang the suite instead of failing it.
+fn announced_port(stdout: ChildStdout) -> Option<u16> {
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let mut line = String::new();
+        let _ = BufReader::new(stdout).read_line(&mut line);
+        let _ = tx.send(line);
+    });
+    let line = rx.recv_timeout(Duration::from_secs(10)).ok()?;
+    line.trim().parse().ok()
+}
+
 struct Provider {
     child: Child,
     port: u16,
 }
 
 impl Provider {
-    fn start(script: &Path, port: u16) -> Provider {
+    /// Starts the script on a port the OS picked, and reads that port back from the
+    /// child that is listening on it.
+    ///
+    /// The port has to come from the process we spawned. A fixed port is a shared
+    /// name, and `TcpStream::connect` answering on one proves only that *something* is
+    /// listening -- a provider left behind by a killed run, or a second worktree of
+    /// this repository running the same suite, gets recorded in place of the provider
+    /// under test. For `a_streamed_response_reaches_the_client_before_it_ends` that is
+    /// a wrong verdict rather than a confusing error, because a stale non-streaming
+    /// provider makes the arrival-spread assertion fail on a proxy that is fine.
+    /// Same remedy as `unique_socket_path` in the engine and as #44 gave `Store::put`:
+    /// never assume a name that another process could already hold.
+    fn start(script: &Path) -> Provider {
         let mut child = Command::new("python3")
             .arg(script)
-            .arg(port.to_string())
-            .stdout(Stdio::null())
+            .stdout(Stdio::piped())
             .stderr(Stdio::null())
             .spawn()
             .expect("the stand-in provider should start");
-        let deadline = Instant::now() + Duration::from_secs(10);
-        while Instant::now() < deadline {
-            if TcpStream::connect(("127.0.0.1", port)).is_ok() {
-                return Provider { child, port };
+        let stdout = child.stdout.take().expect("the child's stdout is a pipe");
+        match announced_port(stdout) {
+            Some(port) => Provider { child, port },
+            None => {
+                let _ = child.kill();
+                let _ = child.wait();
+                panic!("the stand-in provider never announced a port");
             }
-            std::thread::sleep(Duration::from_millis(50));
         }
-        let _ = child.kill();
-        let _ = child.wait();
-        panic!("the stand-in provider never came up");
+    }
+
+    fn endpoint(&self) -> String {
+        format!("http://127.0.0.1:{}", self.port)
     }
 
     fn stop(mut self) {
@@ -579,6 +610,42 @@ fn scratch(label: &str) -> PathBuf {
     dir
 }
 
+/// A provider handle refers to the process it started, never to whoever answered.
+///
+/// This is what a fixed port cost: with one, a second provider spawned while the
+/// first was up failed to bind, died, and `start` handed back a dead child paired
+/// with the incumbent's port -- so the run under test recorded against a server it
+/// had never started and could not stop. The check is behavioural: killing our own
+/// provider must take our own port down and leave the other one alone.
+#[test]
+fn a_provider_never_adopts_a_server_it_did_not_start() {
+    let dir = scratch("proxy-identity");
+    let script = dir.join("provider.py");
+    fs::write(&script, PROVIDER).unwrap();
+
+    let incumbent = Provider::start(&script);
+    let ours = Provider::start(&script);
+    assert_ne!(
+        ours.port, incumbent.port,
+        "two providers cannot both own one port"
+    );
+
+    // `stop` panics if anything still answers, which is the adoption case exactly.
+    let port = ours.port;
+    ours.stop();
+    assert!(
+        TcpStream::connect(("127.0.0.1", port)).is_err(),
+        "our provider's port stayed up after we killed our own child"
+    );
+    assert!(
+        TcpStream::connect(("127.0.0.1", incumbent.port)).is_ok(),
+        "we stopped a provider we did not start"
+    );
+
+    incumbent.stop();
+    let _ = fs::remove_dir_all(&dir);
+}
+
 #[test]
 fn an_agent_that_knows_nothing_about_us_records_and_replays() {
     if !sdk_available() {
@@ -597,6 +664,8 @@ fn an_agent_that_knows_nothing_about_us_records_and_replays() {
     );
 
     let repo = Repo::open(&dir).unwrap();
+    let provider = Provider::start(&provider_script);
+    let upstream = provider.endpoint();
     // Exactly what `noidroid run --proxy` builds: the proxy is an ordinary client of
     // the protocol that happens to run the agent as its own child.
     let spec = |name: Option<&str>| RunSpec {
@@ -605,7 +674,7 @@ fn an_agent_that_knows_nothing_about_us_records_and_replays() {
             "-m".into(),
             "noidroid.proxy".into(),
             "--upstream".into(),
-            format!("http://127.0.0.1:{PORT}"),
+            upstream.clone(),
             "--".into(),
             "python3".into(),
             agent.display().to_string(),
@@ -617,7 +686,6 @@ fn an_agent_that_knows_nothing_about_us_records_and_replays() {
         watch: None,
     };
 
-    let provider = Provider::start(&provider_script, PORT);
     let recorded = engine::run(&repo, &spec(Some("proxied")), Mode::Record, None)
         .expect("recording through the proxy should work")
         .trajectory
@@ -694,13 +762,15 @@ fn a_streamed_response_reaches_the_client_before_it_ends() {
     );
 
     let repo = Repo::open(&dir).unwrap();
+    let provider = Provider::start(&provider_script);
+    let upstream = provider.endpoint();
     let spec = |name: Option<&str>, timings: &Path| RunSpec {
         command: vec![
             "python3".into(),
             "-m".into(),
             "noidroid.proxy".into(),
             "--upstream".into(),
-            format!("http://127.0.0.1:{STREAM_PORT}"),
+            upstream.clone(),
             "--".into(),
             "python3".into(),
             agent.display().to_string(),
@@ -716,7 +786,6 @@ fn a_streamed_response_reaches_the_client_before_it_ends() {
     };
     let while_recording = dir.join("recorded-arrivals.txt");
 
-    let provider = Provider::start(&provider_script, STREAM_PORT);
     let recorded = engine::run(
         &repo,
         &spec(Some("streamed"), &while_recording),
@@ -821,13 +890,15 @@ fn a_compressed_response_is_never_recorded_as_replacement_characters() {
     fs::write(&agent, AGENT).unwrap();
 
     let repo = Repo::open(&dir).unwrap();
+    let provider = Provider::start(&provider_script);
+    let upstream = provider.endpoint();
     let spec = |name: Option<&str>| RunSpec {
         command: vec![
             "python3".into(),
             "-m".into(),
             "noidroid.proxy".into(),
             "--upstream".into(),
-            format!("http://127.0.0.1:{GZIP_PORT}"),
+            upstream.clone(),
             "--".into(),
             "python3".into(),
             agent.display().to_string(),
@@ -839,7 +910,6 @@ fn a_compressed_response_is_never_recorded_as_replacement_characters() {
         watch: None,
     };
 
-    let provider = Provider::start(&provider_script, GZIP_PORT);
     let recorded = engine::run(&repo, &spec(Some("gzipped")), Mode::Record, None)
         .expect("recording through the proxy should work")
         .trajectory
@@ -913,13 +983,14 @@ fn a_content_coding_we_cannot_decode_fails_the_call_instead_of_being_recorded() 
     fs::write(&agent, REPORTING_AGENT).unwrap();
 
     let repo = Repo::open(&dir).unwrap();
+    let provider = Provider::start(&provider_script);
     let spec = RunSpec {
         command: vec![
             "python3".into(),
             "-m".into(),
             "noidroid.proxy".into(),
             "--upstream".into(),
-            format!("http://127.0.0.1:{OPAQUE_PORT}"),
+            provider.endpoint(),
             "--".into(),
             "python3".into(),
             agent.display().to_string(),
@@ -931,7 +1002,6 @@ fn a_content_coding_we_cannot_decode_fails_the_call_instead_of_being_recorded() 
         watch: None,
     };
 
-    let provider = Provider::start(&provider_script, OPAQUE_PORT);
     let recorded = engine::run(&repo, &spec, Mode::Record, None)
         .expect("the run itself should complete; only the call fails")
         .trajectory
@@ -998,12 +1068,16 @@ fn a_trajectory_recorded_through_the_old_proxy_is_not_reported_as_simply_faithfu
     fs::write(&agent, AGENT).unwrap();
 
     let repo = Repo::open(&dir).unwrap();
+    // The legacy proxy takes its upstream on the command line, so the provider has to
+    // be up -- and its OS-assigned port known -- before `spec` can be built at all.
+    let provider = Provider::start(&provider_script);
+    let upstream = provider.endpoint();
     let spec = |name: Option<&str>| RunSpec {
         command: vec![
             "python3".into(),
             proxy_script.display().to_string(),
             "--upstream".into(),
-            format!("http://127.0.0.1:{LEGACY_GZIP_PORT}"),
+            upstream.clone(),
             "--".into(),
             "python3".into(),
             agent.display().to_string(),
@@ -1015,7 +1089,6 @@ fn a_trajectory_recorded_through_the_old_proxy_is_not_reported_as_simply_faithfu
         watch: None,
     };
 
-    let provider = Provider::start(&provider_script, LEGACY_GZIP_PORT);
     let recorded = engine::run(&repo, &spec(Some("legacy-gzipped")), Mode::Record, None)
         .expect("recording through the old proxy should still complete")
         .trajectory

--- a/crates/noidroid-core/tests/proxy_slice.rs
+++ b/crates/noidroid-core/tests/proxy_slice.rs
@@ -46,6 +46,13 @@ class Handler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(body)
 
+# ThreadingHTTPServer.server_bind() calls socket.getfqdn(host) to set
+# self.server_name, which is a REVERSE DNS LOOKUP -- and on some CI hosts that
+# has taken tens of seconds for "127.0.0.1", stalling the print() that the Rust
+# side is waiting on for a port number, which then reads as "never announced a
+# port" rather than what it actually is: a DNS lookup nobody asked for.
+import socket
+socket.getfqdn = lambda *a, **k: "localhost"
 server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
 print(server.server_address[1], flush=True)
 server.serve_forever()
@@ -95,6 +102,13 @@ class Handler(BaseHTTPRequestHandler):
         self.wfile.write(b"0\r\n\r\n")
         self.wfile.flush()
 
+# ThreadingHTTPServer.server_bind() calls socket.getfqdn(host) to set
+# self.server_name, which is a REVERSE DNS LOOKUP -- and on some CI hosts that
+# has taken tens of seconds for "127.0.0.1", stalling the print() that the Rust
+# side is waiting on for a port number, which then reads as "never announced a
+# port" rather than what it actually is: a DNS lookup nobody asked for.
+import socket
+socket.getfqdn = lambda *a, **k: "localhost"
 server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
 print(server.server_address[1], flush=True)
 server.serve_forever()
@@ -154,6 +168,13 @@ class Handler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(body)
 
+# ThreadingHTTPServer.server_bind() calls socket.getfqdn(host) to set
+# self.server_name, which is a REVERSE DNS LOOKUP -- and on some CI hosts that
+# has taken tens of seconds for "127.0.0.1", stalling the print() that the Rust
+# side is waiting on for a port number, which then reads as "never announced a
+# port" rather than what it actually is: a DNS lookup nobody asked for.
+import socket
+socket.getfqdn = lambda *a, **k: "localhost"
 server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
 print(server.server_address[1], flush=True)
 server.serve_forever()
@@ -178,6 +199,13 @@ class Handler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(BODY)
 
+# ThreadingHTTPServer.server_bind() calls socket.getfqdn(host) to set
+# self.server_name, which is a REVERSE DNS LOOKUP -- and on some CI hosts that
+# has taken tens of seconds for "127.0.0.1", stalling the print() that the Rust
+# side is waiting on for a port number, which then reads as "never announced a
+# port" rather than what it actually is: a DNS lookup nobody asked for.
+import socket
+socket.getfqdn = lambda *a, **k: "localhost"
 server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
 print(server.server_address[1], flush=True)
 server.serve_forever()

--- a/crates/noidroid-core/tests/proxy_slice.rs
+++ b/crates/noidroid-core/tests/proxy_slice.rs
@@ -531,7 +531,9 @@ fn announced_port(stdout: ChildStdout) -> Option<u16> {
         let _ = BufReader::new(stdout).read_line(&mut line);
         let _ = tx.send(line);
     });
-    let line = rx.recv_timeout(Duration::from_secs(10)).ok()?;
+    // A macOS CI runner spawning several python3 children at once has taken longer
+    // than 10s here; 30s still fails loudly on a genuinely stuck child.
+    let line = rx.recv_timeout(Duration::from_secs(30)).ok()?;
     line.trim().parse().ok()
 }
 

--- a/crates/noidroid-core/tests/proxy_slice.rs
+++ b/crates/noidroid-core/tests/proxy_slice.rs
@@ -15,7 +15,7 @@ use std::io::{BufRead, BufReader};
 use std::net::TcpStream;
 use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdout, Command, Stdio};
-use std::sync::mpsc;
+use std::sync::{mpsc, Mutex};
 use std::time::{Duration, Instant};
 
 use noidroid_core::engine::{self, Mode, RunSpec};
@@ -537,6 +537,17 @@ fn announced_port(stdout: ChildStdout) -> Option<u16> {
     line.trim().parse().ok()
 }
 
+/// Rust's test runner starts every `#[test]` fn in this binary on its own thread by
+/// default, so several tests can be spawning a `python3` provider at the same moment.
+/// On a machine with few cores that turned "read one line from a just-started child"
+/// into a genuine multi-second stall -- `a_provider_never_adopts_a_server_it_did_not_start`
+/// timed out waiting for its announcement twice on the macOS CI runner, at whatever
+/// bound the timeout was set to, which is what a starved reader looks like rather than
+/// what a hung child looks like. Serialising *startup* (spawn through the first line of
+/// output) rather than the whole test keeps every provider's launch from competing for
+/// the same handful of cores, without serialising the tests themselves.
+static PROVIDER_STARTING: Mutex<()> = Mutex::new(());
+
 struct Provider {
     child: Child,
     port: u16,
@@ -556,19 +567,30 @@ impl Provider {
     /// Same remedy as `unique_socket_path` in the engine and as #44 gave `Store::put`:
     /// never assume a name that another process could already hold.
     fn start(script: &Path) -> Provider {
+        let _slot = PROVIDER_STARTING.lock().unwrap_or_else(|e| e.into_inner());
         let mut child = Command::new("python3")
             .arg(script)
             .stdout(Stdio::piped())
-            .stderr(Stdio::null())
+            .stderr(Stdio::piped())
             .spawn()
             .expect("the stand-in provider should start");
         let stdout = child.stdout.take().expect("the child's stdout is a pipe");
+        let stderr = child.stderr.take().expect("the child's stderr is a pipe");
         match announced_port(stdout) {
             Some(port) => Provider { child, port },
             None => {
                 let _ = child.kill();
                 let _ = child.wait();
-                panic!("the stand-in provider never announced a port");
+                let mut said = String::new();
+                let _ = std::io::Read::read_to_string(&mut BufReader::new(stderr), &mut said);
+                panic!(
+                    "the stand-in provider never announced a port.{}",
+                    if said.trim().is_empty() {
+                        String::new()
+                    } else {
+                        format!(" It said:\n{said}")
+                    }
+                );
             }
         }
     }

--- a/examples/browser_agent/site.py
+++ b/examples/browser_agent/site.py
@@ -110,6 +110,12 @@ class Handler(BaseHTTPRequestHandler):
 
 
 def serve(port):
+    # ThreadingHTTPServer.server_bind() calls socket.getfqdn(host), a reverse DNS
+    # lookup that has stalled for tens of seconds on some CI hosts and delayed the
+    # announce line the browser test waits on for a port number.
+    import socket
+
+    socket.getfqdn = lambda *a, **k: "localhost"
     return ThreadingHTTPServer(("127.0.0.1", port), Handler)
 
 

--- a/examples/browser_agent/site.py
+++ b/examples/browser_agent/site.py
@@ -118,5 +118,8 @@ if __name__ == "__main__":
 
     port = int(sys.argv[1]) if len(sys.argv) > 1 else 8099
     server = serve(port)
-    print(f"serving on http://127.0.0.1:{port}")
+    # The port bound, not the port asked for. They differ when the argument is 0,
+    # which is what the browser test passes so the OS hands out a port nobody else
+    # holds -- and this line is where the test reads it back.
+    print(f"serving on http://127.0.0.1:{server.server_address[1]}", flush=True)
     server.serve_forever()


### PR DESCRIPTION
## Summary

`Provider::start` in `proxy_slice.rs` hardcoded ports `8791`-`8794`, polled
`TcpStream::connect`, and returned as soon as *something* answered — never
checking that the answerer was the process it had just spawned. A provider left
behind by a killed run, or a second worktree of this repository running its
suite at the same time, meant the next test recorded against someone else's
server. For `a_streamed_response_reaches_the_client_before_it_ends` that
produced the wrong verdict rather than a loud failure: a stale non-streaming
provider on the port made the arrival-spread assertion fail on a proxy fix
that was fine — which is what happened once during #30.

Two worktrees running `cargo test --all` concurrently is now the ordinary
case, not the exotic one, because `.claude/` gives every issue its own
worktree. Fix: every stand-in provider (`proxy_slice.rs`, `auto_slice.rs`) and
the example site `browser_slice.rs` drives now binds port 0 and prints the
port the OS actually gave it over its first line of stdout, instead of
assuming a port nobody else holds. Same remedy `unique_socket_path` has
always used, and the one #44 already applied to `Store::put`'s scratch name
and `watch_slice`'s fixture directory.

Added `a_provider_never_adopts_a_server_it_did_not_start`, which starts two
providers back to back and proves that killing the second only takes its own
port down — the invariant a fixed port could not have proven.

## Wider survey

Grepped the test tree for other hardcoded ports and other shared names two
concurrent worktrees would collide on.

- No other hardcoded ports remain in the test suite (`examples/browser_agent/agent.py`
  keeps a `127.0.0.1:8099` fallback, but that's a manual/README default, not exercised
  by the test suite — `browser_slice.rs` now passes `0` and reads the announced port
  back via `FLIGHT_SITE`).
- Every scratch-directory helper across the test tree already names itself from pid
  + nanoseconds (or pid + nanoseconds + a counter), which is sufficient to keep two
  *worktree processes* apart.
- Found a related but distinct bug: `Store`'s and `Tree`'s own unit-test `tmp()`
  helpers (`crates/noidroid-core/src/store.rs`, `crates/noidroid-core/src/tree.rs`)
  still lack the `SEQ` counter that #44 gave `Store::put` and `watch_slice` for the
  same reason — a collision between *threads of one process*, not between worktrees.
  That's a different mechanism from this issue, so it's filed separately rather than
  folded into this PR: #80.

## Verification

```
export PATH="$HOME/.cargo/bin:$PATH"
cargo fmt --all             # clean
cargo clippy --all-targets -- -D warnings   # clean
cargo test --all            # all green
```

`cargo test --test proxy_slice` run 8 times total (5 before rebase onto
`origin/main`, 3 after) — 0 failures every time.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --all`
- [x] `cargo test --test proxy_slice` x8, stable
- [x] New invariant test `a_provider_never_adopts_a_server_it_did_not_start` fails
      against the old fixed-port `Provider::start` (verified manually against a
      temporarily reverted copy) and passes against the fix

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)