### PR TITLE
feat(scout): give the scout an orx-based paper-search tool, validated on a computer-use case study

### DIFF
--- a/.claude/skills/technical-scouting/SKILL.md
+++ b/.claude/skills/technical-scouting/SKILL.md
@@ -143,6 +143,8 @@ It **accumulates**. Nothing is overwritten wholesale, ever.
 ## References
 
 - `references/sources.md` — source mix, vocabulary ladders, query patterns
+- `references/orx-cli.md` — `orx discover`/`orx paper`: structured, no-login paper
+  search and reads; prefer it over WebSearch for the Research source class
 - `references/intelligence-card.md` — card schema, template, worked example
 - `references/prioritisation.md` — scoring rubric and ranking method
 - `references/landscape.md` — classification taxonomy for adjacent projects

--- a/.claude/skills/technical-scouting/references/orx-cli.md
+++ b/.claude/skills/technical-scouting/references/orx-cli.md
@@ -1,0 +1,85 @@
+# `orx` — structured paper search
+
+`orx` (OpenResearch CLI, `orx --help`) is installed on this machine. Two of its
+primitives are a direct upgrade over WebSearch for the "Research" source class in
+`sources.md`: structured, no-login, deduplicable, and they surface a paper's most-
+starred associated repo automatically.
+
+Everything else `orx` ships — the local experiment tree (`orx up`/`project`/`exp`/
+`create-experiment`), remote compute (`instance`, `compute`), and `orx agent spawn`
+— is for running and branching ML training experiments on provisioned compute. That
+is not this project's workload; do not reach for it. Use only `discover` and `paper`.
+
+## The two commands
+
+```bash
+orx discover keyword   "<exact terms>"        # alphaXiv full-text BM25 + match snippets
+orx discover embedding "<semantic question>"   # alphaXiv title/abstract semantic search
+orx discover openalex  "<query>"               # cross-discipline scholarly graph, citations
+orx discover biorxiv   "<query>"               # biology preprints, via OpenAlex's index
+orx paper <id>                                 # fetch a report or full text by arXiv id/URL, DOI, or OpenAlex W…id
+```
+
+No login required. Every `discover` call is one request and returns structured JSON:
+`source`, self-routing `id`, `title`, `abstract`, `publicationDate`, plus alphaXiv
+votes/full-text snippets or OpenAlex/bioRxiv citation counts where available.
+`orx paper <id>` auto-detects the source from the id, returns a compact report by
+default, falls back to extracted full text if no report exists, and — when alphaXiv
+has one — prints the paper's most-starred associated GitHub repo (`GitHub: <url>`).
+That repo can be a general framework rather than the paper's own implementation;
+sanity-check it before treating it as the code.
+
+Useful flags on every `discover` subcommand: `--published-after` / `--published-before`
+(`YYYY-MM-DD`, inclusive), `--prioritize {default,recency,historical,popular}`,
+`--limit`. Never invent a date bound the question didn't ask for — an empty or thin
+result under a narrow window is not evidence the literature doesn't exist; say so and
+widen or drop the bound rather than re-running the identical query.
+
+## When to reach for it vs. WebSearch
+
+- A paper, benchmark, method, author, or venue is the actual object of the search →
+  `orx discover`, not WebSearch. It is built for exactly this and returns abstracts
+  you can screen without a fetch.
+- Use `keyword` for exact terms — method names, acronyms, benchmark names, title
+  phrases. Use `embedding` for a fuzzier description of the idea. Use `openalex` when
+  the work is likely outside arXiv (journals, older CS, cross-discipline) or you need
+  citation context. Use `biorxiv` only for biology/life-science preprints.
+- Read a candidate with `orx paper <id>`, not a WebFetch of the arXiv abstract page —
+  it gets you the report/full text and the associated repo in one call.
+- Still use WebSearch/WebFetch for everything `orx` doesn't cover: repos, issue
+  trackers, engineering blogs, release notes, HN/Reddit threads, design docs. Papers
+  found this way still get read with `orx paper` when the id resolves.
+
+## Folding it into the scout pipeline
+
+- **Sweep.** Run `keyword` and/or `embedding` per the guidance above; add `openalex`
+  for broader coverage. Screen abstracts before opening anything — this is candidate
+  generation, not the primary-source read.
+- **Dedup, by id first.** Before adding a paper to the candidate set, check it isn't
+  already a card: match `id` exactly, then a DOI/arXiv id visible in the metadata,
+  then normalized title. If a full-text alphaXiv match and an OpenAlex match are the
+  same arXiv paper, prefer the alphaXiv one — `orx paper` gets you full text from it.
+  This is in addition to, not instead of, the existing `grep -ril` dedup in `SKILL.md`
+  against `research/`.
+- **Primary-source read.** `orx paper <id>` satisfies "read the primary source, not
+  the README" for a paper candidate — read the report/full text before writing
+  anything down. A card built on a `discover` abstract alone is a LOW-credibility card
+  by `sources.md`'s grading; open it with `orx paper` before grading MEDIUM or HIGH.
+- **Follow the graph.** OpenAlex results carry citation context — use it the same way
+  `SKILL.md` already asks you to follow what a project cites and who cites it.
+
+## Citing results
+
+Link every alphaXiv/arXiv result to `https://www.alphaxiv.org/abs/<versionless-id>`,
+never a bare `arxiv.org` link. Link a DOI to `https://doi.org/<doi>`. Link a bare
+OpenAlex `W…` id to `https://openalex.org/<id>`. Don't compare alphaXiv votes against
+OpenAlex citation counts — they measure different things; treat topical fit as the
+only cross-source ranking signal.
+
+## Retrieval budget
+
+Don't loop indefinitely. Estimate how hard the query is (1–10): 1–3 gets no follow-up
+round, 4–7 gets one, 8–10 gets two. A follow-up round targets one concrete missing
+angle — a specific acronym, method, benchmark, or subtopic — not a rephrase of the
+same query. If initial results already give solid topical coverage, stop and move to
+the primary-source reads; fast-and-slightly-incomplete beats an exhaustive sweep.

--- a/.claude/skills/technical-scouting/references/sources.md
+++ b/.claude/skills/technical-scouting/references/sources.md
@@ -14,6 +14,9 @@ early or not real.
 - Awesome-lists and curated indexes as *entry points only*, never as evidence.
 
 **Research**
+- `orx discover`/`orx paper` (see `orx-cli.md`) for structured, no-login search and
+  reads over alphaXiv (arXiv), OpenAlex, and bioRxiv — prefer this over WebSearch when
+  a paper, benchmark, method, or author is the object of the search.
 - arXiv (cs.DC, cs.SE, cs.PL, cs.OS, cs.DB, cs.LG, cs.RO), and the venues that matter
   here: OSDI, SOSP, NSDI, EuroSys, ATC, PLDI, OOPSLA, ICSE, FSE, ISSTA, VLDB, SIGMOD,
   CoRL, ICRA, MLSys, TaPP/IPAW (provenance), USENIX FAST (storage).

--- a/research/README.md
+++ b/research/README.md
@@ -26,6 +26,7 @@ The live ones, highest priority first. Moved to `decisions.md` once they get a v
 
 | Score | Action | Rec | Card | Touches |
 | --- | --- | --- | --- | --- |
+| 81 | **Close the `--live` irreversible hole** — `engine.rs:693` is the one `execute` path that never consults `may_perform_irreversible()`. Failing test first | PROTOTYPE | [`live-replay-performs-irreversible-effects`](discoveries/2026-08-24-live-replay-performs-irreversible-effects.md) | engine, cli, clients |
 | 81 | ~~Make an adopted world observation report as `opaque`, not `witnessed`~~ — **landed as #52** (`Report::served`, `Situation::achieved`). #53 is open on the model underneath. | PROTOTYPE | [`unverified-world-redrive`](discoveries/2026-08-19-unverified-world-redrive.md) | env, engine, cli |
 | 81 | Build the engine-issued seed — engine mints, `Action::Genesis` records, client applies. Supersedes the autoseed spike's design | PROTOTYPE | [`engine-issued-seed`](discoveries/2026-08-21-engine-issued-seed.md) | proto, model, engine, clients |
 | 81 | Add `noidroid run --verify` — replay the recording you just made and report divergence as a capture gap | PROTOTYPE | [`verify-by-double-execution`](discoveries/2026-08-19-verify-by-double-execution.md) | engine, cli |
@@ -39,12 +40,16 @@ The live ones, highest priority first. Moved to `decisions.md` once they get a v
 | 54 | Settle #53 Q1 (does a pure replay report `opaque`?) using "recomputed vs measured reward" as the forcing case, and name run grip apart from trajectory grip | PROTOTYPE | [`reward-computed-over-an-unaddressed-state`](discoveries/2026-08-21-reward-computed-over-an-unaddressed-state.md) | env, engine, cli |
 | 36 | Add the browser adapter's re-drive mute and assert the run report changes (#53 Q5) | PROTOTYPE | [`reproducibility-bought-by-mocking-the-world`](discoveries/2026-08-21-reproducibility-bought-by-mocking-the-world.md) | clients |
 | 36 | Ship `noidroid score` — re-run a checker against a step's materialised state, offline | PROTOTYPE | [`reward-computed-over-an-unaddressed-state`](discoveries/2026-08-21-reward-computed-over-an-unaddressed-state.md) | cli, tree |
+| 54 | **Measure restore-and-branch at step k and publish the curve** — the band we are compared against is now a distribution (0.1–2 s), not two numbers. Gate on the fork-point record; fourth scan carrying it | INVESTIGATE | [`unverified-fork-in-branching-rl`](discoveries/2026-08-21-unverified-fork-in-branching-rl.md) | engine, cli |
 | 36 | Write an OpenEnv adapter: `state()` becomes a declared world, `witnessed` grip for free | INVESTIGATE | [`openenv`](landscape/openenv.md) | clients |
+| 36 | Survey the four client paths for server-side session handles, then declare the inference endpoint as a world in §12 and `doctor` | INVESTIGATE | [`attended-state-is-a-world-we-never-declare`](discoveries/2026-08-24-attended-state-is-a-world-we-never-declare.md) | env, engine, cli, clients |
+| 24 | Make the irreversible-effect record queryable across a trajectory's branches — a walk and a filter over data we already store | WATCH | [`no-undo-across-the-tool-boundary`](discoveries/2026-08-24-no-undo-across-the-tool-boundary.md) | cli, repo |
 
 ## Scans
 
 | Date | Question | Cadence |
 | --- | --- | --- |
+| [2026-08-24](scans/2026-08-24-computer-use-rollback-and-effect-boundaries.md) | For computer-use agents, what happens to state a rollback does not restore? (Answer: eight 2026 systems are inventing the seam we already have — and reading one of them against `engine.rs` found a live replay that performs irreversible effects.) | targeted |
 | [2026-08-21](scans/2026-08-21-deterministic-simulation-testing.md) | What does the deterministic simulation testing world know that we do not? (Answer: it confirms our branching model and our checkpoint choice, and hands us the seed mechanism. Its technique needs a rewrite of the world.) | targeted |
 | [2026-08-21](scans/2026-08-21-computer-use-gaps-and-rl-post-training.md) | Where is the next capability gap in computer use, and what would make us useful for open-source RL post-training? (Answer: a verified fork — not a rollout format, which is already built.) | open |
 | [2026-08-20](scans/2026-08-20-rl-robotics-autonomous-labs.md) | What should we build next to be useful for RL, autonomous labs and robotics? (Answer: nothing domain-specific — but they found a silent pass in our environment model.) | open |
@@ -56,6 +61,9 @@ Newest first. `PRESENT`/`REFINEMENT` cards are here so nobody rediscovers them.
 
 | Card | Rec | Novelty | Conf | What it is |
 | --- | --- | --- | --- | --- |
