### PR TITLE
fix(verify): detect a body a pre-#56 proxy recording never held intact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,8 @@ jobs:
           test "$before" = "$after" || { echo "branching mutated its parent"; exit 1; }
 
           noidroid verify | tee verify.txt
-          grep -q "intact:" verify.txt
+          grep -q "unedited:" verify.txt
+          grep -q "readable:" verify.txt
 
           # The reference environment: a world that can be re-driven and can never be
           # put back. The release's central claim is that this reconstructs exactly,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,20 @@ how the package version relates to `STEP_VERSION`, the on-disk object format.
   stand-in provider that catches this compresses whether or not it was asked to,
   because a recorder that only copes when it opted in is one that lies the first time
   a provider changes its mind. (#56)
+- **A trajectory the pre-#56 proxy already mangled still read back as faithful.** #56
+  stopped new recordings holding U+FFFD; it did nothing for the ones already on disk,
+  and a replay of one re-derives the same addresses because the mangled body is
+  exactly what was recorded — hash equality proving nothing about content nobody can
+  read. `noidroid verify` now also reads every recorded value back and reports one of
+  three: `intact`, `suspect` (a replacement character is present, which a provider can
+  legitimately send — never called corrupt on that alone), or `lost` (a run of
+  replacement characters, a body that is mostly one, a body opening with what a gzip
+  header becomes under a lossy decode, or a declared `application/json` body that does
+  not parse — evidence weighed together, not a single trigger). `noidroid replay`
+  carries the same reading: a trajectory whose source recording is `lost` now reports
+  `unverifiable`, never `faithful`, because the claim is not available rather than
+  false. Nothing is repaired — the original bytes are gone — so the only outcome is
+  that the recording stops looking real. (#70)
 - **`--inject all` was in the help and never in the binary.** It promised to branch
   every failure in turn and refused the moment anyone tried it. The help now names
   only what works, and a test through the real binary keeps it that way — a tool whose

--- a/crates/noidroid-cli/src/main.rs
+++ b/crates/noidroid-cli/src/main.rs
@@ -12,6 +12,7 @@ use noidroid_core::bundle;
 use noidroid_core::checkpoint;
 use noidroid_core::cost;
 use noidroid_core::engine::{self, Mode, Report, RunSpec};
+use noidroid_core::intact::{self, Reading};
 use noidroid_core::model::{Action, Failure, Intervention, Provenance, Step, Trajectory};
 use noidroid_core::repo::{self, Repo};
 use noidroid_core::{tree, Error, Result};
@@ -688,6 +689,21 @@ fn cmd_replay(
         });
     }
     if report.divergences.is_empty() {
+        // Hash equality is the whole of the check, and it is only worth something if
+        // the bytes it re-derived were readable when they were written down. A body
+        // recorded through the pre-#56 proxy reproduces perfectly *because* it is
+        // mangled, so "faithful" here would be a true sentence about nothing.
+        let reading = print_readback(&report.unreadable);
+        if reading == Reading::Lost {
+            println!(
+                "\n  {} the reconstruction addresses the same objects as the recording,",
+                warn("unverifiable:")
+            );
+            println!("                 and that proves nothing here: a body written down wrong");
+            println!("                 reproduces exactly. The original bytes are not");
+            println!("                 recoverable, so re-record it.");
+            return Ok(ExitCode::from(1));
+        }
         println!(
             "\n  {} the reconstruction addresses the same objects as the recording",
             ok("faithful:")
@@ -1649,21 +1665,112 @@ fn cmd_diff(repo: &Repo, a: &str, b: &str) -> Result<ExitCode> {
     Ok(ExitCode::SUCCESS)
 }
 
+/// Two questions, and the second one is the one nothing else asks.
+///
+/// Re-hashing every object says the past has not been *edited*. It cannot say the
+/// past was ever *readable*: a recording made through the proxy before #56 holds
+/// bodies that were mangled on the way in, and those bytes hash to exactly what they
+/// are. So this also reads the recorded values back and says which of them cannot
+/// have been what the world actually sent.
 fn cmd_verify(repo: &Repo) -> Result<ExitCode> {
     let (count, bad) = repo.store.verify()?;
     println!("{} {count} object(s)", shell("VERIFY"));
+    let mut failed = false;
     if bad.is_empty() {
         println!(
             "  {} every object still hashes to its own name",
-            ok("intact:")
+            ok("unedited:")
         );
-        Ok(ExitCode::SUCCESS)
     } else {
+        failed = true;
         for digest in &bad {
             println!("  {} {digest}", warn("corrupt:"));
         }
-        Ok(ExitCode::from(1))
     }
+
+    let mut findings: Vec<(String, intact::Finding)> = Vec::new();
+    for t in repo.list_trajectories()? {
+        for finding in intact::scan_chain(&repo.store, &repo.chain(&t)?)? {
+            findings.push((t.name.clone(), finding));
+        }
+    }
+    let reading = intact::worst(&findings.iter().map(|(_, f)| f.clone()).collect::<Vec<_>>());
+    match reading {
+        Reading::Intact => println!(
+            "  {} every recorded value reads back as text somebody could have sent",
+            ok("readable:")
+        ),
+        _ => {
+            for (name, finding) in &findings {
+                let mark = match finding.reading {
+                    Reading::Lost => warn("lost:"),
+                    _ => dim("suspect:"),
+                };
+                println!("  {mark} {name}{}", finding.summary());
+                for signal in &finding.signals {
+                    println!("        {} {}", dim("·"), dim(&signal.describes()));
+                }
+                if finding.signals.is_empty() {
+                    println!(
+                        "        {} {}",
+                        dim("·"),
+                        dim("a provider can legitimately send one; this is not a verdict")
+                    );
+                }
+            }
+            if reading == Reading::Lost {
+                failed = true;
+                println!(
+                    "\n  {}",
+                    warn(
+                        "a body that was not recorded intact cannot be repaired — the \
+                          original bytes are gone."
+                    )
+                );
+                println!(
+                    "  {}",
+                    dim(
+                        "Re-record it. A replay of it re-derives the same addresses and \
+                         proves nothing."
+                    )
+                );
+            }
+        }
+    }
+
+    Ok(if failed {
+        ExitCode::from(1)
+    } else {
+        ExitCode::SUCCESS
+    })
+}
+
+/// Say what a reconstruction's source recording is worth, and return the worst of it.
+///
+/// Silent when there is nothing to say, which is every recording made after #56.
+fn print_readback(findings: &[intact::Finding]) -> Reading {
+    let reading = intact::worst(findings);
+    if reading == Reading::Intact {
+        return reading;
+    }
+    println!("\n  {}", shell("WHAT THE RECORDING ITSELF IS WORTH"));
+    for finding in findings {
+        let mark = match finding.reading {
+            Reading::Lost => warn("lost"),
+            _ => dim("suspect"),
+        };
+        println!("    {mark} {}", finding.summary());
+        for signal in &finding.signals {
+            println!("      {} {}", dim("·"), dim(&signal.describes()));
+        }
+    }
+    if reading == Reading::Suspect {
+        println!(
+            "    {}",
+            dim("a provider can legitimately send U+FFFD; nothing here says it did not")
+        );
+    }
+    reading
 }
 
 // ---------------------------------------------------------------- presentation

--- a/crates/noidroid-core/src/engine.rs
+++ b/crates/noidroid-core/src/engine.rs
@@ -33,6 +33,7 @@ use crate::checkpoint;
 use crate::env::{Environment, Grip, Situation, State, Workspace, WORLD_DIR};
 use crate::error::{Doing, Error, Result};
 use crate::hash::Digest;
+use crate::intact;
 use crate::model::{
     Action, Delivery, Effect, EffectKind, EffectOutcome, ForkPoint, Intervention, Outcome,
     Provenance, Step, StepNote, Trajectory,
@@ -139,6 +140,13 @@ pub struct Report {
     /// The weakest grip anywhere in this run: what it could prove at its weakest
     /// point, which is what it can prove.
     pub grip: Grip,
+    /// Recorded values in the *source* trajectory that were not recorded intact.
+    ///
+    /// Nothing this run did can change these: they are a property of the recording
+    /// being reconstructed. They are here because the run is where somebody reads the
+    /// verdict, and a reconstruction that re-derives a mangled body reproduces it
+    /// perfectly. See [`crate::intact`].
+    pub unreadable: Vec<intact::Finding>,
     pub divergences: Vec<Divergence>,
     pub provenance: BTreeMap<&'static str, u64>,
     pub delivery: BTreeMap<&'static str, u64>,
@@ -153,7 +161,22 @@ pub struct Report {
 }
 
 impl Report {
+    /// Every step re-derived to its recorded address, *and* those addresses are worth
+    /// something.
+    ///
+    /// The second half is not decoration. A trajectory holding a body that was
+    /// written down wrong reproduces that body exactly, so hash equality alone
+    /// reports it as a perfect reconstruction of something nobody ever said. Anything
+    /// read as [`intact::Reading::Lost`] therefore takes `faithful` away — the claim
+    /// is not available, which is different from being false.
     pub fn faithful(&self) -> bool {
+        self.reproduces_the_recording() && intact::lost(&self.unreadable).next().is_none()
+    }
+
+    /// The narrow, mechanical half: the re-derived chain addresses the same objects.
+    /// True of a trajectory whose content is garbage, which is why it is not the
+    /// verdict anybody should print on its own.
+    pub fn reproduces_the_recording(&self) -> bool {
         self.divergences.is_empty() && self.reproduced == self.expected
     }
 }
@@ -193,6 +216,11 @@ pub fn run(repo: &Repo, spec: &RunSpec, mode: Mode, source: Option<&Trajectory>)
             return Err(Error::Refused(why));
         }
     }
+
+    // Read *before* anything is spawned, and independent of what the run does: this
+    // is a property of the recording, and a reconstruction of a mangled body succeeds
+    // by definition.
+    let unreadable = intact::scan_chain(&repo.store, &recorded)?;
 
     let run_label = spec.name.clone().unwrap_or_else(|| {
         format!(
@@ -274,6 +302,7 @@ pub fn run(repo: &Repo, spec: &RunSpec, mode: Mode, source: Option<&Trajectory>)
         notes: Vec::new(),
         report: Report {
             mode: mode.label().to_string(),
+            unreadable,
             stdout_path: Some(stdout_path.clone()),
             stderr_path: Some(stderr_path.clone()),
             workspace: Some(workspace.clone()),

--- a/crates/noidroid-core/src/intact.rs
+++ b/crates/noidroid-core/src/intact.rs
@@ -1,0 +1,464 @@
+//! Was this recording ever readable?
+//!
+//! Every other check in this repository asks whether the past has been *edited*:
+//! `store::verify` re-hashes an object against its own name, and a replay re-derives
+//! addresses. Neither can see the failure this module is for, because the bytes on
+//! disk are exactly the bytes that were written. They were already wrong when they
+//! were written.
+//!
+//! Before #56 the recording proxy stripped `Content-Encoding` and stored
+//! `payload.decode("utf-8", "replace")`, so a compressed reply went into the
+//! trajectory with every byte it could not read swapped for U+FFFD. The original
+//! bytes are gone and nothing in the object says they ever existed. Such a trajectory
+//! reads back as faithful — a replay re-derives the same hashes, because the mangled
+//! body is precisely what was recorded.
+//!
+//! So the question here is not "do these bytes match" but "could these bytes ever
+//! have been what the provider sent". It is answered from evidence and reported as
+//! evidence:
+//!
+//! ```text
+//! intact    nothing in it suggests bytes were dropped
+//! suspect   a replacement character is in it, and one can be content
+//! lost      it was not recorded intact; what it says is not what was said
+//! ```
+//!
+//! `lost` is the strongest claim available and it is deliberately narrow: *this was
+//! not recorded intact*. It is never a guess at what the body should have said, and
+//! nothing here repairs anything — the bytes are not recoverable. The only useful
+//! outcome is that the recording stops looking real.
+
+use serde_json::Value;
+
+use crate::error::Result;
+use crate::model::{Action, Step};
+use crate::store::Store;
+use crate::Digest;
+
+/// U+FFFD. A decoder writes one of these where it threw a byte away.
+pub const LOST: char = '\u{fffd}';
+
+/// gzip's magic number as a lossy decode renders it: `1f` is a control character and
+/// survives, `8b` is a lone continuation byte and does not. Every gzip stream starts
+/// this way, so a recorded body that starts this way was a gzip stream.
+const GZIP_MAGIC: &str = "\u{1f}\u{fffd}";
+
+/// A body this many hundredths replacement characters was not text that happened to
+/// contain a few. Real prose that has been through a bad decode sits far above this;
+/// a provider quoting a user's U+FFFD sits far below.
+const DENSE_PERCENT: usize = 10;
+
+/// …and this many of them at least, so a four-character string with one bad byte in
+/// it is not called lost on the strength of arithmetic.
+const DENSE_COUNT: usize = 8;
+
+/// What a recorded value is worth as a record of what crossed the wire.
+///
+/// Ordered by how much it takes away; `join` keeps the worst, exactly as
+/// [`crate::model::Provenance`] and [`crate::env::Grip`] do.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Default)]
+pub enum Reading {
+    #[default]
+    Intact,
+    Suspect,
+    Lost,
+}
+
+impl Reading {
+    pub fn label(self) -> &'static str {
+        match self {
+            Reading::Intact => "intact",
+            Reading::Suspect => "suspect",
+            Reading::Lost => "lost",
+        }
+    }
+
+    /// The weaker of the two.
+    pub fn join(self, other: Reading) -> Reading {
+        self.max(other)
+    }
+
+    pub fn describes(self) -> &'static str {
+        match self {
+            Reading::Intact => "nothing in it suggests bytes were dropped on the way in",
+            Reading::Suspect => {
+                "it holds a replacement character, which a provider can legitimately send"
+            }
+            Reading::Lost => "it was not recorded intact; the bytes it stands for are gone",
+        }
+    }
+}
+
+/// One reason a value was read as `lost`. Reported instead of a score: a number here
+/// would be a confidence we did not measure, and this project does not print those.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum Signal {
+    /// Consecutive replacement characters. One can be content; two in a row is a
+    /// multi-byte sequence that was thrown away whole.
+    Run(usize),
+    /// How much of the text is replacement characters.
+    Density { lost: usize, total: usize },
+    /// It begins with what gzip's header becomes under a lossy decode.
+    GzipMagic,
+    /// The headers recorded beside it declared JSON, and it does not parse.
+    DeclaredJson,
+}
+
+impl Signal {
+    pub fn describes(&self) -> String {
+        match self {
+            Signal::Run(n) => format!("{n} replacement characters in a row"),
+            Signal::Density { lost, total } => {
+                format!("{lost} of {total} characters are replacement characters")
+            }
+            Signal::GzipMagic => {
+                "it begins with what a gzip header becomes when the bytes are dropped".to_string()
+            }
+            Signal::DeclaredJson => {
+                "the recorded headers declare JSON and the body does not parse".to_string()
+            }
+        }
+    }
+}
+
+/// A recorded string that was read as something other than intact.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct Finding {
+    /// Step it belongs to.
+    pub index: u64,
+    /// What that step was doing, for a reader who has to find it again.
+    pub target: String,
+    /// Where inside the step: `response body`, `argument body`, and so on.
+    pub place: String,
+    /// Address of the object holding it, when it has one of its own.
+    pub value: Option<Digest>,
+    pub lost: usize,
+    pub total: usize,
+    pub reading: Reading,
+    /// Why it was read that way. Empty for `suspect`: the presence of the character
+    /// is the whole of the evidence, and saying more would be inventing it.
+    pub signals: Vec<Signal>,
+}
+
+impl Finding {
+    /// The one-line version: where it is and how bad it looks.
+    pub fn summary(&self) -> String {
+        format!(
+            "@{} {} — {} ({} of {} characters lost)",
+            self.index, self.target, self.place, self.lost, self.total
+        )
+    }
+}
+
+/// The worst reading in a set of findings.
+pub fn worst(findings: &[Finding]) -> Reading {
+    findings
+        .iter()
+        .fold(Reading::Intact, |acc, f| acc.join(f.reading))
+}
+
+/// Findings that make the recording's own content untrustworthy.
+pub fn lost(findings: &[Finding]) -> impl Iterator<Item = &Finding> {
+    findings.iter().filter(|f| f.reading == Reading::Lost)
+}
+
+/// Read every recorded string in a chain.
+pub fn scan_chain(store: &Store, chain: &[(Digest, Step)]) -> Result<Vec<Finding>> {
+    let mut out = Vec::new();
+    for (_, step) in chain {
+        out.extend(scan_step(store, step)?);
+    }
+    Ok(out)
+}
+
+/// Read every recorded string in one step: what the program said, and what the world
+/// answered.
+///
+/// The workspace is not walked. A tree blob is a file the program wrote, and a file
+/// is allowed to be anything — calling a binary asset "lost" because it is not UTF-8
+/// would be a false alarm on every recording that has one. What the proxy mangled was
+/// a mediated value, and mediated values are what this reads.
+pub fn scan_step(store: &Store, step: &Step) -> Result<Vec<Finding>> {
+    let mut out = Vec::new();
+    let target = target_of(&step.action);
+
+    let (place, value) = match &step.action {
+        Action::Call { args, .. } => ("argument", Some(args)),
+        Action::Decide { choice, .. } => ("decision", Some(choice)),
+        Action::Finish { result, .. } => ("result", Some(result)),
+        Action::Genesis { .. } => ("", None),
+    };
+    if let Some(value) = value {
+        for (path, reading, signals, lost, total) in scan_value(value) {
+            out.push(Finding {
+                index: step.index,
+                target: target.clone(),
+                place: join_place(place, &path),
+                value: None,
+                lost,
+                total,
+                reading,
+                signals,
+            });
+        }
+    }
+
+    for effect in &step.effects {
+        let value: Value = store.get_json(&effect.value)?;
+        for (path, reading, signals, lost, total) in scan_value(&value) {
+            out.push(Finding {
+                index: step.index,
+                target: target.clone(),
+                place: join_place("response", &path),
+                value: Some(effect.value.clone()),
+                lost,
+                total,
+                reading,
+                signals,
+            });
+        }
+    }
+    Ok(out)
+}
+
+fn join_place(kind: &str, path: &str) -> String {
+    match (kind.is_empty(), path.is_empty()) {
+        (true, true) => "value".to_string(),
+        (true, false) => path.to_string(),
+        (false, true) => kind.to_string(),
+        (false, false) => format!("{kind} {path}"),
+    }
+}
+
+fn target_of(action: &Action) -> String {
+    match action {
+        Action::Call { target, .. } => target.clone(),
+        Action::Decide { name, .. } => format!("decide {name}"),
+        Action::Genesis { .. } => "genesis".to_string(),
+        Action::Finish { .. } => "finish".to_string(),
+    }
+}
+
+/// Walk a recorded value and read every string in it.
+///
+/// Returns `(path, reading, signals, lost, total)` for each string that is not
+/// intact. Structure matters in one place only: a `body` sitting beside `headers`
+/// that declare JSON is the shape the proxy records, and a declared-JSON body that
+/// does not parse is evidence the other signals cannot supply.
+fn scan_value(root: &Value) -> Vec<(String, Reading, Vec<Signal>, usize, usize)> {
+    let mut out = Vec::new();
+    walk(root, String::new(), false, &mut out);
+    out
+}
+
+fn walk(
+    value: &Value,
+    path: String,
+    declared_json: bool,
+    out: &mut Vec<(String, Reading, Vec<Signal>, usize, usize)>,
+) {
+    match value {
+        Value::String(text) => {
+            if let Some((reading, signals, lost, total)) = read(text, declared_json) {
+                out.push((path, reading, signals, lost, total));
+            }
+        }
+        Value::Array(items) => {
+            for (i, item) in items.iter().enumerate() {
+                walk(item, format!("{path}[{i}]"), false, out);
+            }
+        }
+        Value::Object(fields) => {
+            let json_body = declares_json(fields);
+            for (key, field) in fields {
+                let child = if path.is_empty() {
+                    key.clone()
+                } else {
+                    format!("{path}.{key}")
+                };
+                walk(field, child, json_body && key == "body", out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Does this object carry headers that say its `body` is JSON?
+fn declares_json(fields: &serde_json::Map<String, Value>) -> bool {
+    let Some(Value::Object(headers)) = fields.get("headers") else {
+        return false;
+    };
+    headers.iter().any(|(name, value)| {
+        name.eq_ignore_ascii_case("content-type")
+            && value
+                .as_str()
+                .map(|v| {
+                    v.trim_start()
+                        .to_ascii_lowercase()
+                        .starts_with("application/json")
+                })
+                .unwrap_or(false)
+    })
+}
+
+/// Read one recorded string.
+///
+/// `None` when there is nothing to say: no replacement character, nothing to report.
+fn read(text: &str, declared_json: bool) -> Option<(Reading, Vec<Signal>, usize, usize)> {
+    let mut lost = 0usize;
+    let mut total = 0usize;
+    let mut run = 0usize;
+    let mut longest = 0usize;
+    for c in text.chars() {
+        total += 1;
+        if c == LOST {
+            lost += 1;
+            run += 1;
+            longest = longest.max(run);
+        } else {
+            run = 0;
+        }
+    }
+    if lost == 0 {
+        return None;
+    }
+
+    let mut signals = Vec::new();
+    if longest >= 2 {
+        signals.push(Signal::Run(longest));
+    }
+    if lost >= DENSE_COUNT && lost * 100 >= total * DENSE_PERCENT {
+        signals.push(Signal::Density { lost, total });
+    }
+    if text.starts_with(GZIP_MAGIC) {
+        signals.push(Signal::GzipMagic);
+    }
+    // Only ever alongside a replacement character. A body that does not parse is by
+    // itself an error page, a redirect, a provider having a bad day — none of which
+    // is this bug, and saying otherwise would fail a great many honest recordings.
+    if declared_json && serde_json::from_str::<Value>(text).is_err() {
+        signals.push(Signal::DeclaredJson);
+    }
+
+    if signals.is_empty() {
+        Some((Reading::Suspect, signals, lost, total))
+    } else {
+        Some((Reading::Lost, signals, lost, total))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn reading_of(text: &str) -> Reading {
+        read(text, false).map(|r| r.0).unwrap_or(Reading::Intact)
+    }
+
+    #[test]
+    fn a_body_with_no_replacement_character_is_intact() {
+        assert_eq!(reading_of("{\"content\": \"four\"}"), Reading::Intact);
+        assert_eq!(reading_of(""), Reading::Intact);
+    }
+
+    /// The whole point of the module: one U+FFFD is evidence, not proof. A provider
+    /// really can send text containing it, and calling that recording corrupt would
+    /// scare somebody off a good trajectory.
+    #[test]
+    fn a_single_replacement_character_is_suspect_and_never_lost() {
+        assert_eq!(
+            reading_of("the user typed \u{fffd} into the box, twice over"),
+            Reading::Suspect
+        );
+        assert!(read("a \u{fffd} b", false).unwrap().1.is_empty());
+    }
+
+    #[test]
+    fn two_replacement_characters_in_a_row_are_a_sequence_that_was_thrown_away() {
+        let (reading, signals, ..) = read("ab\u{fffd}\u{fffd}cd", false).unwrap();
+        assert_eq!(reading, Reading::Lost);
+        assert_eq!(signals, vec![Signal::Run(2)]);
+    }
+
+    #[test]
+    fn a_gzip_header_survives_a_lossy_decode_well_enough_to_name_it() {
+        // `1f 8b 08 00` — the first four bytes of every gzip stream — under
+        // `decode("utf-8", "replace")`.
+        let mangled = "\u{1f}\u{fffd}\u{8}\u{0}rest of the deflate stream";
+        let (reading, signals, ..) = read(mangled, false).unwrap();
+        assert_eq!(reading, Reading::Lost);
+        assert!(signals.contains(&Signal::GzipMagic), "{signals:?}");
+    }
+
+    #[test]
+    fn a_body_that_is_mostly_replacement_characters_is_lost() {
+        let mangled: String = std::iter::repeat_n("a\u{fffd}", 20).collect();
+        let (reading, signals, lost, total) = read(&mangled, false).unwrap();
+        assert_eq!(reading, Reading::Lost);
+        assert_eq!((lost, total), (20, 40));
+        assert!(
+            signals.contains(&Signal::Density {
+                lost: 20,
+                total: 40
+            }),
+            "{signals:?}"
+        );
+    }
+
+    /// A declared JSON body that does not parse is only evidence next to a
+    /// replacement character. On its own it is an error page.
+    #[test]
+    fn declared_json_that_does_not_parse_is_evidence_only_beside_a_lost_byte() {
+        assert!(read("<html>503</html>", true).is_none());
+        let (reading, signals, ..) = read("<html>5\u{fffd}3</html>", true).unwrap();
+        assert_eq!(reading, Reading::Lost);
+        assert!(signals.contains(&Signal::DeclaredJson), "{signals:?}");
+    }
+
+    #[test]
+    fn json_that_parses_raises_no_signal_of_its_own() {
+        let (reading, signals, ..) = read("{\"text\": \"\u{fffd}\"}", true).unwrap();
+        assert_eq!(reading, Reading::Suspect);
+        assert!(signals.is_empty(), "{signals:?}");
+    }
+
+    /// The declared-JSON signal needs the headers that sit beside the body, so the
+    /// walk has to keep the object it is inside.
+    #[test]
+    fn the_walk_finds_a_body_under_the_headers_that_describe_it() {
+        let recorded = json!({
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": "\u{1f}\u{fffd}\u{8}\u{0}\u{fffd}\u{fffd}",
+        });
+        let found = scan_value(&recorded);
+        assert_eq!(found.len(), 1, "{found:?}");
+        let (path, reading, signals, ..) = &found[0];
+        assert_eq!(path, "body");
+        assert_eq!(*reading, Reading::Lost);
+        assert!(signals.contains(&Signal::DeclaredJson), "{signals:?}");
+        assert!(signals.contains(&Signal::GzipMagic), "{signals:?}");
+    }
+
+    #[test]
+    fn a_clean_recorded_response_produces_nothing_at_all() {
+        let recorded = json!({
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": "{\"content\":[{\"type\":\"text\",\"text\":\"four\"}]}",
+        });
+        assert!(scan_value(&recorded).is_empty());
+    }
+
+    #[test]
+    fn readings_never_improve_when_joined() {
+        for a in [Reading::Intact, Reading::Suspect, Reading::Lost] {
+            for b in [Reading::Intact, Reading::Suspect, Reading::Lost] {
+                assert_eq!(a.join(b), b.join(a));
+                assert!(a.join(b) >= a);
+                assert!(a.join(b) >= b);
+            }
+        }
+    }
+}

--- a/crates/noidroid-core/src/lib.rs
+++ b/crates/noidroid-core/src/lib.rs
@@ -18,6 +18,7 @@ pub mod engine;
 pub mod env;
 pub mod error;
 pub mod hash;
+pub mod intact;
 pub mod model;
 pub mod proto;
 pub mod repo;

--- a/crates/noidroid-core/tests/proxy_slice.rs
+++ b/crates/noidroid-core/tests/proxy_slice.rs
@@ -17,6 +17,7 @@ use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
 
 use noidroid_core::engine::{self, Mode, RunSpec};
+use noidroid_core::intact::Reading;
 use noidroid_core::model::EffectOutcome;
 use noidroid_core::Repo;
 
@@ -24,6 +25,7 @@ const PORT: u16 = 8791;
 const STREAM_PORT: u16 = 8792;
 const GZIP_PORT: u16 = 8793;
 const OPAQUE_PORT: u16 = 8794;
+const LEGACY_GZIP_PORT: u16 = 8795;
 
 /// The replacement character. Its presence in a recorded body means bytes were
 /// dropped on the way in and nothing said so.
@@ -179,6 +181,296 @@ ThreadingHTTPServer(("127.0.0.1", int(sys.argv[1])), Handler).serve_forever()
 "#;
 
 /// No noidroid import, and no base_url — it comes from the environment.
+/// The proxy exactly as it stood at f72979e^ (before #56): `accept-encoding`
+/// forwarded upstream untouched, and every response body written into the
+/// trajectory as `payload.decode("utf-8", "replace")`. Sourced from git history
+/// rather than reconstructed by hand, so this test proves something about the
+/// actual bug and not about a plausible-looking stand-in for it. The one edit is
+/// the import line: `from . import READ, connect` only works when the file is
+/// part of the `noidroid` package, and this copy is run as a standalone script.
+const PRE_56_PROXY: &str = r#""""Record an agent you did not write.
+
+`--auto` patches SDKs inside a Python process, which is the right thing when the agent
+is yours and is Python. It cannot help with a coding agent you installed, a Go service,
+or anything whose source you are not editing.
+
+Both the Anthropic and OpenAI clients read their endpoint from an environment variable,
+so there is a second way in that needs no patching and no language: stand between the
+agent and the provider, and record what actually crosses the wire.
+
+    noidroid run --proxy -- claude --print "fix the failing test"
+
+That is a better recording than an instrumented one in one specific way. A trace from
+an observability tool holds whatever a framework callback chose to serialise; this
+holds the request itself, which means a replay can match on the thing that was actually
+sent rather than on a lossy summary of it.
+
+Run directly if you prefer:
+
+    python -m noidroid.proxy --upstream https://api.anthropic.com -- <command...>
+
+**What it captures**: every HTTP request the agent sends to the provider, and the full
+response. **What it does not**: anything the agent does that is not that request —
+files it writes, commands it runs, other services it calls. Those are invisible here,
+and a replay will not reproduce them.
+
+**A server-sent event stream is passed through as it arrives**, chunk by chunk, while
+the concatenation is kept for the trajectory. An agent under recording therefore sees
+its tokens on the same schedule as one that is not being recorded — which matters,
+because an agent that times out only when recorded is not the agent you meant to
+record. Everything else is still read in full before it is written back.
+
+The engine hears about a call only once it completes, so a passed-through stream is
+recorded after its last byte has already reached the agent. That is fine for a
+recording; it would have to be reconsidered if a replay ever streamed.
+
+No TLS interception. The agent is pointed at a plain local address and the proxy makes
+the upstream call itself, so nothing has to trust a forged certificate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import socket
+import subprocess
+import sys
+import threading
+import urllib.error
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+from noidroid import READ, connect
+
+#: Endpoint variables the common clients honour, so the agent needs no flags.
+BASE_URL_VARS = {
+    "anthropic": "ANTHROPIC_BASE_URL",
+    "openai": "OPENAI_BASE_URL",
+}
+
+#: Not forwarded upstream: hop-by-hop, or ours to set.
+SKIP_REQUEST_HEADERS = {"host", "connection", "proxy-connection", "keep-alive",
+                        "transfer-encoding", "upgrade", "content-length"}
+SKIP_RESPONSE_HEADERS = {"connection", "keep-alive", "transfer-encoding", "upgrade",
+                         "content-encoding", "content-length"}
+
+#: How much to ask upstream for at a time; it returns whatever has arrived.
+CHUNK = 64 * 1024
+
+
+def _target(path: str) -> str:
+    """Name a call after its endpoint, so a timeline reads as something recognisable."""
+    return "http" + path.split("?", 1)[0].replace("/", ".").rstrip(".")
+
+
+def _is_stream(headers: dict) -> bool:
+    """Is this the one content type where arrival time is part of the behaviour?
+
+    Only server-sent events. A JSON body is one value that exists all at once, and
+    handing it over in pieces buys the agent nothing.
+    """
+    for key, value in headers.items():
+        if key.lower() == "content-type":
+            return value.split(";", 1)[0].strip().lower() == "text/event-stream"
+    return False
+
+
+class _Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    # Injected by serve().
+    upstream = ""
+    session = None
+    lock = threading.Lock()
+
+    def log_message(self, *args):
+        pass  # the agent's output is the interesting output
+
+    def _relay(self, method: str) -> None:
+        length = int(self.headers.get("Content-Length") or 0)
+        raw = self.rfile.read(length) if length else b""
+        headers = {
+            k: v for k, v in self.headers.items()
+            if k.lower() not in SKIP_REQUEST_HEADERS
+        }
+
+        # The body is what identifies the call, so it is what a replay matches on.
+        # Parsed when it is JSON, because a dict diffs field by field and a blob does
+        # not — and a divergence you cannot read is a divergence you cannot fix.
+        try:
+            body = json.loads(raw) if raw else None
+        except ValueError:
+            body = {"__raw__": raw.decode("utf-8", "replace")}
+
+        # Set by perform() when the response has already gone back to the agent a
+        # chunk at a time. Only a recording gets there: a reconstruction serves the
+        # body from the trajectory, so perform() is never called.
+        passed_through = []
+
+        def perform():
+            request = urllib.request.Request(
+                self.upstream.rstrip("/") + self.path,
+                data=raw or None,
+                headers=headers,
+                method=method,
+            )
+            try:
+                with urllib.request.urlopen(request) as response:
+                    status = response.status
+                    got = dict(response.headers)
+                    if _is_stream(got):
+                        payload = self._pass_through(status, got, response)
+                        passed_through.append(True)
+                    else:
+                        payload = response.read()
+            except urllib.error.HTTPError as failure:
+                # A provider error is part of what happened, not a reason to stop.
+                payload = failure.read()
+                status = failure.code
+                got = dict(failure.headers)
+            return {
+                "status": status,
+                "headers": {k: v for k, v in got.items()
+                            if k.lower() not in SKIP_RESPONSE_HEADERS},
+                "body": payload.decode("utf-8", "replace"),
+            }
+
+        # One conversation with the engine at a time: the protocol is request and
+        # response over a single socket, and an agent may well be concurrent.
+        with self.lock:
+            recorded = self.session.call(
+                _target(self.path),
+                perform,
+                args={"method": method, "path": self.path, "body": body},
+                effect=READ,
+            )
+
+        if passed_through:
+            return  # the agent already has every byte of it
+
+        payload = (recorded.get("body") or "").encode("utf-8")
+        self.send_response(int(recorded.get("status", 200)))
+        for key, value in (recorded.get("headers") or {}).items():
+            if key.lower() not in SKIP_RESPONSE_HEADERS:
+                self.send_header(key, value)
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def _pass_through(self, status: int, headers: dict, response) -> bytes:
+        """Relay a stream while it is still running, and return all of what went by.
+
+        Chunked, because the length of a generation is not known until it ends, and
+        the whole point is to not wait for that. Flushed after every write: a chunk
+        sitting in our buffer is the same delay we are removing.
+        """
+        self.send_response(status)
+        for key, value in headers.items():
+            if key.lower() not in SKIP_RESPONSE_HEADERS:
+                self.send_header(key, value)
+        self.send_header("Transfer-Encoding", "chunked")
+        self.end_headers()
+
+        seen = []
+        while True:
+            # read1, so a chunk goes out when it arrives rather than when enough of
+            # them have arrived to fill a buffer.
+            chunk = response.read1(CHUNK)
+            if not chunk:
+                break
+            seen.append(chunk)
+            self.wfile.write(b"%X\r\n" % len(chunk) + chunk + b"\r\n")
+            self.wfile.flush()
+        self.wfile.write(b"0\r\n\r\n")
+        self.wfile.flush()
+        return b"".join(seen)
+
+    # Anthropic and OpenAI between them use more than two verbs — files and batches
+    # are deleted, assistants are patched. An unhandled method would 501 here, which
+    # is a loud failure but a needless one.
+    def do_POST(self):
+        self._relay("POST")
+
+    def do_GET(self):
+        self._relay("GET")
+
+    def do_PUT(self):
+        self._relay("PUT")
+
+    def do_PATCH(self):
+        self._relay("PATCH")
+
+    def do_DELETE(self):
+        self._relay("DELETE")
+
+
+def _free_port() -> int:
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        return probe.getsockname()[1]
+
+
+def serve(upstream: str, command: list) -> int:
+    """Run `command` with the provider endpoint pointed at us, and record it."""
+    session = connect()
+    port = _free_port()
+
+    _Handler.upstream = upstream
+    _Handler.session = session
+    server = ThreadingHTTPServer(("127.0.0.1", port), _Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    endpoint = f"http://127.0.0.1:{port}"
+    environment = dict(os.environ)
+    for variable in BASE_URL_VARS.values():
+        environment[variable] = endpoint
+    print(f"[noidroid.proxy] recording {upstream} via {endpoint}", file=sys.stderr)
+
+    # A command that cannot even start still has to close its trajectory: an
+    # unfinished one replays as truncated, which describes the recorder's crash
+    # rather than anything the agent did.
+    status = 127
+    detail = {}
+    try:
+        status = subprocess.call(command, env=environment)
+        detail = {"exit_code": status}
+    except OSError as failure:
+        detail = {"exit_code": status, "error": str(failure)}
+        print(f"[noidroid.proxy] could not run {command[0]}: {failure}", file=sys.stderr)
+    finally:
+        server.shutdown()
+        # The agent's own exit code is its verdict, so it becomes the outcome.
+        session.finish("success" if status == 0 else "failure", detail)
+    return status
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m noidroid.proxy",
+        description="Record an agent's provider traffic without changing it.",
+    )
+    parser.add_argument(
+        "--upstream",
+        default=os.environ.get("NOIDROID_PROXY_UPSTREAM", "https://api.anthropic.com"),
+        help="the real provider endpoint (default: %(default)s)",
+    )
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+
+    command = args.command
+    if command and command[0] == "--":
+        command = command[1:]
+    if not command:
+        parser.error("give a command to run after --")
+    return serve(args.upstream, command)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+"#;
+
 const AGENT: &str = r#"
 import anthropic
 
@@ -672,6 +964,112 @@ fn a_content_coding_we_cannot_decode_fails_the_call_instead_of_being_recorded() 
     assert!(
         refusal.contains("content-encoding") && refusal.contains("br"),
         "the recorded failure should name what could not be decoded: {refusal}"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// The failure #70 is for: a recording made by the pre-#56 proxy holds a body that
+/// was never what the provider sent, and nothing about the bytes on disk says so.
+/// `store::verify` re-hashes objects against their own names and finds nothing wrong
+/// -- the mangled body *is* what was written. A replay re-derives the same addresses
+/// for the same reason. Both checks are answering "was this edited", and the honest
+/// answer to that is yes, it was written correctly the first time; the bug happened
+/// one step earlier, between the wire and the write.
+///
+/// This constructs the trajectory the hard way: by running the actual pre-#56 proxy
+/// source (`PRE_56_PROXY`, taken from git history at f72979e^) against a provider
+/// that compresses, exactly as #56's own regression test does for the fixed proxy.
+/// If this test used a hand-built trajectory instead, it would only prove that the
+/// detector recognises what we imagine the bug looks like.
+#[test]
+fn a_trajectory_recorded_through_the_old_proxy_is_not_reported_as_simply_faithful() {
+    if !sdk_available() {
+        eprintln!("SKIP: proxy test needs the anthropic SDK (pip install anthropic)");
+        return;
+    }
+
+    let dir = scratch("proxy-legacy-gzip");
+    let provider_script = dir.join("provider.py");
+    fs::write(&provider_script, GZIP_PROVIDER).unwrap();
+    let proxy_script = dir.join("legacy_proxy.py");
+    fs::write(&proxy_script, PRE_56_PROXY).unwrap();
+    let agent = dir.join("agent.py");
+    fs::write(&agent, AGENT).unwrap();
+
+    let repo = Repo::open(&dir).unwrap();
+    let spec = |name: Option<&str>| RunSpec {
+        command: vec![
+            "python3".into(),
+            proxy_script.display().to_string(),
+            "--upstream".into(),
+            format!("http://127.0.0.1:{LEGACY_GZIP_PORT}"),
+            "--".into(),
+            "python3".into(),
+            agent.display().to_string(),
+        ],
+        launch_dir: dir.clone(),
+        name: name.map(str::to_string),
+        env: vec![("PYTHONPATH".into(), client_path().display().to_string())],
+        auto: false,
+        watch: None,
+    };
+
+    let provider = Provider::start(&provider_script, LEGACY_GZIP_PORT);
+    let recorded = engine::run(&repo, &spec(Some("legacy-gzipped")), Mode::Record, None)
+        .expect("recording through the old proxy should still complete")
+        .trajectory
+        .expect("a recording produces a trajectory");
+    provider.stop();
+
+    // Prove the bug actually happened, or the rest of the test proves nothing: the
+    // recorded body must hold the replacement character the old proxy wrote.
+    let bodies = recorded_bodies(&repo, &recorded);
+    let mangled = bodies
+        .iter()
+        .any(|(_, value)| value.to_string().contains(LOST));
+    assert!(
+        mangled,
+        "the pre-#56 proxy should have written U+FFFD into the recording, found: {bodies:?}"
+    );
+
+    // The mechanical check still passes: nothing on disk was edited, so the re-derived
+    // chain addresses exactly what was recorded.
+    let report = engine::run(
+        &repo,
+        &spec(None),
+        Mode::Replay { live: Vec::new() },
+        Some(&recorded),
+    )
+    .expect("replay should run to completion");
+    assert!(
+        report.reproduces_the_recording(),
+        "hash equality should hold -- the recorded bytes are exactly what was written: {:?}",
+        report.divergences
+    );
+
+    // The claim that matters does not: this is the specific harm #70 names, a replay
+    // reporting itself faithful over a body that cannot have been what the provider
+    // sent.
+    assert!(
+        !report.faithful(),
+        "a replay of a trajectory holding a mangled body must not report itself \
+         simply faithful"
+    );
+    let worst = noidroid_core::intact::worst(&report.unreadable);
+    assert_eq!(
+        worst,
+        Reading::Lost,
+        "the recorded body should be read as lost, not merely suspect: {:?}",
+        report.unreadable
+    );
+    assert!(
+        noidroid_core::intact::lost(&report.unreadable)
+            .next()
+            .is_some(),
+        "faithful() must be false because of a *lost* finding, not because of an \
+         ordinary divergence: {:?}",
+        report.unreadable
     );
 
     let _ = fs::remove_dir_all(&dir);


### PR DESCRIPTION
## Summary

#56 stopped the proxy writing unreadable bytes into new trajectories. It did nothing for recordings already made — a trajectory whose body was `decode("utf-8", "replace")`d before that fix still reads back as **faithful**: a replay re-derives the same hashes, because the mangled body is exactly what was recorded. Hash equality proves nothing about content nobody can read. That is the failure `docs/direction.md` puts first: not a crash, a trajectory that looks real.

- `crates/noidroid-core/src/intact.rs` reads every mediated value (call arguments, decisions, results, response bodies) in a recorded chain and rates each as `intact`, `suspect`, or `lost`. A single U+FFFD is only `suspect` — a provider can legitimately send one, and this project does not turn a piece of evidence into a certainty. `lost` needs corroboration: a run of two or more replacement characters in a row, a body that is mostly replacement characters, a body opening with what a gzip header becomes under a lossy decode, or a `content-type: application/json` body that does not parse — evidence weighed together, never a single trigger.
- `noidroid verify` now reports readability alongside the existing re-hash check. Re-hashing only proves the past was not *edited*; it says nothing about whether it was ever *readable*, and a pre-#56 recording's bytes hash to exactly what they are.
- `engine::Report` carries the same finding. `Report::faithful()` now requires both hash equality *and* nothing `lost` in the source recording — the two are different claims and collapsing them was the bug. `noidroid replay` reports `unverifiable` rather than `faithful` when the source is affected, so the specific harm named in #70 — a replay that looks clean printing "faithful" with no caveat — is closed at the point people actually read it, not just in an offline check.
- Nothing is repaired. The original bytes are gone; the only useful outcome is that the recording stops looking real.

## Confidence and which way I erred

This is evidence, not proof, and it says so in the code and in the CLI output. I erred toward **false positives over false negatives**: `lost` requires at least one corroborating signal beyond a bare replacement character, so an unusual-but-real body is at worst flagged `suspect` and never blocked. The gap this leaves: a compressed body whose lossy decode happens to still parse as JSON and doesn't start with the gzip magic sequence would pass as `intact`. That's inherent to reading evidence after the original wire bytes are already gone — there's no wire capture left to fall back on.

## Test plan

- [x] `crates/noidroid-core/src/intact.rs` unit tests cover the reading rules in isolation (single U+FFFD stays `suspect`, a run of two is `lost`, density, gzip magic, declared-JSON-that-doesn't-parse, and that JSON that *does* parse raises no signal).
- [x] New integration test `a_trajectory_recorded_through_the_old_proxy_is_not_reported_as_simply_faithful` in `crates/noidroid-core/tests/proxy_slice.rs` runs the **actual pre-#56 proxy source**, taken from `git show f72979e^:clients/python/noidroid/proxy.py`, against a stand-in provider that compresses — the real bug, not a hand-built stand-in for it. It asserts the recorded body really does hold U+FFFD, that hash equality still holds (`reproduces_the_recording()`), and that `faithful()` is false because of a `Lost` finding specifically (not an ordinary divergence).
- [x] Confirmed by hand that this test fails without the `faithful()` change and passes with it (temporarily reverted the check, reran, restored).
- [x] `cargo fmt --all`, `cargo clippy --all-targets -- -D warnings`, `cargo test --all` all green after rebasing onto `origin/main`.

Closes #70