### PR TITLE
fix(cost): count a streamed call's usage, or name it unaccounted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,20 @@ how the package version relates to `STEP_VERSION`, the on-disk object format.
   `Store::put`'s scratch name and `watch_slice`'s fixture directory. A new test,
   `a_provider_never_adopts_a_server_it_did_not_start`, starts two providers back to
   back and proves that killing the second one only takes down its own port. (#74)
+- **A streamed call had no single JSON object for `cost` to read, so it vanished from
+  the total instead of being reported unaccounted for.** #45 made streaming pass
+  through as it arrives; a provider that streams reports usage split across events —
+  Anthropic's input count on `message_start`, its output count on `message_delta`;
+  OpenAI's whole `usage` block once, on the final chunk, only with
+  `stream_options.include_usage`. None of that is the one `usage` object `cost`
+  already knew how to read, so the call was silently skipped: not zero, not named,
+  just gone, and the total it fed into looked complete. `cost` now reads a recorded
+  event stream the same way it reads a plain response — recognising the events by the
+  shape a model's own stream actually uses, not by the request's target name — and
+  takes the last value reported for each field, which is correct for both providers'
+  streaming conventions. A stream that never reports usage at all is still counted,
+  named `unaccounted`, and kept out of every `$0.00` the tool would otherwise print:
+  a call nothing could read is not a call that cost nothing. (#62)
 - **A branch whose program died printed a timeline that just stopped.** `noidroid log`
   called it `aborted` and `noidroid branch` never did, so the operator had to infer the
   crash from a missing `finish` row — the inference this tool exists to remove, and the

--- a/crates/noidroid-cli/src/main.rs
+++ b/crates/noidroid-cli/src/main.rs
@@ -1418,6 +1418,28 @@ fn print_verdict(ledger: &cost::Ledger, prices: &BTreeMap<String, cost::Price>) 
         );
         return;
     }