+| [live-replay-performs-irreversible-effects](discoveries/2026-08-24-live-replay-performs-irreversible-effects.md) | PROTOTYPE | MISSING | HIGH | Of three `execute` paths in `on_call`, one never asks `may_perform_irreversible()`. `--live` on an irreversible target charges the card again, silently. |
+| [attended-state-is-a-world-we-never-declare](discoveries/2026-08-24-attended-state-is-a-world-we-never-declare.md) | INVESTIGATE | MISSING | MEDIUM | A logical rollback and a serving session's KV disagree invisibly. The inference endpoint is a world in our own §12 sense and has no row. |
+| [no-undo-across-the-tool-boundary](discoveries/2026-08-24-no-undo-across-the-tool-boundary.md) | WATCH | PRESENT | MEDIUM | Eight 2026 systems inventing a transaction boundary for agent effects. All three inference mechanisms exist because nobody can declare what `EffectKind` declares. |
 | [engine-issued-seed](discoveries/2026-08-21-engine-issued-seed.md) | PROTOTYPE | MISSING | HIGH | Temporal issues the PRNG seed from the orchestrator and records re-seeding as an event. The only shape that keeps a branch honest. |
 | [a-simulator-per-dependency](discoveries/2026-08-21-a-simulator-per-dependency.md) | WATCH | DIFFERENT | HIGH | DST's price is a hand-written simulator per dependency. RisingWave got to one; their escape plan was Hermit. The unserved row is ours. |
 | [replay-safe-change-taxonomy](discoveries/2026-08-21-replay-safe-change-taxonomy.md) | INVESTIGATE | REFINEMENT | HIGH | Temporal runs our architecture and says code change, not capture, is the top divergence cause. We have no change-safety table. |
@@ -80,6 +88,8 @@ Newest first. `PRESENT`/`REFINEMENT` cards are here so nobody rediscovers them.
 | Project | Class | Activity | Entry |
 | --- | --- | --- | --- |
 | Shepherd | DIRECT COMPETITOR | active — alpha v0.3.0 | [`shepherd`](landscape/shepherd.md) |
+| Crab (HKUST) | INFRASTRUCTURE | active — preprint, no repo found | [`crab-agent-checkpoint-restore`](landscape/crab-agent-checkpoint-restore.md) |
+| orx (OpenResearch CLI) | INSPIRATION | active — our own literature tool | [`openresearch-cli`](landscape/openresearch-cli.md) |
 | verifiers (Prime Intellect) | POTENTIAL INTEGRATION | active — v1 | [`verifiers-prime-intellect`](landscape/verifiers-prime-intellect.md) |
 | OpenEnv | POTENTIAL INTEGRATION | active — nine-org steering committee | [`openenv`](landscape/openenv.md) |
 | AgentENV (kvcache-ai / Moonshot) | INFRASTRUCTURE | active | [`agentenv-kvcache`](landscape/agentenv-kvcache.md) |
@@ -105,9 +115,17 @@ Empty. Superseded cards move here with a pointer to what replaced them.
 The things the next scans should chip at, kept here so they are not lost between runs:
 
 - **How long does our checkpoint actually take to restore and branch, as a function of
-  k?** Nothing has ever measured it. The public numbers we would be compared against are
-  1,920 ms (BPO Docker snapshot) and sub-50 ms (AgentENV microVM resume). Every RL
-  recommendation from 2026-08-21 is conditioned on this and it is a day's work.
+  k?** Nothing has ever measured it, through four scans. The comparison band resolved on
+  2026-08-24: Crab reports checkpoint p50/p95/p99 of 0.1/0.7/1.0 s and restore median 0.71 s
+  on commodity backends (OpenZFS + runc-CRIU), bracketed by 1,920 ms (BPO Docker snapshot)
+  and sub-50 ms (AgentENV microVM resume). So the question is now "are we inside 0.1–2 s at
+  realistic k", which is sharper and still a day's work.
+- **Do any of our client paths hold a server-side inference session handle?** Opened
+  2026-08-24. Decides whether `2026-08-24-attended-state-is-a-world-we-never-declare` is one
+  sentence of documentation or a `doctor` warning plus a declared world. A survey of four
+  code paths, not research.
+- **Does anyone besides ACRFence maintain a cross-branch log of irreversible effects, and
+  in what shape?** Opened 2026-08-24. We found the need and not the prior art.
 - **How often does a real-web browser re-drive reproduce the page digest exactly?** Decides
   whether "a reproducible computer-use episode against the real web" is a claim we may make.
 - ~~**Deterministic simulation testing**~~ — **done 2026-08-21**, own targeted scan.
@@ -126,7 +144,9 @@ The things the next scans should chip at, kept here so they are not lost between
   rests on `verl` and `verifiers` only.
 - **Computer-use trajectory datasets** — OpenCUA/AgentNet, AgentTrek, OS-Genesis,
   GUI-Odyssey, AndroidControl. An explicit sub-question of the 2026-08-21 scan that it did
-  not reach.
+  not reach, and which the 2026-08-24 scan also did not reach. **It has now lost twice.**
+  Commission it as its own targeted scan or strike it — leaving it here is how it stays
+  permanently second to whatever the run's headline question is.
 - **rosbag2's replay implementation and the MCAP container format** — the 2026-08-20 scan
   reached the ROS *complaint* but not the source. The one weak line in
   `unverified-world-redrive`'s comparison table.

--- a/research/discoveries/2026-08-19-kernel-enforced-capture-boundary.md
+++ b/research/discoveries/2026-08-19-kernel-enforced-capture-boundary.md
@@ -161,10 +161,51 @@ Not verified: I read their README and concepts docs, not their enforcement code,
 "enforced at the syscall" is their claim. `2026-08-19-silent-best-effort-sandboxing` is
 the reason to check it rather than assume it.
 
+## Update — 2026-08-24: the other verb, with accuracy numbers
+
+Crab (HKUST, <https://www.alphaxiv.org/abs/2604.28138>) uses the same kernel surface for
+the *other* half of this card. Landlock **forbids**; Crab **detects**, and it publishes the
+numbers this card has always lacked.
+
+Their Inspector combines an in-kernel eBPF monitor with a user-space daemon:
+`sys_enter`/`sys_exit` tracepoints on filesystem-affecting syscalls made by sandbox
+processes, cgroups to delineate which processes are the sandbox's, and kernel soft-dirty
+page tracking (`/proc/PID/pagemap`, `/proc/PID/clear_refs`) for in-memory change. It
+computes **net** change between checkpoints, so a temp file created and deleted inside one
+turn registers as nothing.
+
+Measured, on Claude-code / iFlow-cli / SWE-agent over Terminal-Bench and SWE-Bench:
+
+- Process change detection: **100% accurate, zero false positives, zero false negatives.**
+- Filesystem change detection: **98.3% accurate, zero false negatives, 2.3% false positives.**
+- Asynchronous, off the critical path; median per-turn Inspector latency 31–72 ms, p95
+  under 200 ms.
+
+Two things matter to us. First, the **error direction is the one we require**: zero false
+negatives, and a false positive costs an unnecessary checkpoint rather than a missed
+effect. That is the acceptance criterion for roadmap item 2 ("detecting unmediated effects
+beyond the workspace") written by someone else's evaluation — a detector for us is only
+admissible if a miss is impossible and the cost of a spurious hit is bounded.
+
+Second, it reframes the Landlock spike. The two verbs are separable and can ship
+separately: *forbid* the egress and out-of-workspace writes (Landlock, this card's original
+proposal), or *observe* them and name the step that did it (eBPF, Crab's mechanism). Forbid
+is a smaller change and fits our posture better — a loud refusal over a silent gap — but
+observe is the only one that works for the `--watch <dir>` mode, where the whole point is
+that the program writes to a real project directory we do not own.
+
+Caveat, and it is the same one as for Shepherd: I read Crab's report, not its code. The
+accuracy figures are theirs. eBPF also carries a privilege cost that Landlock does not —
+Landlock is unprivileged by design, tracepoint-attaching eBPF generally is not — so
+"observe" is the option with the worse deployment story even though it has the better
+numbers.
+
 ## Evidence
 
 - Primary: <https://docs.kernel.org/userspace-api/landlock.html>
 - Primary: <https://landlock.io/>
+- Supporting: <https://www.alphaxiv.org/abs/2604.28138> — Crab; eBPF change detection with
+  a zero-false-negative result, and the fail-safe error direction we would need.
 - Supporting: <https://man7.org/linux/man-pages/man7/landlock.7.html>
 - Counter-evidence: <https://github.com/NVIDIA/OpenShell/issues/803> — how this goes
   wrong in practice; see `2026-08-19-silent-best-effort-sandboxing`.
@@ -176,3 +217,7 @@ the reason to check it rather than assume it.
 - 2026-08-19 — created.
 - 2026-08-21 — updated: Shepherd ships Seatbelt + Landlock enforcement with documented
   scope limits; spike is smaller than originally scoped. Landscape entry added.
+- 2026-08-24 — updated: Crab's eBPF Inspector supplies the *detection* half of this card
+  with published accuracy (zero false negatives on both filesystem and process change) and
+  the fail-safe error direction roadmap item 2 needs. Forbid and observe separated as two
+  shippable halves.

--- a/research/discoveries/2026-08-21-unverified-fork-in-branching-rl.md
+++ b/research/discoveries/2026-08-21-unverified-fork-in-branching-rl.md
@@ -2,7 +2,7 @@
 id: 2026-08-21-unverified-fork-in-branching-rl
 title: Branching RL rests on a snapshot-fidelity assumption nobody checks
 discovered: 2026-08-21
-updated: 2026-08-21
+updated: 2026-08-24
 categories: [checkpointing, state reconstruction, counterfactual reasoning, model-based RL, unserved-problem, negative-signal]
 class: RESEARCH
 recommendation: PROTOTYPE
@@ -200,5 +200,46 @@ AgentENV numbers being right; it depends only on the README being silent, which 
   pattern in four unrelated physical domains.
 - Counter-evidence: BPO's measured +5.8 SWE-bench gain with the unverified restore.
 
+## Update — 2026-08-24: a fourth instance, and the latency distribution step 0 needs
+
+**Crab** (HKUST, <https://www.alphaxiv.org/abs/2604.28138>) is a semantics-aware
+checkpoint/restore runtime for agent sandboxes that names RL rollout branching as one of
+its four motivating use cases and reports **40.0–64.2% token savings for tree-based RL
+post-training** by reusing intermediate sandbox states across branched rollouts. It is the
+fourth independent system in this card's pattern: it claims "100% recovery correctness",
+and that figure is **benchmark task outcome, not a re-derived address**. Nothing in Crab
+compares the restored state to the state that was checkpointed. The irony is sharp — their
+eBPF Inspector computes exactly the net-change information that would let them check, and
+they use it only to decide *whether* to checkpoint, never to verify that a restore landed.
+
+Crab also supplies the number this card's recommendation was blocked on. The 2026-08-21
+scan's item 1 had a step 0 ("measure wall-clock restore-and-branch at step k") whose only
+reference points were 1,920 ms (BPO Docker overlayfs) and sub-50 ms (AgentENV microVM).
+Crab gives a distribution on commodity backends (OpenZFS + runc-CRIU):
+
+- checkpoint p50 / p95 / p99: **0.1 / 0.7 / 1.0 s**, bimodal — filesystem-only 20–100 ms,
+  process checkpoints 700–1000 ms;
+- restore under 1 s (median 0.71 s, p95 1.00 s) even on constrained shared storage;
+- and the sparsity result that sets the bar: **up to 87% of agent turns need no checkpoint
+  at all**, because they change no recovery-relevant state.
+
+So the band we would be measured in is roughly 0.1–2 s per fork, not 50 ms. A deterministic
+prefix replay at small k is plausibly inside that band; at large k it is not. Step 0 is
+still the gate and is still unmeasured.
+
+One further corroboration of C2, from a system that did not set out to make it. Crab's
+"agent-in-a-sandbox" deployment has a **fast-forward mechanism**: after restoring, the
+Coordinator *replays cached historical LLM responses* to the agent until its logical
+progress matches the restored checkpoint head. That is a deterministic prefix served from a
+recording — our checkpoint, invented as a reconciliation hack to paper over the gap between
+a snapshot and a process that outlived it. And their Coordinator is an HTTP reverse proxy
+on the agent–LLM path that logs request/response pairs: the third independent instance of
+`--proxy`'s architecture, after `verifiers` and our own `af81680`.
+
+Read as a report via `orx paper`, not as source; the numbers are theirs.
+
 ## Changelog
 - 2026-08-21 — created.
+- 2026-08-24 — updated: Crab added as a fourth unverified-restore instance, with the
+  checkpoint/restore latency distribution that step 0 of the 2026-08-21 recommendation was
+  waiting on, and an independent re-derivation of the deterministic-prefix checkpoint.

--- a/research/discoveries/2026-08-24-attended-state-is-a-world-we-never-declare.md
+++ b/research/discoveries/2026-08-24-attended-state-is-a-world-we-never-declare.md
@@ -1,0 +1,195 @@
+---
+id: 2026-08-24-attended-state-is-a-world-we-never-declare
+title: The inference session is a stateful world with opaque grip, and no recording declares it
+discovered: 2026-08-24
+updated: 2026-08-24
+categories: [capture honesty, environment reconstruction / hermeticity, state reconstruction, computer-use agents]
+class: RESEARCH
+recommendation: INVESTIGATE
+transferability: MEDIUM
+novelty: MISSING
+confidence: MEDIUM
+touches: [env, engine, cli, clients]
+---
+
+## Discovery
+
+"Aborted but Not Forgotten" (arXiv 2608.15939, 16 Aug 2026) formalises **rollback
+consistency**: a believed-complete abort must restore the state the model *attends*, not
+merely the application's transcript. When a serving session retains its KV cache across a
+logical rollback — as it does whenever an application reuses a session handle or a cached
+`past_key_values` — the model keeps attending to a branch the application deleted. Across
+seven open-weight families the retained KV alone flipped a typed protected effect in
+**25 of 63 audited cells while the attacker tokens were provably absent from the served
+request in all 63**, and it reproduced *inside LangGraph's first-class time-travel API*,
+where a verified logical rollback still left the KV stale.
+
+The consequence for us is not that attack. It is the category: **the inference endpoint is
+a world in the sense of `docs/environment-model.md`, and nothing in our tree declares it as
+one.**
+
+## Source
+
+- Primary: <https://www.alphaxiv.org/abs/2608.15939> — read the abstract, introduction,
+  threat model and the same-token/different-cache audit design (§1–2) in full text via
+  `orx paper`. I did not read the appendices or the per-model tables.
+- Primary, ours: `crates/noidroid-cli/src/doctor.rs` (the full list of what a recording
+  would not cover), `clients/python/noidroid/llm.py`, `crates/noidroid-core/src/env.rs`.
+
+## What is interesting
+
+The methodological core is the part worth stealing, independent of the security framing.
+Their **same-token / different-cache audit** holds the decision-step tokens *token-identical*
+across two arms and varies only the cached prefix: `stale` (KV retained across the abort)
+versus `fresh` (KV rebuilt from the committed transcript). Anything that differs between
+the arms is attributable to retained state alone, and they verify per cell that the carrier
+token is absent from the fed tokens. That is a controlled-variable experiment over an
+invisible state channel — the same shape as our own "change one thing and branch", applied
+to a layer nobody instruments.
+
+Their scope note is what makes this precise rather than alarmist, and it is the sentence
+that decides whether we are exposed:
+
+> A content-addressed automatic prefix cache (e.g. vLLM's) reuses only prefixes actually
+> present in the request and never re-injects removed tokens, so it is exempt. Our claims
+> are scoped to retained-handle reuse.
+
+So the hazard is **retained-handle** serving — session handles, continued-generation APIs,
+`past_key_values` in a local transformers loop — not stateless `messages=[...]` calls.
+
+Their fix is also instructive: a **transaction-local cache restore** (rebuild from the
+committed transcript) closes every cell, while a *global flush or full restart does not*
+help more and costs more. Rebuilding from the committed history is precisely C2's
+deterministic prefix, arrived at independently, for the layer below us.
+
+## Why it matters to Paranoid Android
+
+Our environment model's whole argument is: *name the worlds you cannot capture, and say
+what holding a state address entitles you to.* `grip` is `captured` / `witnessed` /
+`opaque`; §12 has a six-environment conformance table.
+
+The one world that **every single noidroid recording touches** — the model provider — is
+absent from that table and absent from the code. `clients/python/noidroid/llm.py` wraps the
+call as an ordinary `nd.call("model.complete", ...)`; it never calls `session.observe(of=...)`,
+so no world is declared, no fingerprint is taken, and the run report has no row for it.
+`grep -rn "previous_response_id\|past_key_values" clients/` returns nothing — we have no
+notion that a model call might carry a handle at all.
+
+For `Mode::Record` and a pure `Mode::Replay` this is genuinely harmless, and I want to be
+clear about that: a pure replay serves the recorded completion and never contacts the
+server, so there is no attended state to be stale. **The exposure is `Replay { live: [...] }`,**
+the flagship hybrid — and it is exposed in the mirror-image direction to the paper's:
+
+- The paper's agent has KV the transcript does not.
+- Our live replay has the opposite: steps 0..k are served from the recording and *never
+  sent to the server*, so a retained session handle held by the client has KV that reflects
+  none of the replayed prefix. The client's transcript is verified by hash; the server's
+  attended state is not merely unverified, it was never built.
+
+If the client is doing stateless completions, this is a non-issue and the honest answer is
+one sentence saying so. If the client holds a handle, our verified prefix sits on top of an
+unverified — possibly empty, possibly stale from a previous branch — attended state, and
+the run report calls the reconstruction faithful. That is the `unverified-world-redrive`
+shape (2026-08-19) in a new place: we print that the prefix reproduced exactly, and the
+sentence is true about the only layer we look at.
+
+`noidroid doctor` is the natural home for the answer. It already enumerates clock,
+randomness, subprocesses, the egress fence and platform under "what a recording made now
+would and would not cover" (#75). "Whether your model client holds a server-side session
+handle" belongs on that list and is not on it.
+
+## Transferability
+
+**MEDIUM.**
+
+What transfers cleanly: the *category*. Adding a row to §12's conformance table for the
+inference endpoint, and a `doctor` check for retained-handle usage, is a documentation and
+reporting change that needs no new mechanism — `Session.observe` already exists.
+
+What does not transfer: the fix. We cannot rebuild a provider's KV cache, and we should not
+try; for a hosted API the honest grip is `opaque` (we hold nothing, we cannot detect a
+difference, we cannot put it back) and the only correct action is to say so. For a
+self-hosted vLLM the paper says we are exempt, which is a fact worth writing down rather
+than a capability to build.
+
+What is uncertain: whether real noidroid users hold handles at all. Our own `llm.py` and
+`--proxy` path are message-list shaped. The Responses API's `previous_response_id`, Gemini
+context caching, and any local `transformers` loop are the cases where this bites, and I do
+not know how common they are among the programs people actually record.
+
+## Novelty
+
+**MISSING**, verified by grep rather than memory. No world is declared for the model
+anywhere: `clients/python/noidroid/llm.py` contains no `observe`; `doctor.rs`'s check list
+has no entry for serving-session state; `docs/environment-model.md` §12's table has no row
+for an inference endpoint. The concept we need (`grip`, `Situation`, `observe`) shipped in
+0.3.0 — this is an unfilled row in a table we already built, not a new abstraction.
+
+## Limitations and negative signal
+
+Arguing against myself, hard, because this is the kind of finding that flatters our
+architecture:
+
+- **The realistic exposure may be zero.** If every recorded program uses stateless
+  completions, the correct output of this card is one sentence in `doctor` and nothing
+  else. I have not measured which shape our users use, and there is no user data to
+  measure.
+- **The paper's harm story is a security one we do not inherit.** Their threat model needs
+  an attacker placing content in a branch that gets abandoned. Our value is a truthful
+  report, not a defended boundary; the transferable part is the *invisible-state* claim,
+  not the exfiltration.
+- **This is not a reason to capture the model server.** Capturing provider-side KV is not
+  possible for a hosted API and is C1 territory for a self-hosted one. The finding is
+  "declare it", not "capture it".
+- **It arguably lands near C2 and does not dent it.** If anything the paper corroborates
+  C2 — their sufficient fix is "rebuild from the committed transcript", i.e. a deterministic
+  prefix, chosen over a snapshot restore *and over a full restart*. Score novelty 1 on that
+  reading and 3 on the undeclared-world reading; I claim the latter, and the former is worth
+  recording as confirmation.
+- I read §1–2 and the abstract, not the full evaluation. The 25/63 figure is theirs,
+  unverified by me.
+
+## Recommendation
+
+**INVESTIGATE** — one question, answerable in an afternoon, before any code.
+
+## Proposed action
+
+Answer: **does any supported client path hold a server-side session handle across steps?**
+Enumerate the four shapes — `llm.py`'s `model.complete`, `--auto`'s `sitecustomize` hooks,
+`--proxy`'s intercepted request bodies, and a hand-written client — and for each say whether
+the request is self-contained (`messages=[...]`, exempt per the paper's own scope) or
+handle-carrying (`previous_response_id`, cached-content handles, local `past_key_values`).
+
+Then, depending on the answer:
+
+- **All self-contained** → add one line to `doctor` saying so, and a row to
+  `docs/environment-model.md` §12 recording the inference endpoint as a world with `opaque`
+  grip whose statelessness is what makes reconstruction sound. Cost: a paragraph. This is
+  the likely outcome and it is still worth having, because right now the guarantee is
+  accidental rather than stated.
+- **Any handle-carrying path exists** → `doctor` must warn on it, and `--live` on that
+  target should declare the session as an `opaque` world in the run report via
+  `Session.observe`, so a live replay stops claiming a clean prefix over a state it never
+  built.
+
+## Confidence
+
+**MEDIUM.** HIGH that we declare no world for the model — that is grep. MEDIUM on the
+consequence, because it is conditional on a client shape I have not surveyed, and because I
+read part of the paper rather than all of it.
+
+## Evidence
+
+- Primary: <https://www.alphaxiv.org/abs/2608.15939> — establishes that logical rollback
+  and retained serving state can disagree invisibly, with a controlled audit, and scopes it
+  to retained-handle reuse.
+- Supporting: `2026-08-19-unverified-world-redrive` — the same failure shape (we print that
+  we checked a world we did not) in four other domains.
+- Supporting: `crates/noidroid-cli/src/doctor.rs` — the coverage list this belongs on.
+- Counter-evidence: the paper's own exemption for content-addressed prefix caches, which
+  may cover every client we actually have.
+
+## Changelog
+
+- 2026-08-24 — created, from the computer-use rollback scan.

--- a/research/discoveries/2026-08-24-live-replay-performs-irreversible-effects.md
+++ b/research/discoveries/2026-08-24-live-replay-performs-irreversible-effects.md
@@ -1,0 +1,192 @@
+---
+id: 2026-08-24-live-replay-performs-irreversible-effects
+title: A live replay executes irreversible effects for real, and it is the one execute path that never asks
+discovered: 2026-08-24
+updated: 2026-08-24
+categories: [capture honesty, agent effect boundaries, record/replay systems, negative-signal, computer-use agents]
+class: RESEARCH
+recommendation: PROTOTYPE
+transferability: HIGH
+novelty: MISSING
+confidence: HIGH
+touches: [engine, cli, clients]
+---
+
+## Discovery
+
+ACRFence (arXiv 2603.20625) demonstrates, at 10/10 in a controlled experiment, that an
+LLM agent restored from a checkpoint re-performs an irreversible external action because
+it re-synthesises a *different* request and the server's duplicate detection therefore
+does not fire. Reading it against our own code, I found that `engine.rs` has the guard
+that would prevent this — `may_perform_irreversible()`, which returns true only for
+`Mode::Record` — and that **one of the three `Response::execute()` paths does not consult
+it**. In `Mode::Replay { live }`, a target named `--live` whose effect is
+`EffectKind::Irreversible` is executed against the real world during a replay.
+
+## Source
+
+- Primary: <https://www.alphaxiv.org/abs/2603.20625> — ACRFence, read in full via
+  `orx paper`. Threat model, the 12-framework survey, both experiments, the mitigation.
+- Primary, ours: `crates/noidroid-core/src/engine.rs` lines 621–709 (`on_call`), 826–843
+  (`runs_live`, `may_perform_irreversible`), 845–872 (`deny_irreversible`).
+- Primary, ours: `crates/noidroid-core/tests/vertical_slice.rs:226`
+  (`a_replay_never_touches_the_world`), `:689`
+  (`a_live_replay_reruns_only_what_it_was_asked_to`).
+
+## What is interesting
+
+The engine says the rule out loud, in a comment on the guard itself:
+
+```rust
+fn may_perform_irreversible(&self) -> bool {
+    // Only an original recording is allowed to touch the world for real. Every
+    // reconstruction and every branch is denied by default.
+    matches!(self.mode, Mode::Record)
+}
+```
+
+Three arms of `on_call` reach `Response::execute()`. Two check it:
+
+- line 649 — `Phase::Counterfactual` under a live replay, for a target *not* named live;
+- line 665 — `Phase::Fresh | Phase::Counterfactual`, the ordinary execute path.
+
+The third does not:
+
+```rust
+Phase::Reconstructing if self.runs_live(&target) => {
+    self.gone_live = true;
+    self.pending = Some(Pending { action, effect, provenance: Provenance::Live, .. });
+    Ok(Response::execute())
+}
+```
+
+`effect` is carried straight through from the client's `call` request and never
+inspected. So `noidroid replay <t> --live world` on a trajectory containing
+`world.charge` declared `irreversible` charges the card again. `runs_live` is *prefix*
+matching (`target == p || target.starts_with("{p}."))`, so `--live world` covers
+`world.charge` without anyone typing a glob — the flag's own doc comment only ever
+imagines `--live model`.
+
+Two details make this quieter than it should be, and one makes it narrower:
+
+- **Narrower:** `expect_match` runs first (line 627), so to reach this arm the call must
+  already agree with the recording. This is not the divergent re-synthesis ACRFence
+  describes; the divergent case falls through to `Phase::Counterfactual` and *is* guarded.
+  What fires here is the plain double-spend: the same irreversible action, performed a
+  second time, against a world that already has the first one.
+- **Quieter 1:** `report.denied` stays empty, because nothing was denied. The run report
+  has no line for "this replay performed an irreversible effect".
+- **Quieter 2:** the CLI's denial hint (`main.rs:867`, "irreversible outside a recording")
+  is only printed when `report.denied` is non-empty, so the one place a reader would look
+  says nothing.
+
+ACRFence's own survey is the reason to treat this as a live hazard rather than a
+curiosity. Across 12 frameworks it found the same class of report: LangGraph maintainers
+calling re-execution architecturally hard to fix, Google ADK documenting that its rewind
+"cannot undo external side effects", a HashiCorp Vault issue where single-use tokens
+reappeared after a snapshot restore, and duplicate-charge reports from CrewAI, AutoGen,
+OpenHands, n8n and Claude Code. We built the mechanism that answers this. It has a hole
+in it.
+
+## Why it matters to Paranoid Android
+
+This is `a_replay_never_touches_the_world` — a named test, one of the project's stated
+claims — being true only because the test passes `live: &[]`. The one live-replay test,
+`a_live_replay_reruns_only_what_it_was_asked_to`, names `world.read`. No test in the tree
+combines `--live` with an irreversible target.
+
+It bears on capture honesty and on the README's promise directly. `Replay { live }` is
+the flagship hybrid: the mode we tell people to use when the prompt or the model changed.
+It is exactly the mode ACRFence attacks, and it is the mode in which a user is most
+likely to name a target broadly (`--live world`, `--live api`) to get a comparison to
+work. The failure is silent in the run report and produces a trajectory that looks
+faithful.
+
+Note what is *not* wrong: the design. Denying irreversible effects outside a recording is
+already the stated rule, `deny_irreversible` already writes a proper `EffectOutcome::Denied`
+step with a `Provenance::Unknown` effect, and `--simulate <target>=<json>` is already the
+escape hatch. The fix is to consult the guard on the third path, decide what `--live` on
+an irreversible target should mean, and test it.
+
+## Transferability
+
+**HIGH** — it is our own code. The only design question is which of three behaviours the
+third arm should take:
+
+1. **Deny**, as `Fresh | Counterfactual` does, and let `--simulate` override. Consistent,
+   and the strictest reading of the guard's own comment.
+2. **Refuse the run up front**: if any `--live` prefix could match an irreversible target
+   in the recording, refuse before starting rather than mid-run. Loudest, and checkable
+   from the recorded chain without executing anything.
+3. **Execute but report it**, adding a `report.performed_irreversible` line. Weakest, and
+   it makes a replay's world-touching a footnote rather than a refusal.
+
+(1) or (2). (3) is the shape this project usually calls wrong.
+
+## Novelty
+
+**MISSING.** The check does not exist on that path. `grep -n "Response::execute()"
+crates/noidroid-core/src/engine.rs` returns three sites; two are preceded by
+`may_perform_irreversible()` and line 693 is not. `noidroid doctor` (`doctor.rs`) covers
+clock, randomness, subprocesses, the egress fence, client version and platform — it has
+no check for this. Nothing in `crates/noidroid-core/tests/` exercises it.
+
+## Limitations and negative signal
+
+Against my own claim:
+
+- I have **not run** the failing case. This is a read of the control flow, not an
+  executed reproduction. That is the first thing the fix should do, and if a test written
+  to fail passes instead, this card is wrong and should be struck.
+- The severity depends on someone naming an irreversible target `--live`, which the
+  documented use (`--live model`) does not. It is a foot-gun rather than a default.
+- ACRFence's headline mechanism — divergent re-synthesis bypassing idempotency keys — is
+  *guarded* in our engine, via `expect_match` and the `Phase::Counterfactual` arm. The
+  transferable part of their paper is the empirical fact that agents do re-perform
+  irreversible effects after a restore and that no surveyed framework prevents it; the
+  specific hole I found is a plainer one.
+- ACRFence itself is a workshop-scale paper: the mitigation is *designed, not evaluated*
+  (their own words — "an implementation of ACRFence itself was not evaluated"), and its
+  core comparison mechanism is an **analyzer LLM** deciding whether two tool calls are
+  semantically equivalent. That is a fuzzy matcher, it is C4 in new clothes, and we should
+  not take it. Our version of their idea is `key` equality plus a fatal divergence, which
+  is the thing they had to approximate because they had no oracle.
+
+## Recommendation
+
+**PROTOTYPE** — write the failing test first, then pick behaviour (1) or (2).
+
+## Proposed action
+
+1. Add `a_live_replay_still_refuses_an_irreversible_target` to
+   `crates/noidroid-core/tests/vertical_slice.rs`, modelled on the existing `irreversible`
+   fixture: record, then `Mode::Replay { live: vec!["world".into()] }`, and assert the
+   witness file contains `charge` exactly once. Confirm it fails.
+2. Consult `may_perform_irreversible()` on the `Phase::Reconstructing if runs_live` arm,
+   routing to `simulated_value` then `deny_irreversible`, as line 665 already does.
+3. Decide whether `--live <prefix>` matching a recorded irreversible target should refuse
+   the run before it starts. The recorded chain is walkable at `cmd_replay` time, so this
+   is a pre-flight check, not a runtime one.
+4. Add a `doctor` line, or a `replay` warning, naming which recorded targets a given
+   `--live` prefix would cover.
+
+## Confidence
+
+**HIGH** on the code path — I read `on_call` in full, enumerated all three `execute()`
+sites, and read both relevant tests. **MEDIUM** on the practical severity, because I did
+not execute the case and the trigger requires a broad `--live` prefix.
+
+## Evidence
+
+- Primary: <https://www.alphaxiv.org/abs/2603.20625> — establishes that agents re-perform
+  irreversible effects after a restore, empirically (10/10), and that none of 12 surveyed
+  frameworks prevent it.
+- Primary: `crates/noidroid-core/src/engine.rs:684-694` — the unguarded execute path.
+- Supporting: `crates/noidroid-core/src/engine.rs:839-843` — the guard, and its comment
+  stating the rule the path violates.
+- Counter-evidence: `expect_match` at line 627 confines this to non-divergent calls, which
+  is narrower than ACRFence's attack; and I did not reproduce it.
+
+## Changelog
+
+- 2026-08-24 — created, from the computer-use rollback scan.

--- a/research/discoveries/2026-08-24-no-undo-across-the-tool-boundary.md
+++ b/research/discoveries/2026-08-24-no-undo-across-the-tool-boundary.md
@@ -1,0 +1,167 @@
+---
+id: 2026-08-24-no-undo-across-the-tool-boundary
+title: Eight independent 2026 systems are inventing a transaction boundary for agent side effects
+discovered: 2026-08-24
+updated: 2026-08-24
+categories: [unserved-problem, negative-signal, agent effect boundaries, checkpointing, computer-use agents]
+class: RESEARCH
+recommendation: WATCH
+transferability: MEDIUM
+novelty: PRESENT
+confidence: MEDIUM
+touches: [model, engine, proto]
+---
+
+## Discovery
+
+Over 2026 at least eight unrelated groups have independently built the same missing
+primitive: a **task-scoped commit/rollback boundary around an agent's external effects**,
+because rolling back an agent's transcript does not roll back what left the process. They
+disagree on the layer — security fence, transaction runtime, OS checkpointer, memory
+version-control — and agree on the diagnosis. Every one of them ends up needing a
+per-effect declaration of reversibility, and every one of them has to *infer* it, because
+no tool interface carries it.
+
+## Who hits this
+
+- **ACRFence** (UCSC/UConn) — <https://www.alphaxiv.org/abs/2603.20625> — surveyed 12
+  agent frameworks; none enforce exactly-once semantics at the tool boundary. Proposes an
+  effect log plus "replay-or-fork" semantics.
+- **Cordon** (Tsinghua/SJTU/RUC) — <https://www.alphaxiv.org/abs/2606.17573> — "today's
+  agent runtimes still expose tools as isolated RPCs… it lacks a task-scoped execution
+  boundary for commit, rollback, recovery." Stages external effects in an *effect outbox*
+  and local mutations in a *shadow state*.
+- **DART** (<https://www.alphaxiv.org/abs/2605.23311>) — "replaying the entire task is safe
+  but wasteful, while restoring from a local checkpoint is efficient but can leave
+  committed downstream work tied to an upstream history that no longer exists."
+- **Crab** (HKUST) — <https://www.alphaxiv.org/abs/2604.28138> — the "agent–OS semantic
+  gap": frameworks see tool calls but not their OS effects; the OS sees state changes but
+  not turn-level context.
+- **ChronoMem** (<https://www.alphaxiv.org/abs/2607.27773>) — agent memory is
+  "forward-only… with no principled mechanism to inspect, version, or revert prior states."
+- **MemTX** (<https://www.alphaxiv.org/abs/2607.23929>) and **Beyond Memory: A Transactional
+  Continuity Kernel** (<https://www.alphaxiv.org/abs/2608.11632>) — the same commit
+  discipline applied to belief/memory state.
+- **AID-Guard** (<https://www.alphaxiv.org/abs/2608.21159>, 21 Aug 2026) — stateful
+  authorization for delegated agent effects; three days old at the time of this scan.
+- **The framework maintainers themselves**, via ACRFence's survey: LangGraph
+  (re-execution acknowledged as architecturally hard), Google ADK (documentation states
+  rewind "cannot undo external side effects"), OpenClaw (webhook replay advisory), and a
+  HashiCorp Vault issue where single-use tokens reappeared after a snapshot restore.
+
+Far more than the three independent sources `negative-space.md` requires, and — importantly
+— they are not all agent-debugging tools. Crab is a systems paper, Cordon is a security
+runtime, ChronoMem is a memory system, Vault is a secrets manager.
+
+## Why it is unsolved
+
+Structural, and worth stating precisely: **a checkpoint restores the process, and the
+process is not where the effect went.** Local state (files, memory, transcript) is
+restorable by copying bytes. External state (a payment, a sent message, a consumed token,
+a provisioned VM) is restorable only by a *compensating action* that the tool interface
+does not describe and often does not offer. Cordon says this outright — once an effect is
+released, it relies on "audit or compensation, as physical undo is not possible."
+
+So every one of these systems is forced to answer, per call, "is this reversible?", and
+none of them can ask. They infer it instead:
+
+- ACRFence: an **analyzer LLM** decides whether two calls are semantically equivalent.
+- Cordon: a lineage graph plus nine hand-written invariants and path/fan-out heuristics.
+- Crab: eBPF syscall tracing to infer which turns changed OS state at all.
+
+Three different inference mechanisms for a fact the caller knows and has no way to state.
+That is the signature of a missing seam (`negative-space.md`, kind 4).
+
+## Would Paranoid Android's model help?
+
+**We already have the seam, and this is the card's main point: novelty here is PRESENT,
+not MISSING.** `EffectKind { Read, Write, Irreversible }` is declared by the caller at the
+call site and travels in the wire protocol (`proto.rs`), is hashed into the step
+(`model.rs`), is refused outside a recording (`engine.rs::may_perform_irreversible`), and
+determines checkpoint reachability (`checkpoint.rs:101`, an irreversible effect is
+survivable only in a world we hold). We did not have to infer anything.
+
+That is a genuinely strong position and it is worth *saying* rather than building toward.
+But three honest deductions:
+
+1. **Our declaration is only as good as the caller.** A client that labels a charge `write`
+   gets it replayed for free. We have no detection, by design (C1). Crab's eBPF Inspector
+   is the one mechanism in this cluster that *detects* rather than trusts — see the update
+   to `2026-08-19-kernel-enforced-capture-boundary`.
+2. **We have no cross-branch effect log.** ACRFence's core artefact is a log of irreversible
+   effects keyed by *thread and branch id*, so a restored run can be told "this already
+   happened on another branch." We store effects per step in an immutable chain, which is
+   strictly better data — but nothing queries *across* siblings. The question "has any
+   branch of this trajectory already performed `world.charge`?" is answerable from the
+   store and is not answerable from the CLI.
+3. **`2026-08-24-live-replay-performs-irreversible-effects` shows our own guard has a hole
+   in it.** Having the right primitive is not the same as applying it on every path.
+
+## Limitations and negative signal
+
+- **This is mostly a positioning finding, and positioning is C6-adjacent.** It does not
+  change what the tool can claim; it tells us what to say. Score it accordingly.
+- Most of these systems are 2026 preprints with prototype implementations; ACRFence's
+  mitigation is explicitly unevaluated. Cordon and Crab have real evaluations; the rest I
+  screened by abstract only.
+- The cluster's centre of gravity is *prevention* (block the bad effect), which is not our
+  business and is squarely inside C9's "not an agent framework". We should not follow them
+  into policy engines, outboxes or guard models.
+- The convergence could reflect a fashionable framing rather than a real gap — "transactions
+  for agents" is an easy paper to write. The evidence that it is real is the non-academic
+  half: the LangGraph, ADK, OpenClaw and Vault reports, which are maintainers describing
+  production bugs.
+
+## Recommendation
+
+**WATCH**, with one cheap concrete action. The mechanism is built; what is missing is a
+query over it and a sentence in the README. Re-check on the trigger below.
+
+## Proposed action
+
+Two things, both small, neither a new abstraction:
+
+1. **Say it.** One line in the README's positioning: an effect's reversibility is declared
+   by the caller and carried in the step, which is why a replay can refuse it. Eight 2026
+   systems are inferring what we are told. This is free and it is the only place in the
+   competitive picture where we are unambiguously ahead of the field rather than level.
+2. **Make the effect log queryable across branches.** `noidroid log --irreversible <traj>`,
+   or a column in `noidroid diff`, answering "which irreversible effects exist anywhere in
+   this trajectory's family, on which branch, with what outcome (`Value` / `Denied`)?" The
+   data is already in the chain; this is a walk plus a filter, and it is the artefact
+   ACRFence had to invent from scratch.
+
+**Watch trigger:** if any of MCP, OpenEnv or the OpenAI/Anthropic tool schemas adds a
+reversibility or idempotency field to its tool declaration, that is the ecosystem adopting
+our seam, and the right response is an adapter that maps it onto `EffectKind` — reopen this
+card then. `2026-08-19-reversibility-is-not-in-the-instrument-standard` is the same
+observation from the laboratory-instrument side (SiLA 2's FDL describes every command
+except what re-performing it costs); that this recurs in an unrelated standards family
+strengthens both.
+
+## Confidence
+
+**MEDIUM.** HIGH that the cluster exists and that our primitive is the one they lack —
+ACRFence, Cordon and Crab were read as full reports, and our own code was read directly.
+MEDIUM overall because five of the eight sources are abstract-only screening, and because
+the "we are ahead" conclusion is the kind that deserves suspicion.
+
+## Evidence
+
+- Primary: <https://www.alphaxiv.org/abs/2606.17573> — Cordon, read in full; the clearest
+  statement of the missing boundary and the best evaluation (45/45 intercepted pre-commit
+  versus 14/45 for adapted existing defences).
+- Primary: <https://www.alphaxiv.org/abs/2603.20625> — ACRFence, read in full; the
+  12-framework survey and the maintainer reports.
+- Primary: <https://www.alphaxiv.org/abs/2604.28138> — Crab, read in full; the agent–OS
+  semantic gap.
+- Supporting: five further 2026 preprints screened by abstract (DART, ChronoMem, MemTX,
+  Transactional Continuity Kernel, AID-Guard).
+- Ours: `crates/noidroid-core/src/model.rs:104-126`, `engine.rs:839-872`,
+  `checkpoint.rs:95-110`.
+- Counter-evidence: the whole cluster is about *preventing* effects, which is not our
+  problem; and our declaration is unverified by construction (C1).
+
+## Changelog
+
+- 2026-08-24 — created, from the computer-use rollback scan.

--- a/research/landscape/crab-agent-checkpoint-restore.md
+++ b/research/landscape/crab-agent-checkpoint-restore.md
@@ -1,0 +1,112 @@
+---
+name: Crab (HKUST) — semantics-aware checkpoint/restore for agent sandboxes
+class: INFRASTRUCTURE
+first_seen: 2026-08-24
+updated: 2026-08-24
+url: https://www.alphaxiv.org/abs/2604.28138
+licence: unknown — no repository located
+activity: active — preprint, April 2026
+---
+
+## What it is
+
+A host-side runtime that makes checkpoint/restore of agent sandboxes *selective* rather
+than uniform, by inferring from OS-visible effects whether a given agent turn changed
+anything worth checkpointing. Its framing is the **agent–OS semantic gap**: agent
+frameworks see tool calls but not their concrete OS effects; the OS sees state changes but
+not the turn-level context that says whether they matter for recovery. Crab sits between
+the two and reports that **over 75% of agent turns produce no recovery-relevant state**,
+making most full checkpoints unnecessary.
+
+## How it works
+
+Three components, none requiring modification to the agent or the C/R backend.
+
+- **Coordinator** — an HTTP reverse proxy on the agent↔LLM control path. An outbound LLM
+  request marks a turn boundary; the Coordinator logs the request/response pair, dispatches
+  a checkpoint job asynchronously *into the LLM inference wait window*, and buffers the
+  response until that job is durable. If the response lands first, the job is promoted to a
+  high-priority queue because its latency is now on the critical path.
+- **Inspector** — in-kernel eBPF `sys_enter`/`sys_exit` tracepoints on filesystem syscalls,
+  cgroups to bound which processes are the sandbox's, and soft-dirty page tracking
+  (`/proc/PID/pagemap`, `/proc/PID/clear_refs`) for memory. Computes **net** change since
+  the last checkpoint, so a temp file created and deleted in one turn counts as nothing.
+  Classifies each turn: no checkpoint / filesystem-only / process-only / full.
+- **C/R Engine** — OpenZFS incremental snapshots for the filesystem, runc-CRIU for process
+  dumps, and a versioned manifest `C_i = (P_j, F_k)` pairing the latest process and
+  filesystem artefacts into a consistent recoverable state, published transactionally.
+
+Measured: Inspector accuracy 100% on process change (no false positives or negatives) and
+98.3% on filesystem change with **zero false negatives** and 2.3% false positives.
+Checkpoint p50/p95/p99 = 0.1/0.7/1.0 s, bimodal (filesystem-only 20–100 ms, process
+700–1000 ms). Restore under 1 s. End-to-end overhead 0–1.9% versus fault-free execution;
+up to 87% of turns skipped. RL tree rollouts: 40.0–64.2% token reduction.
+
+## What it does that we should learn from
+
+**The error direction is stated and it is the right one.** A false positive costs an
+unnecessary filesystem checkpoint; a false negative would cost correctness; they measured
+zero of the latter. Any detector we build for roadmap item 2 ("detecting unmediated effects
+beyond the workspace") should be held to exactly that asymmetry, and Crab is the evidence
+that it is achievable with commodity kernel facilities. This is now written into
+`2026-08-19-kernel-enforced-capture-boundary`.
+
+**Net change, not raw change.** The Inspector deliberately ignores transient effects that
+cancel within a turn. `tree::snapshot` already gets this free by content-addressing — an
+unchanged workspace yields the same `state_root` and `Store::put` is a no-op — but we pay
+the *walk-and-hash* cost every step where Crab pays nothing. That is a performance
+observation, not a correctness one, and it should not be dressed up as more.
+
+**Checkpointing hidden inside the inference wait.** The median exposed delay is zero
+because the checkpoint runs while the model is thinking. If our restore cost ever becomes a
+problem, this is the trick — the agent is idle for seconds per turn and we currently do
+nothing with that window.
+
+**Their fast-forward is our checkpoint.** For the agent-in-a-sandbox deployment, after a
+restore the Coordinator replays *cached historical LLM responses* to the agent until its
+logical progress matches the restored checkpoint head. They needed a deterministic prefix
+served from a recording to reconcile a snapshot with a process that outlived it. C2,
+re-derived by someone solving a different problem.
+
+## Where it is weaker, and why that is interesting
+
+**"100% recovery correctness" is a benchmark outcome, not a re-derivation.** It means the
+task still passed, on Terminal-Bench and SWE-Bench, with one injected crash. Nothing in
+Crab compares the restored state to the state that was checkpointed. This is the same hole
+as BPO's Assumption 1 and AgentENV's silent fork — see
+`2026-08-21-unverified-fork-in-branching-rl`, which now lists Crab as its fourth instance.
+The sharp part: their Inspector *already computes* the net-change information that would
+let them verify a restore. They use it only to decide whether to checkpoint.
+
+**The comparison baselines are the interesting data.** "Chat-only" recovery scored 8–28%
+correctness and "Chat+FS" 28–42% on Terminal-Bench — that is the measured cost of
+recovering an agent from its transcript alone, which is what most frameworks do.
+
+**Deployment cost.** eBPF tracepoint attachment and CRIU both want privilege; this is a
+host-side runtime for a fleet operator, not something a developer installs. That is the
+opposite of our posture and it is why the *mechanism* transfers and the *product* does not.
+
+## Overlap with us
+
+Small and clean. Crab optimises the cost of checkpointing; we make a checkpoint verifiable.
+They are a plausible *substrate* underneath a very different tool, not a competitor — and
+the roadmap's "snapshot fast-path behind the same checkpoint interface" is precisely the
+place their mechanism could sit, if C2's verification story survived the change
+(`2026-08-19-snapshot-omits-derived-state` is the acceptance criterion).
+
+They make no fidelity claim we also make. They claim efficiency and task-level recovery,
+and they back both.
+
+## Watch triggers
+
+- **A repository appears.** None located; `orx paper` surfaced no associated GitHub. Source
+  would let us check whether the Inspector's zero-false-negative result survives reading.
+- **The Inspector is used to verify a restore rather than to schedule one.** That would make
+  them the first system in this space with an evidence story, and it would close the gap
+  `2026-08-21-unverified-fork-in-branching-rl` says is ours.
+- Adoption by an RL stack (verl, verifiers, SkyRL) as a rollout substrate.
+
+## Changelog
+
+- 2026-08-24 — created, from the computer-use rollback scan. Report read via `orx paper`;
+  no source read.

--- a/research/landscape/openresearch-cli.md
+++ b/research/landscape/openresearch-cli.md
@@ -1,0 +1,109 @@
+---
+name: orx (OpenResearch CLI) — experiment tree
+class: INSPIRATION
+first_seen: 2026-08-24
+updated: 2026-08-24
+url: https://github.com/openresearch (CLI; `orx skill orx-experiment-tree`)
+licence: unknown — distributed as a binary, source not located
+activity: active — the tool this project now uses for literature search
+---
+
+## Why this entry exists, and what it is *not*
+
+`orx` is the paper-search tool the scout now uses (`orx discover` / `orx paper`, see
+`.claude/skills/technical-scouting/references/orx-cli.md`). Separately, it ships a local
+**experiment tree** for ML training runs whose two cardinal rules — *never edit a node a
+run has answered*, and *branch a child to try a variant* — look, at a glance, like this
+project's checkpoint model.
+
+**I tested that resemblance and most of it does not survive.** The entry exists for a
+narrower reason, given at the end: orx publishes a written branch-*selection* policy, and
+that is the first answer of any kind to a standing question in `research/README.md` that
+has had no source at all.
+
+## What it is
+
+A project is a tree of experiment nodes. The root (baseline) holds starting code and a
+**run command** — one shell command that trains or evaluates the node and prints results to
+a run log. Every other node is a child branched off a parent, inheriting its code (as a git
+branch) and its run command. Runs are launched against the node; results attach to it.
+
+## How it works
+
+Two rules carry the model:
+
+- **Provisional until it answers.** A run that dies on an error establishes nothing and
+  tests nothing, so the node is still provisional: fix it in place and re-run the same node.
+  There is a repair cap of two.
+- **Frozen once it answers.** A run that produced the result the node was after — "good, bad
+  or `nan`" — freezes the node permanently. Never edit it again; branch a child. Explicitly:
+  "a disappointing number is a result, not a reason to repair," and, on the other side,
+  "unintended behaviour is not an answer" — an OOM, a timeout, a missing dependency leaves
+  the node provisional, *unless the node's hypothesis was about memory or runtime*.
+
+State lives in a local store plus a git worktree per project; the unit of capture is a git
+branch plus a run log.
+
+## What it does that we should learn from
+
+**The one thing worth taking, and it is not the freeze rule.** orx publishes an explicit
+policy for *which* branch to create next, which is roadmap item 4's problem and which the
+2026-08-21 DST scan recorded as having no source anywhere ("Antithesis explicitly withholds
+its guidance component; nobody else publishes one"). Theirs:
+
+> **width = the open options of one decision** (fan freely — a 3-way LR sweep *should* be
+> three siblings under a common head); **depth = decisions already resolved, stacked** (one
+> level down per winner kept). A new round never hangs off the root — it hangs off the
+> previous round's winner.
+
+with two named anti-patterns: the **flat fan** (whole sweep off the root, so "every result
+is measured against the *start*, so wins never accumulate"), and the **noodle** (a long
+single-child chain, "depth manufactured for its own sake"). The operational test for
+whether X should be a child of Y or its sibling is stated as a question: *name what Y
+established that X builds on.* If you can name it, descend; if X and Y are co-equal options
+of the same decision, fan.
+
+That is a real, checkable heuristic for shaping a branch tree, published rather than
+withheld. It is one data point, from a domain (hyperparameter search) with a property we
+lack — a scalar per round that identifies a "winner". A counterfactual debugging session has
+no winner, so the rule cannot be lifted. But "measure this round against the last round's
+winner, not against the root" is a shape our `bisect` already implicitly has and our
+multi-branch exploration does not yet have a story for.
+
+## Where it is weaker, and why that is interesting
+
+**The freeze is a discipline, not an invariant — this is where the analogy fails.** orx's
+immutability is a rule written in a skill document and obeyed by an agent that reads it.
+Nothing content-addresses a node; a child inherits code through a git branch and the run
+command is a "fixed contract" by convention. You *can* edit a frozen node; you are told not
+to. In our model you cannot edit a step without changing its address, and prefix sharing,
+copy-on-write and immutable history are consequences of hashing rather than of compliance.
+Two systems can share a shape without sharing an evidence standard, and the evidence
+standard is the whole of our differentiation. Treating this as a peer model would be exactly
+the surface analogy the scout is supposed to reject.
+
+**And the interesting half of the freeze rule, we already have.** orx's sharpest distinction
+is between "the run answered the question" and "the run broke for an unrelated reason". That
+is `ceb2fd4` / #58 — "'It ended here' and 'it broke here' are different facts. A timeline
+that stops does not distinguish them, which is this project's stated failure mode in
+miniature." We shipped that argument on 2026-08-21 in `noidroid branch`'s outcome reporting.
+Novelty PRESENT; no action.
+
+## Overlap with us
+
+Essentially none as products. orx branches *code* to answer research questions; we branch
+*executions* to answer counterfactual ones. It makes no reconstruction claim, no fidelity
+claim, and no verification claim, so there is nothing to compare on the axis we compete on.
+
+## Watch triggers
+
+- If orx (or anything like it) publishes a branch-selection policy that does **not** assume a
+  scalar winner per round, that is directly relevant to roadmap item 4 — reopen.
+- If the experiment tree gains content addressing or any re-derivation check on a node, the
+  comparison becomes real and this entry should be rewritten as `IDEAS WORTH TAKING`.
+
+## Changelog
+
+- 2026-08-24 — created. Read `orx skill orx-experiment-tree` and `orx --help`. The
+  checkpoint-model resemblance was examined and largely rejected; the entry is kept for the
+  published branch-selection policy only.

--- a/research/scans/2026-08-24-computer-use-rollback-and-effect-boundaries.md
+++ b/research/scans/2026-08-24-computer-use-rollback-and-effect-boundaries.md
@@ -1,0 +1,422 @@
+---
+date: 2026-08-24
+cadence: targeted
+question: "For computer-use agents, what happens to state that a rollback does not restore — and what has the field shipped on that since 2026-08-21?"
+cards_created:
+  - 2026-08-24-live-replay-performs-irreversible-effects
+  - 2026-08-24-attended-state-is-a-world-we-never-declare
+  - 2026-08-24-no-undo-across-the-tool-boundary
+cards_updated:
+  - 2026-08-19-kernel-enforced-capture-boundary
+  - 2026-08-21-unverified-fork-in-branching-rl
+landscape_created:
+  - crab-agent-checkpoint-restore
+  - openresearch-cli
+---
+
+# Scan: computer use, and what a rollback does not take back
+
+> **Framing and dedup.** `scans/2026-08-21-computer-use-gaps-and-rl-post-training.md`
+> covered computer-use capability gaps and the RL post-training pipeline. This pass is
+> deliberately narrower and on a different axis it did not touch: **the state an agent
+> rollback fails to restore.** Nothing here re-treads benchmarks, mocked environments,
+> rollout formats or reward integrity. Every paper cited was checked against `research/`
+> by id and by name before being opened; all were new. Also a case study for `orx
+> discover`/`orx paper` as the literature tool — verdict at the end.
+>
+> C1, C2, C3, C4 and C9 all bind and nothing below asks to reopen any of them. There is no
+> similarity score, no threshold and no fuzzy match in any recommendation — and where a
+> source offered one, I say why we should not take it.
+
+## In one paragraph
+
+I started on "computer use for agents" and the sweep pulled up something narrower and more
+useful than expected: a **cluster of at least eight independent 2026 systems papers all
+building a transaction boundary around agent side effects**, because rolling back an agent
+does not roll back what left the process. I read four as full primary sources (ACRFence,
+Cordon, Crab, and the KV-cache rollback paper) and screened the rest. Three things
+survived. **The headline is a defect in our own code, and it is the run's most important
+output:** ACRFence demonstrates at 10/10 that agents re-perform irreversible actions after
+a restore, and reading it against `engine.rs` I found that of the three code paths that can
+answer `execute`, **one — `Phase::Reconstructing if runs_live(&target)`, line 693 — never
+consults `may_perform_irreversible()`**. A `noidroid replay --live world` on a trajectory
+containing an irreversible `world.charge` performs it again, `report.denied` stays empty,
+and the CLI's warning is gated on `report.denied` being non-empty so nothing is printed.
+Our own test `a_replay_never_touches_the_world` passes because it is called with
+`live: &[]`. Second, "Aborted but Not Forgotten" (16 Aug 2026) shows that a logical rollback
+and a serving session's retained KV cache can disagree invisibly — and the general lesson,
+stripped of its security framing, is that **the inference endpoint is a world in our own
+environment-model sense and no recording declares it**, which is an unfilled row in a table
+we shipped in 0.3.0. Third, the negative half: the eight-paper cluster is inventing, badly
+and by inference (one of them uses an LLM to judge whether two tool calls are "the same"),
+the seam we already have as `EffectKind`. That is a positioning finding, not a build, and I
+have scored it as such. Crab additionally hands us the restore-latency distribution that the
+2026-08-21 scan's top recommendation was explicitly blocked on.
+
+## What survived
+
+**`2026-08-24-live-replay-performs-irreversible-effects` — PROTOTYPE. The headline, and it
+is about us.**
+`may_perform_irreversible()` in `engine.rs:839` returns true only for `Mode::Record`, with
+the comment "Only an original recording is allowed to touch the world for real. Every
+reconstruction and every branch is denied by default." Three arms of `on_call` reach
+`Response::execute()`. Lines 649 and 665 check the guard. Line 693 —
+`Phase::Reconstructing if self.runs_live(&target)` — takes `effect` straight from the
+client's request and never inspects it. `runs_live` is *prefix* matching, so `--live world`
+covers `world.charge` without a glob, while the flag's own doc comment only ever imagines
+`--live model`. Narrower than ACRFence's attack (`expect_match` runs first, so the call must
+already agree with the recording — this is the plain double-spend, not divergent
+re-synthesis, which *is* guarded), but silent in the report and in a mode we actively
+recommend. I did not execute the failing case; writing the test that should fail is step one
+and could prove this card wrong.
+
+**`2026-08-24-attended-state-is-a-world-we-never-declare` — INVESTIGATE.**
+arXiv 2608.15939 formalises *rollback consistency*: a believed-complete abort must restore
+the state the model attends, not just the transcript. Retained KV alone flipped a protected
+effect in 25/63 cells with the attacker tokens provably absent from the served request in
+all 63, and it reproduced inside LangGraph time-travel. Their scope note is the load-bearing
+sentence for us: a content-addressed prefix cache (vLLM) is **exempt**; the hazard is
+retained-*handle* reuse. Our exposure is the mirror image and confined to
+`Replay { live: [...] }` — steps 0..k are served from the recording and never sent to the
+server, so a client holding a session handle has a verified transcript sitting on an
+attended state that was never built. `grep` confirms we declare no world for the model:
+`llm.py` has no `observe`, `doctor.rs`'s coverage list has no entry, §12's conformance table
+has no row. The likely honest outcome is one sentence saying our clients are stateless — but
+right now that guarantee is accidental rather than stated.
+
+**`2026-08-24-no-undo-across-the-tool-boundary` — WATCH, and the run's most useful
+negative.** ACRFence, Cordon, DART, Crab, ChronoMem, MemTX, Transactional Continuity Kernel,
+AID-Guard, plus maintainer reports from LangGraph, Google ADK, OpenClaw and a HashiCorp
+Vault issue where single-use tokens reappeared after a snapshot restore. Every one needs to
+know, per call, "is this reversible?", and none can ask — so ACRFence infers it with an
+**analyzer LLM**, Cordon with a lineage graph and nine hand-written invariants, Crab with
+eBPF syscall tracing. Three inference mechanisms for a fact the caller knows.
+`EffectKind { Read, Write, Irreversible }` is declared at the call site, travels in
+`proto.rs`, is hashed into the step, and gates `checkpoint.rs`. Novelty **PRESENT** — the
+finding is that we should *say* this, plus one small gap: we have no cross-branch query
+("has any branch of this trajectory already performed `world.charge`?"), which is the exact
+artefact ACRFence had to invent.
+
+## Looked at, not pursued
+
+- **Qwen-CUA (2608.02352)**, 86.2 on OSWorld-Verified, ~100,000 vCPUs of rollout fleet,
+  "trajectory slicing". Screened by abstract. Capability scaling; nothing about state
+  fidelity, rollback or capture. Confirms the 2026-08-21 picture rather than changing it.
+- **Computer-Using World Model (2602.17365, Microsoft)** — read in full and it is the most
+  interesting near-miss. Its motivation is verbatim our problem: "real execution does not
+  support counterfactual exploration… despite the environment being fully digital and
+  deterministic", and it names the reason as latency plus irreversibility ("undo functions
+  are often limited and context-dependent"). Their answer is to *generate* the next
+  screenshot with a fine-tuned VLM plus a diffusion editor. That is `Provenance::Simulated`
+  with a learned generator: useful for action search before acting, useless as evidence, and
+  they never claim otherwise. Not a card because there is no mechanism to take — but it is a
+  clean statement that the field wants counterfactual exploration of computer use and is
+  reaching for a generative substitute because nobody offers a faithful one. Notable detail
+  for anyone tempted by multimodal state: combining their text and image predictions
+  *degraded* agent performance, which they attribute to cross-modal conflict.
+- **DeltaBox (2605.22781)** — millisecond sandbox C/R via delta snapshots. Same unverified-
+  restore family as Crab; folded into that card's family rather than opened, since Crab
+  covers the mechanism class and has the better evaluation.
+- **SynChain (2608.06862)** — agents induced to synthesise poisoned skills that survive
+  internal state updates; concludes that "securing CUAs requires provenance-aware reasoning
+  over cross-task execution trajectories". Interesting vocabulary collision with ours, but
+  the mechanism is fine-tuning-based attack construction. No transferable seam.
+- **"What Did It Actually Do?" (2603.28551)** — AgentTrace, an interview study plus a
+  traceability UI prototype for what an agent touched and what persists after uninstall.
+  Real user need, but it is a visualisation layer and C9 says we are not building a
+  dashboard. Recorded so nobody re-opens it.
+- **Inducing Task Models from Computer-Use Traces (2608.20319)** — passive screenshot/input
+  traces to symbolic task models. Trace *summarisation*, which is C5's territory from the
+  other direction; nothing re-derives an address.
+- **The CUA safety line** — BraveGuard, StepJack, SeerGuard, CORA, Safety Sentry, Visual
+  Confused Deputy, ROGUE. Screened. All are guard models, risk classifiers or conformal
+  abstention over proposed actions. Crowded, actively researched, and squarely inside "do
+  not build a judge" from the 2026-08-21 scan. One line each and no more.
+- **CLI-Anything (2606.03854)**, **Multi-Agent Computer Use (2606.01533)**,
+  **AOI (2606.29472)**, **CUADebug (2608.02643)** — agent architecture and interface papers.
+  CUADebug is the closest to us in spirit (root-cause localisation over failed OSWorld
+  trajectories, 11.2%→19.6% joint subtype-and-step diagnosis with Gemini 2.5 Pro) and is
+  worth one sentence: it is `bisect`'s problem solved by prompting a debugger over
+  screenshots instead of by re-running the execution, and its numbers are the reason we
+  answer it by experiment. Not a card; it corroborates a claim the README already makes.
+- **`orx`'s experiment tree** — examined at the task's suggestion, and the checkpoint-model
+  resemblance mostly **did not survive**. See the landscape entry for why; short version, the
+  freeze is a discipline rule over a git branch rather than an invariant of an addressed
+  structure, and the genuinely sharp half of it ("a run that broke is not a run that
+  answered") we shipped ourselves in #58. Kept for one narrow reason only.
+
+## Negative findings
+
+**Opportunities.**
+
+1. *Nobody can declare an effect's reversibility, so everybody infers it.* Eight systems,
+   three different inference mechanisms, none of them sound. We are told. (Card 3.)
+2. *No system in this cluster verifies its restore.* Crab claims "100% recovery correctness"
+   and means benchmark pass rate under one injected crash. Its Inspector already computes
+   the net-change data that would let it check, and it uses that data only to decide whether
+   to checkpoint. Fourth instance of the pattern in
+   `2026-08-21-unverified-fork-in-branching-rl`.
+3. *Recovering an agent from its transcript alone does not work, and there is now a number.*
+   Crab's baselines: chat-only recovery 8–28% correct, chat+filesystem 28–42% on
+   Terminal-Bench. That is the measured cost of the thing most frameworks do.
+4. *Counterfactual exploration of computer use is wanted and unserved.* CUWM says so in its
+   motivation and answers it with a generative model because no faithful option exists.
+
+**Warnings.**
+
+5. *Our own irreversible guard has a hole, in the mode we recommend most.* Card 1. This is
+   the project's stated worst failure mode — a trajectory that looks real — in our own
+   engine, and it was found by reading a paper against our code rather than by any test.
+6. *The fashionable fix in this cluster is a fuzzy matcher and we must not take it.*
+   ACRFence's replay-or-fork decision is made by "a lightweight analyzer LLM" comparing
+   whether two tool calls are semantically equivalent, precisely so it can ignore differing
+   request ids and timestamps. That is C4 wearing a new hat. Our version is `key` equality
+   and a fatal divergence; they approximate it because they have no oracle.
+7. *The whole cluster is about prevention, which is not our business.* Outboxes, shadow
+   state, policy engines, guard models. C9. The temptation to add "and it can block the bad
+   call too" should be refused — we report, we do not police.
+8. *We would be measured against 0.1–2 s per fork, not 50 ms.* Crab's commodity-backend
+   distribution reframes the AgentENV comparison in our favour, and our own number is still
+   unmeasured after three scans.
+
+## What we now know that we did not
+
+1. **`engine.rs:693` executes irreversible effects during a replay**, and it is the only one
+   of three `execute` paths that does not consult the guard. Read directly from source.
+2. **A logical rollback and a serving session's KV can disagree invisibly**, causally
+   demonstrated with a same-token/different-cache audit, reproducing inside a first-class
+   rollback API — and **content-addressed prefix caches are exempt**, which is the sentence
+   that scopes our exposure.
+3. **We declare no world for the model provider anywhere in the tree.** grep-verified across
+   `llm.py`, `doctor.rs` and §12's conformance table.
+4. **At least eight independent 2026 systems are building an agent effect-transaction
+   boundary**, and none of them can ask the caller what we ask the caller.
+5. **Checkpoint/restore cost on commodity backends**: p50/p95/p99 = 0.1/0.7/1.0 s,
+   bimodal — filesystem-only 20–100 ms, process 700–1000 ms; restore median 0.71 s.
+6. **Up to 87% of agent turns change no recovery-relevant state**, and detecting that with
+   eBPF is 100% accurate on process change and 98.3% on filesystem change **with zero false
+   negatives** — the fail-safe direction roadmap item 2 requires.
+7. **The deterministic prefix keeps being re-derived by people solving other problems.**
+   Crab's fast-forward replays cached LLM responses to realign an agent with a restored
+   checkpoint; the KV paper's sufficient fix is "rebuild from the committed transcript",
+   chosen over both a global flush and a full restart. C2 gains two more independent
+   corroborations.
+8. **`--proxy` is now the third-party architecture three times over**: `verifiers`,
+   our `af81680`, and Crab's Coordinator.
+
+## Still unknown
+
+- **Our own restore-and-branch cost as a function of k.** Fourth consecutive scan carrying
+  this. We now have a proper band to be measured in (item 5 above), which makes the
+  measurement more valuable, not less. It remains a day's work.
+- **Do any of our client paths hold a server-side session handle?** The whole consequence of
+  card 2 turns on this and it is a survey of four code paths, not research.
+- **Does the `--live` irreversible case actually fire?** Card 1 is a control-flow read, not
+  an execution. One test settles it.
+- **Crab's source.** No repository located; `orx paper` surfaced no associated GitHub. Every
+  number in that landscape entry is theirs.
+- **Cross-branch effect queries** — whether anyone besides ACRFence has built one, and what
+  shape. I found the need, not the prior art.
+- **The computer-use trajectory datasets** — OpenCUA/AgentNet, AgentTrek, OS-Genesis,
+  GUI-Odyssey, AndroidControl. Carried from 2026-08-21 and *still* not reached; this pass
+  went sideways into rollback semantics instead. It should be its own scan or be dropped
+  from the standing list, because it has now lost twice.
+- **Whether `EffectKind` survives contact with a real adapter author.** Card 3's whole
+  argument is that declaring reversibility is better than inferring it. We have no evidence
+  that people declare it *correctly*, and a mislabelled charge is indistinguishable from a
+  correct one to us by construction (C1).
+
+# Recommended Actions
+
+Ranked by Impact × Relevance × Feasibility × Novelty.
+
+### 1. Close the `--live` irreversible hole, failing test first
+
+**What to build.** Add `a_live_replay_still_refuses_an_irreversible_target` to
+`crates/noidroid-core/tests/vertical_slice.rs`, modelled on the existing `irreversible`
+fixture: record, then run `Mode::Replay { live: vec!["world".into()] }`, and assert the
+witness file contains `charge` exactly once. Confirm it fails. Then consult
+`may_perform_irreversible()` on the `Phase::Reconstructing if runs_live` arm, routing to
+`simulated_value` then `deny_irreversible` exactly as line 665 already does. Then decide
+whether `--live <prefix>` that matches a recorded irreversible target should refuse the run
+*before it starts* — the chain is walkable at `cmd_replay` time, so this is a pre-flight
+check.
+
+**Why now:** ACRFence is the trigger — it establishes empirically (10/10, and a survey
+finding that none of 12 frameworks prevent it) that re-performing irreversible effects after
+a restore is a real production failure rather than a hypothetical. We built the mechanism
+that answers it and left one path unguarded. Every day it stays open, `--live` is the mode
+we recommend for the most common change people make.
+
+**Impact:** 3 — it restores a claim the README makes and a named test asserts. A replay that
+touches the world and reports itself faithful is this project's defining failure.
+**Relevance:** 3 — capture honesty and replay, dead centre.
+**Feasibility:** 3 — one guard call, one test, optionally one pre-flight check. Nothing
+hashed moves; `STEP_VERSION` unaffected. Single PR.
+**Novelty:** 3 — the check does not exist on that path and no test covers it.
+**Score:** 81
+
+**Cost:** one PR. The risk that blows it up: the test written to fail passes instead, meaning
+I misread the control flow and the card is wrong. That is a cheap failure and it is why the
+test comes first.
+**What we would learn:** whether `Phase::Reconstructing` + `runs_live` + `Irreversible` is
+actually reachable end-to-end through the client, or whether something upstream in
+`proto.rs` or the Python client already prevents it. A "no, it is already safe" is a real
+answer and would downgrade this to a comment in the code explaining why.
+**Touches:** `crates/noidroid-core/src/engine.rs` (`on_call` line 684–694),
+`crates/noidroid-core/tests/vertical_slice.rs`, `crates/noidroid-cli/src/main.rs`
+(`cmd_replay` pre-flight and the denial hint at line 867).
+**Evidence:** `2026-08-24-live-replay-performs-irreversible-effects`.
+
+---
+
+### 2. Measure restore-and-branch at step k, and publish the curve
+
+**What to build.** The step 0 the 2026-08-21 scan named and nobody has run: wall-clock
+restore-and-branch at step k, as a function of k, on the reference environment and on the
+browser example. Report the curve, not a single number.
+
+**Why now:** this is the fourth consecutive scan to carry it, and it is now *more*
+decision-relevant rather than less, because the comparison band has resolved. It was
+"1,920 ms or 50 ms, take your pick"; Crab makes it a distribution on commodity hardware —
+p50/p95/p99 of 0.1/0.7/1.0 s to checkpoint, 0.71 s median to restore. If our re-execution at
+k=25 lands inside 0.1–2 s we are competitive on a claim nobody else can make; if it is tens
+of seconds, several open PROTOTYPE recommendations are mis-scoped and should be re-pitched as
+offline analysis rather than as rollout primitives.
+
+**Impact:** 2 — it changes no capability, but it decides the framing of at least three open
+recommendations and one competitive claim.
+**Relevance:** 3 — checkpoints and branching, directly.
+**Feasibility:** 3 — no new code; a script over existing CLI commands and the two examples
+already in the tree.
+**Novelty:** 3 — never measured, and named as the single most decision-relevant unknown by
+the 2026-08-21 scan.
+**Score:** 54
+
+**Cost:** a day. The risk: the reference environment is small enough that the curve is
+flattering and tells us nothing about a k=200 agent run. Mitigate by reporting k on both
+examples and stating the shape rather than a headline figure.
+**What we would learn:** whether verified forking is a rollout-collection primitive or an
+offline-analysis tool. "It is tens of seconds at k=25" is a perfectly good answer and it
+changes the pitch rather than killing the work.
+**Touches:** nothing in `crates/` — a benchmark script, `examples/`, and a paragraph in
+`README.md` if the number is good.
+**Evidence:** `2026-08-21-unverified-fork-in-branching-rl` (updated),
+`research/landscape/crab-agent-checkpoint-restore.md`.
+
+---
+
+### 3. Survey the four client paths for session handles, then write one honest sentence
+
+**What to build.** No code first. Enumerate `llm.py`'s `model.complete`, `--auto`'s
+`sitecustomize` hooks, `--proxy`'s intercepted request bodies, and the hand-written-client
+case, and for each record whether the request is self-contained (`messages=[...]`, exempt by
+the KV paper's own scope note) or handle-carrying (`previous_response_id`, cached-content
+handles, local `past_key_values`). Then: if all self-contained, add one line to
+`noidroid doctor` and one row to `docs/environment-model.md` §12 recording the inference
+endpoint as a world with `opaque` grip whose statelessness is what makes reconstruction
+sound. If any path carries a handle, `doctor` must warn on it and `--live` on that target
+should declare the session as an `opaque` world via `Session.observe`.
+
+**Why now:** 2608.15939 is eight days old and is the first work to state the cross-layer
+rollback-consistency contract precisely enough to check ourselves against. §12's conformance
+table is the artefact that is supposed to answer "which environments get which grip", and the
+one environment every recording touches is missing from it. Doing this before the table
+acquires more rows is cheaper than retrofitting it.
+
+**Impact:** 2 — converts an accidental guarantee into a stated one. It does not add a
+capability, and if the survey comes back "all stateless" the output is a paragraph.
+**Relevance:** 3 — capture honesty and the environment contract.
+**Feasibility:** 3 — a survey plus a `doctor` line plus a table row. No hashed bytes move.
+**Novelty:** 2 — the mechanism (`grip`, `observe`, `Situation`) shipped in 0.3.0; this is an
+unfilled row, not a new abstraction.
+**Score:** 36
+
+**Cost:** an afternoon for the survey, then a small PR. The risk: over-reach. If this turns
+into "capture the model's serving state" it has gone wrong — that is not possible for a
+hosted API and is C1 for a self-hosted one. The deliverable is a sentence, not a mechanism.
+**What we would learn:** whether any supported path holds server-side state across steps.
+"No, all four are self-contained" is the likely answer and it is worth having written down,
+because right now nobody can tell whether that is a design guarantee or a coincidence.
+**Touches:** `clients/python/noidroid/llm.py`, `auto.py`, `proxy.py`,
+`crates/noidroid-cli/src/doctor.rs`, `docs/environment-model.md` §12.
+**Evidence:** `2026-08-24-attended-state-is-a-world-we-never-declare`.
+
+---
+
+### 4. Make the irreversible-effect record queryable across a trajectory's branches
+
+**What to build.** `noidroid log --irreversible <trajectory>`, or an equivalent column in
+`noidroid diff`: walk the trajectory and its branches and answer "which irreversible effects
+exist anywhere in this family, on which branch, with what outcome (`Value` / `Denied`)?" A
+walk plus a filter over data already in the chain. Stores nothing new, judges nothing,
+blocks nothing.
+
+**Why now:** ACRFence's central artefact is an effect log keyed by thread and branch id,
+which they had to build from scratch and which they populate by interposing with eBPF. We
+already store strictly better data — hashed, immutable, per-step, with a declared
+`EffectKind` and an `EffectOutcome` — and no command surfaces it. Making it queryable is the
+cheapest way to turn a design advantage into something a user can see.
+
+**Impact:** 2 — exposes something we already hold; no change to what a reconstruction can
+claim.
+**Relevance:** 2 — CLI and reporting.
+**Feasibility:** 3 — a chain walk and a filter, single PR.
+**Novelty:** 2 — the data exists and is not reachable; this is a named improvement to
+reporting rather than a new capability.
+**Score:** 24
+
+**Cost:** one PR. The risk: it drifts toward "and it can warn you before you re-run one",
+which is the prevention business (C9) that the entire eight-paper cluster is in and we are
+not. The discipline is that it reports history and offers no opinion about the future.
+**What we would learn:** whether "what irreversible things did this family of runs do?" is a
+question anyone asks. If nobody uses it, that is evidence that our `EffectKind` advantage is
+architecturally real but practically invisible, which is itself worth knowing before we lead
+with it in positioning.
+**Touches:** `crates/noidroid-cli/src/main.rs`, `crates/noidroid-core/src/repo.rs`
+(read-only walk).
+**Evidence:** `2026-08-24-no-undo-across-the-tool-boundary`.
+
+## Explicitly not recommended
+
+**Do not adopt ACRFence's analyzer-LLM comparison, in any form.** Their replay-or-fork
+decision is made by an LLM judging whether two tool calls are "semantically equivalent", so
+that differing request ids and timestamps can be ignored. It is a fuzzy matcher with a
+learned oracle, it is C4 exactly, and the reason they need it is that they have no way to
+identify a call positionally. We do: `key` is position-and-identity, and divergence is fatal.
+The correct reading of ACRFence is that it validates our evidence standard by demonstrating
+what you have to resort to without one.
+
+**Do not build an effect outbox, shadow state, or a staged-commit boundary.** Cordon is very
+good at this — 45/45 risk-bearing workflows intercepted before commit versus 14/45 for
+adapted existing defences — and it is an agent runtime that interposes on tool dispatch,
+holds writes in a shadow filesystem, and decides policy. That is C9's agent framework and
+C1's "own the program" trade in one package. Our answer to the same problem is that we record
+what happened and refuse to re-perform it, which is a different and smaller job.
+
+**Do not build a guard model, a risk classifier, or an action-abstention mechanism.** The
+computer-use safety literature is large, well-funded and moving fast — BraveGuard, StepJack,
+SeerGuard, CORA, Safety Sentry, the visual-confused-deputy line. The 2026-08-21 scan already
+ruled out judging trajectories; this rules out judging actions, for the same reason and with
+more sources.
+
+**Do not build a generative world model for counterfactual computer use.** CUWM is the
+tempting one because its motivation sentence is ours almost verbatim. But a predicted next
+screenshot is `Provenance::Simulated` produced by a diffusion model, and our whole claim is
+that a reconstruction is faithful or says why not. Their own result that adding text to image
+predictions *degrades* agent performance is a hint at how load-bearing the fidelity is.
+Where we and they overlap is a customer question, not an engineering one: they serve "search
+before you act", we serve "find out what would have happened".
+
+**Do not treat orx's experiment tree as a peer checkpoint model.** I tested the resemblance
+because the task asked me to, and it does not hold: the freeze is a rule an agent obeys, over
+a git branch, with no content addressing and no re-derivation check. The one part of it worth
+having — distinguishing "the run answered" from "the run broke" — we shipped in #58. The
+entry is kept only for its published branch-selection policy, which is the first data point
+of any kind on a standing question, and even that assumes a scalar winner per round that
+counterfactual debugging does not have.
+
+**Do not re-open computer-use benchmarks or datasets on the strength of this run.** The
+standing-questions list has carried "computer-use trajectory datasets" for two scans and it
+has now lost twice to a more urgent question. Either commission it as its own targeted scan
+or strike it; leaving it on the list is how it stays permanently second.

--- a/research/taxonomy.md
+++ b/research/taxonomy.md
@@ -69,6 +69,10 @@ Marked `[active]` where we are currently looking hardest.
 - computer-use agents `[active]`
 - browser automation `[active]`
 - AI-assisted debugging
+- agent effect boundaries `[active]` — commit/rollback scope around an agent's *external*
+  side effects. Opened 2026-08-24. Distinct from `checkpointing`: the subject is not how
+  state is saved but **what a restore fails to take back**, and it is where `EffectKind`
+  and the deny-by-default rule get compared against the field.
 
 ## RL post-training
 *Opened 2026-08-21. This is where the trainer-side landscape lives — the question is not
@@ -96,6 +100,13 @@ Marked `[active]` where we are currently looking hardest.
   `agent evaluation`, `computer-use agents` and `browser automation` active. No other
   category opened — `checkpointing`, `state reconstruction`, `provenance` and
   `counterfactual reasoning` already covered the mechanism side of every finding.
+- 2026-08-24 — added **agent effect boundaries** under *Agents* after the computer-use
+  rollback scan. Three cards needed a home that `checkpointing` did not give them: the
+  eight-paper transaction cluster, the `--live` irreversible defect, and the attended-state
+  finding are all about the effects a restore does *not* undo, which is a different subject
+  from how a checkpoint is taken. Nothing else opened — `capture honesty`,
+  `environment reconstruction / hermeticity` and `state reconstruction` housed the rest, and
+  `computer-use agents` stays active.
 - 2026-08-21 — added **deterministic simulation testing** under *Core mechanism* after the
   DST scan, and marked `fault injection` and `simulation` active. It needed its own line
   rather than living under `deterministic replay`: DST reproduces a run from a seed with no


### PR DESCRIPTION
## Summary
- Adds `.claude/skills/technical-scouting/references/orx-cli.md`: when/how the scout should use `orx discover`/`orx paper` (structured, no-login alphaXiv/OpenAlex/bioRxiv search) instead of WebSearch for the Research source class. Wired into `sources.md` and `SKILL.md`. Deliberately does not touch `orx`'s ML-experiment-tree/compute surface — out of scope, not this project's workload.
- Validates the tool with a real case study: a targeted scan on rollback/effect-boundary handling in computer-use agents (`research/scans/2026-08-24-computer-use-rollback-and-effect-boundaries.md`), deduped against the existing 2026-08-21 computer-use scan. Three new cards, two landscape entries.
- **Surfaces a real bug**, filed separately as #87: `engine.rs`'s live-replay execute path can perform a recorded-irreversible effect for real, unguarded, during `replay --live`. Not fixed here.

## Stacked on #85
This branch is built on `feat/84-chore-research-commit-the-scout-s-uncomm` (#84 / PR #85), which recovers `research/`'s pre-existing content that had never been committed anywhere. Merge #85 first; this diff will shrink to just this PR's own commits once it does.

## Tool verdict (from the case-study run)
Worth keeping for papers specifically — `orx paper` returned exact numbers and limitations sections a WebFetch of an abstract page wouldn't surface, and one query on alphaXiv assembled the scan's entire spine. `orx discover openalex` was useless for this domain (keyword-matches "agent" across all of science) — reserved for genuinely cross-disciplinary queries per the doc. Pairs with, does not replace, WebSearch for repos/issues/engineering writing.

## Test plan
- [x] Independently re-read `engine.rs:621-709` and confirmed the guard gap the case study reports (lines 649/665 check `may_perform_irreversible()`, line 693 doesn't).
- [x] Confirmed dedup: no existing card/scan covers the rollback/effect-boundary angle.
- [ ] Human review of the new reference doc and the case-study cards' recommendations.

Closes #83