+    if ledger.calls_without_usage > 0 {
+        // A call whose usage cannot be read is not a call worth zero: something
+        // answered it, and nothing here says that cost nothing. Printing $0.00 would
+        // be exactly the quiet lie this command exists to refuse, so there is no
+        // figure — only the gap, named.
+        println!(
+            "  {} {} model call(s) reported nothing this tool could read — the total \
+             is unknown, not zero.",
+            warn("cost:"),
+            ledger.calls_without_usage
+        );
+        if !spent.usage.is_zero() {
+            println!(
+                "        {}",
+                dim(&format!(
+                    "{} was accounted for separately and is not part of that gap",
+                    usage_text(&spent.usage)
+                ))
+            );
+        }
+        return;
+    }
     if spent.usage.is_zero() {
         println!(
             "  {} {} — every model call was {}, so nothing was bought.",
@@ -1479,7 +1501,7 @@ fn print_ledger_line(
         return;
     }
     let spent = ledger.spent();
-    let money = if !ledger.undeliverable().usage.is_zero() {
+    let money = if !ledger.undeliverable().usage.is_zero() || ledger.calls_without_usage > 0 {
         warn("?")
     } else if spent.usage.is_zero() {
         ok("$0.00")
@@ -1488,7 +1510,12 @@ fn print_ledger_line(
     } else {
         dim("—")
     };
-    let note = if spent.usage.is_zero() {
+    let note = if ledger.calls_without_usage > 0 {
+        format!(
+            "— {} call(s) unaccounted, usage could not be read",
+            ledger.calls_without_usage
+        )
+    } else if spent.usage.is_zero() {
         format!("— {}", free_phrase(ledger))
     } else {
         String::new()

--- a/crates/noidroid-cli/tests/cost.rs
+++ b/crates/noidroid-cli/tests/cost.rs
@@ -10,6 +10,7 @@
 //! dollar figure appears only when the caller supplied the price, or when the tokens
 //! bought were zero — which costs nothing at every price there is.
 
+use std::io::BufRead;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -154,6 +155,228 @@ fn a_dollar_figure_never_appears_without_a_price_somebody_supplied() {
     assert!(
         !ok,
         "a price that is not two numbers should be refused: {bad}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// A stand-in provider that answers with a server-sent event stream, which is what a
+/// provider sends when the client asked for `stream: true`. The usage is never in one
+/// JSON object: `message_start` reports the input, `message_delta` reports the output
+/// at the end. Run with `silent` it reports neither, which is the other case `cost`
+/// has to survive — a call it cannot account for.
+///
+/// It binds port zero and prints what it got, so two of these can run at once.
+const STREAMING_PROVIDER: &str = r#"
+import json, sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+COUNTED = sys.argv[1] == "counted"
+
+def events():
+    message = {"id": "msg_local", "type": "message", "role": "assistant",
+               "model": "stand-in-model", "content": [], "stop_reason": None,
+               "stop_sequence": None}
+    if COUNTED:
+        message["usage"] = {"input_tokens": 11, "output_tokens": 0}
+    yield "message_start", {"type": "message_start", "message": message}
+    yield "content_block_start", {"type": "content_block_start", "index": 0,
+        "content_block": {"type": "text", "text": ""}}
+    for piece in ["one ", "two ", "three"]:
+        yield "content_block_delta", {"type": "content_block_delta", "index": 0,
+            "delta": {"type": "text_delta", "text": piece}}
+    yield "content_block_stop", {"type": "content_block_stop", "index": 0}
+    stop = {"type": "message_delta",
+            "delta": {"stop_reason": "end_turn", "stop_sequence": None}}
+    if COUNTED:
+        stop["usage"] = {"output_tokens": 6}
+    yield "message_delta", stop
+    yield "message_stop", {"type": "message_stop"}
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+    def log_message(self, *a): pass
+    def do_POST(self):
+        self.rfile.read(int(self.headers.get("Content-Length") or 0))
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.send_header("Transfer-Encoding", "chunked")
+        self.end_headers()
+        for name, payload in events():
+            frame = ("event: %s\ndata: %s\n\n" % (name, json.dumps(payload))).encode()
+            self.wfile.write(b"%X\r\n" % len(frame) + frame + b"\r\n")
+            self.wfile.flush()
+        self.wfile.write(b"0\r\n\r\n")
+        self.wfile.flush()
+
+server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+print(server.server_address[1], flush=True)
+server.serve_forever()
+"#;
+
+/// An agent that streams, knows nothing about us, and reads its endpoint from the
+/// environment the way every provider SDK does. Deliberately not the Anthropic SDK:
+/// what is under test is what `cost` can read back out of the recording, and a plain
+/// client keeps the test running on the jobs that install no SDK.
+const STREAMING_AGENT: &str = r#"
+import json, os, urllib.request
+
+endpoint = os.environ["ANTHROPIC_BASE_URL"].rstrip("/") + "/v1/messages"
+payload = json.dumps({
+    "model": "stand-in-model", "max_tokens": 64, "stream": True,
+    "messages": [{"role": "user", "content": "count to three"}],
+}).encode()
+request = urllib.request.Request(
+    endpoint, data=payload, method="POST",
+    headers={"content-type": "application/json"},
+)
+
+text = []
+with urllib.request.urlopen(request) as response:
+    for line in response:
+        line = line.decode("utf-8").strip()
+        if not line.startswith("data:"):
+            continue
+        event = json.loads(line[len("data:"):])
+        if event.get("type") == "content_block_delta":
+            text.append(event["delta"]["text"])
+
+with open("answer.txt", "w", encoding="utf-8") as handle:
+    handle.write("".join(text))
+"#;
+
+struct Provider(std::process::Child);
+
+impl Drop for Provider {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+/// Start the stand-in provider and wait for it to say which port it bound.
+fn provider(script: &Path, mode: &str) -> (Provider, u16) {
+    let mut child = Command::new("python3")
+        .arg(script)
+        .arg(mode)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("the stand-in provider should start");
+    let mut line = String::new();
+    std::io::BufReader::new(child.stdout.take().expect("stdout is piped"))
+        .read_line(&mut line)
+        .expect("the provider prints the port it bound");
+    let port = line.trim().parse().expect("a port number");
+    (Provider(child), port)
+}
+
+/// Record one streamed call through the real proxy, and return the working directory.
+///
+/// `--allow-gaps` because `--proxy` also puts the automatic-capture bootstrap on the
+/// agent's path, and this agent is a plain HTTP client that capture has nothing to
+/// say about. The proxy is what is recording here.
+fn recorded_stream(tag: &str, mode: &str) -> PathBuf {
+    let dir = workdir(tag);
+    let script = dir.join("provider.py");
+    std::fs::write(&script, STREAMING_PROVIDER).unwrap();
+    let agent = dir.join("agent.py");
+    std::fs::write(&agent, STREAMING_AGENT).unwrap();
+
+    let (_provider, port) = provider(&script, mode);
+    let (out, ok) = noidroid(
+        &dir,
+        &[
+            "run",
+            "--proxy",
+            &format!("http://127.0.0.1:{port}"),
+            "--allow-gaps",
+            "--",
+            "python3",
+            agent.to_str().unwrap(),
+        ],
+    );
+    assert!(ok, "recording the stream failed: {out}");
+    assert_eq!(
+        std::fs::read_to_string(dir.join(".noidroid/workspaces/run-1/answer.txt")).unwrap(),
+        "one two three",
+        "the agent should have received the whole stream"
+    );
+    dir
+}
+
+/// A streamed response reports its tokens across `message_start` and `message_delta`,
+/// so there is no single JSON object to read them out of — and `cost` used to skip the
+/// call entirely rather than fail on it. A skipped call is the dangerous kind of wrong:
+/// the total still prints, and nothing in it says a call is missing.
+#[test]
+fn a_streamed_call_is_counted_from_the_events_it_recorded() {
+    let dir = recorded_stream("streamed", "counted");
+
+    let (out, ok) = noidroid(&dir, &["cost", "run-1"]);
+    assert!(ok, "{out}");
+    assert!(
+        out.contains("11 in / 6 out"),
+        "the input came from message_start and the output from message_delta; both \
+         were recorded: {out}"
+    );
+    assert!(
+        out.contains("1 executed"),
+        "the recording really made the call: {out}"
+    );
+    assert!(
+        out.contains("stand-in-model"),
+        "the model that answered is named in the stream too: {out}"
+    );
+    assert!(
+        !out.contains("unaccounted"),
+        "this call's usage was recorded and could be read: {out}"
+    );
+
+    let (list, ok) = noidroid(&dir, &["cost"]);
+    assert!(ok, "{list}");
+    assert!(
+        !list.contains("no model calls"),
+        "the streamed call must not vanish from the side-by-side listing: {list}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// The invariant, stated the other way round: some streams report no usage at all —
+/// an OpenAI stream nobody asked `include_usage` of, a provider that stopped early.
+/// Those cannot be counted, and must therefore be *named*. Counting them as zero, or
+/// leaving them out of a total that then reads as complete, is the failure this tool
+/// exists to refuse.
+#[test]
+fn a_streamed_call_is_counted_or_named_but_never_silently_dropped() {
+    let dir = recorded_stream("unreadable", "silent");
+
+    let (out, ok) = noidroid(&dir, &["cost", "run-1"]);
+    assert!(ok, "{out}");
+    assert!(
+        out.contains("unaccounted"),
+        "a call whose usage cannot be read has to be named as unaccounted: {out}"
+    );
+    assert!(
+        out.contains("1 model call"),
+        "and counted, so the reader knows how much is missing: {out}"
+    );
+    assert!(
+        !out.contains("$0.00"),
+        "a call nothing could read is not a call that cost nothing: {out}"
+    );
+
+    let (list, ok) = noidroid(&dir, &["cost"]);
+    assert!(ok, "{list}");
+    assert!(
+        !list.contains("no model calls"),
+        "the listing said there were no model calls, and there was one: {list}"
+    );
+    assert!(
+        list.contains("run-1"),
+        "the trajectory should still be listed: {list}"
     );
 
     let _ = std::fs::remove_dir_all(&dir);

--- a/crates/noidroid-core/src/cost.rs
+++ b/crates/noidroid-core/src/cost.rs
@@ -203,21 +203,30 @@ pub fn account(repo: &Repo, t: &Trajectory) -> Result<Ledger> {
             None => UNRECORDED,
         };
         let mut accounted = false;
+        // A recognisable streamed model response among this step's effects, whose
+        // usage could not be read out of it. Distinct from "not a model call at
+        // all" — collapsing the two would put the omission back where it started.
+        let mut unreadable_stream = false;
         for effect in &step.effects {
             let value: Value = repo.store.get_json(&effect.value)?;
-            let Some(reported) = reported_in(&value) else {
-                continue;
-            };
-            accounted = true;
-            let model = reported
-                .model
-                .or_else(|| named_model(args))
-                .unwrap_or_else(|| "unnamed model".to_string());
-            ledger.add(&model, delivery, &reported.usage);
+            match reported_or_unreadable(&value) {
+                Reading::Reported(reported) => {
+                    accounted = true;
+                    let model = reported
+                        .model
+                        .or_else(|| named_model(args))
+                        .unwrap_or_else(|| "unnamed model".to_string());
+                    ledger.add(&model, delivery, &reported.usage);
+                }
+                Reading::UnreadableStream => unreadable_stream = true,
+                Reading::NotAModelCall => {}
+            }
         }
-        // A call the adapter routed to a model, whose response says nothing about
-        // what it cost. Reporting it as zero would be the quiet lie.
-        if !accounted && target.starts_with("model.") {
+        // A call the adapter routed to a model, or a streamed response shaped
+        // recognisably like one, whose usage nothing here could read. Reporting it
+        // as zero would be the quiet lie; leaving it out entirely is the same lie
+        // one step removed — the total would look complete and would not be.
+        if !accounted && (target.starts_with("model.") || unreadable_stream) {
             ledger.calls_without_usage += 1;
         }
     }
@@ -239,6 +248,13 @@ pub struct Reported {
 /// Two shapes, both of which this repository records today: the response object as
 /// the model adapter stores it, and the HTTP exchange the recording proxy stores,
 /// whose body is that same object still in a string.
+///
+/// A third shape — a streamed response, whose usage is split across events rather
+/// than sitting in one object — is deliberately not handled here. It can be read
+/// (see [`reported_or_unreadable`]), but it can also fail to report usage at all,
+/// and that failure must be visible rather than folded into the same `None` that
+/// means "this was never a model call." This function keeps the simple two-shape
+/// case simple; `account` is where the honest distinction actually matters.
 pub fn reported_in(value: &Value) -> Option<Reported> {
     if let Some(reported) = direct(value) {
         return Some(reported);
@@ -246,6 +262,41 @@ pub fn reported_in(value: &Value) -> Option<Reported> {
     let body = value.as_object()?.get("body")?.as_str()?;
     let parsed: Value = serde_json::from_str(body).ok()?;
     direct(&parsed)
+}
+
+/// What came out of trying to read a call's own account of itself, keeping apart the
+/// two ways that can fail: this was never a model call, or it was one and it did not
+/// say what it used.
+enum Reading {
+    Reported(Reported),
+    /// A recognisable streamed model response with no usage anywhere in it.
+    UnreadableStream,
+    NotAModelCall,
+}
+
+/// [`reported_in`], extended to recognise a streamed response it cannot fully read.
+fn reported_or_unreadable(value: &Value) -> Reading {
+    if let Some(reported) = direct(value) {
+        return Reading::Reported(reported);
+    }
+    let Some(body) = value
+        .as_object()
+        .and_then(|o| o.get("body"))
+        .and_then(Value::as_str)
+    else {
+        return Reading::NotAModelCall;
+    };
+    if let Ok(parsed) = serde_json::from_str::<Value>(body) {
+        return match direct(&parsed) {
+            Some(reported) => Reading::Reported(reported),
+            None => Reading::NotAModelCall,
+        };
+    }
+    match reported_in_stream(body) {
+        Some(reported) => Reading::Reported(reported),
+        None if looks_like_a_model_stream(body) => Reading::UnreadableStream,
+        None => Reading::NotAModelCall,
+    }
 }
 
 fn direct(value: &Value) -> Option<Reported> {
@@ -257,6 +308,94 @@ fn direct(value: &Value) -> Option<Reported> {
     Some(Reported {
         usage: read_usage(usage),
         model: named_model(value),
+    })
+}
+
+/// The `type` (Anthropic) or `object` (OpenAI) values a model's own stream uses for
+/// its events, as opposed to any other server-sent event the proxy happened to pass
+/// through untouched. Recognising the shape mirrors how [`direct`] recognises a
+/// non-streamed response by its `usage` object: this keys off what the provider
+/// actually sent, not off the URL the request went to — the same request path can
+/// carry things that are not a model completion, and this must not claim they are.
+const STREAM_EVENT_TYPES: &[&str] = &[
+    "message_start",
+    "message_delta",
+    "message_stop",
+    "content_block_start",
+    "content_block_delta",
+    "content_block_stop",
+];
+
+fn is_model_stream_event(event: &Value) -> bool {
+    if matches!(
+        event.get("type").and_then(Value::as_str),
+        Some(kind) if STREAM_EVENT_TYPES.contains(&kind)
+    ) {
+        return true;
+    }
+    matches!(
+        event.get("object").and_then(Value::as_str),
+        Some("chat.completion.chunk")
+    )
+}
+
+/// One JSON value per `data:` line — the shape the recording proxy stores for a
+/// passed-through `text/event-stream` body, concatenated as it arrived. `[DONE]`
+/// (OpenAI's sentinel) is not JSON and is skipped rather than treated as a parse
+/// failure.
+fn sse_values(body: &str) -> Vec<Value> {
+    body.lines()
+        .filter_map(|line| line.strip_prefix("data:"))
+        .map(str::trim)
+        .filter(|data| *data != "[DONE]")
+        .filter_map(|data| serde_json::from_str::<Value>(data).ok())
+        .collect()
+}
+
+fn looks_like_a_model_stream(body: &str) -> bool {
+    sse_values(body).iter().any(is_model_stream_event)
+}
+
+/// Read a streamed call's own account of itself.
+///
+/// A stream never carries its usage in one JSON value. Anthropic reports the input
+/// count on `message_start` and the output count on `message_delta` — and despite
+/// the event's name, `message_delta.usage` is the *cumulative* count so far, not an
+/// increment, so the last value seen for a field is the total. OpenAI instead reports
+/// the whole thing once, in a `usage` object on the final chunk, and only when the
+/// caller asked for `stream_options.include_usage` — absent that, there is nothing
+/// to read, which is exactly the case this function must be able to say so about
+/// rather than pretend didn't happen.
+///
+/// `None` means no usage field was found anywhere in the stream; it does not mean
+/// this was not a model call, and callers must not conflate the two.
+fn reported_in_stream(body: &str) -> Option<Reported> {
+    let events = sse_values(body);
+    if events.is_empty() || !events.iter().any(is_model_stream_event) {
+        return None;
+    }
+    let mut fields = Map::new();
+    let mut model = None;
+    for event in &events {
+        let candidate = named_model(event).or_else(|| event.get("message").and_then(named_model));
+        if candidate.is_some() {
+            model = candidate;
+        }
+        let usage = event
+            .get("usage")
+            .or_else(|| event.get("message").and_then(|m| m.get("usage")));
+        if let Some(Value::Object(usage)) = usage {
+            for (name, count) in usage {
+                fields.insert(name.clone(), count.clone());
+            }
+        }
+    }
+    if fields.is_empty() {
+        return None;
+    }
+    Some(Reported {
+        usage: read_usage(&fields),
+        model,
     })
 }
 


### PR DESCRIPTION
A streamed provider response never carries its usage in one JSON object: Anthropic reports the input count on `message_start` and the output count on `message_delta`; OpenAI reports it once on the final chunk, only when the caller asked for `stream_options.include_usage`. `cost` only knew how to read a single usage object, so it silently skipped every streamed call — and since #45 made streaming the normal shape of a recorded response, the total looked complete while it quietly excluded real calls.

## What changed

`cost.rs` now reads a recorded event stream the same way it reads a plain response: it recognises events by the shape a model's own stream actually uses (`message_start`/`message_delta`/... for Anthropic, `chat.completion.chunk` for OpenAI), not by the request's target name, and takes the last value reported for each usage field across the stream — correct for both providers' streaming conventions.

A stream that never reports usage at all is still counted and named **unaccounted** rather than silently skipped or counted as zero. The CLI no longer prints `$0.00` for a trajectory that has one — a call nothing could read is not a call that cost nothing.

Verified locally: `cargo fmt --all`, `cargo clippy --all-targets -- -D warnings`, `cargo test --all` all clean after rebasing onto current `main` (0e2b6a6, which includes #82's verify split and is about to include #74's proxy port-allocation fix).

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)