### PR TITLE
feat(auto): a program that spawns a child process is caught, not missed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,25 @@ how the package version relates to `STEP_VERSION`, the on-disk object format.
   clean program. The async SDK surface (#33) and the hardcoded `AF_UNIX` (#32) are
   named as the known limitations they are instead of being left to look covered. There
   is no score, no percentage and no readiness grade. (#29)
+- **A program that spawns a child process is caught, not silently missed.** A child
+  does not inherit the bootstrap's patch, so nothing it does was ever mediated,
+  fenced, or reported — and until now nothing said so. `--auto` treats it exactly
+  like the async-client hole: reported, and refused unless the caller says
+  `--allow-gaps`, in which case the recording declares `subprocess` as an opaque
+  world so every step after it says what it is worth. Detection patches
+  `subprocess.Popen.__init__` and checks the immediate caller, past `subprocess.py`'s
+  own convenience wrappers, against the standard library and every installed
+  package — precise enough to catch `subprocess.run(["git", "diff"])` written in the
+  program while staying silent on `uname -p`, which `httpx` (and so `anthropic` and
+  `openai`) shells out to on every real request to build a User-Agent header. An
+  import-time signal was tried first and does not work: `anthropic` imports
+  `subprocess` itself as a side effect before the program's own code ever runs,
+  which spends the one-shot `import` audit event on plumbing that has nothing to do
+  with the program shelling out and leaves every later `import subprocess`
+  invisible. Because detection can only happen once the program is already running,
+  a refusal here may follow steps already recorded; the engine's existing handling
+  for a program that dies mid-run applies unchanged — what happened is kept, marked
+  `aborted`. `os.system` bypasses `Popen` entirely and is a known gap. (#31)
 - **The ways a world fails, named.** `noidroid branch --inject <kind>` writes the
   intervention for you: `timeout`, `server-error`, `rate-limited`, `unauthorized`,
   `malformed`, `empty`. Writing the payload by hand is the difference between a thing

--- a/README.md
+++ b/README.md
@@ -543,9 +543,11 @@ pick = nd.decide("route", options=candidates, choice=candidates[0])
 ```
 
 It also does not capture async clients, streaming responses, non-SDK HTTP, the clock,
-or randomness — and it will not quietly record around them. `--auto` prints what it
-hooked *and* what it could not, and **refuses to record** when it finds a surface it
-cannot cover:
+randomness, or what a child process does — and it will not quietly record around
+them. `--auto` prints what it hooked *and* what it could not, and **refuses to
+record** when it finds a surface it cannot cover. A subprocess is caught the moment
+the program actually spawns one — `subprocess.run`, `.call`, `Popen` directly, all of
+it — not merely a library that happens to import the module for its own reasons:
 
 ```console
 $ noidroid run --auto -- python3 agent.py

--- a/clients/python/noidroid/__init__.py
+++ b/clients/python/noidroid/__init__.py
@@ -349,15 +349,32 @@ class _PassThrough:
         return None
 
 
+#: The one live connection this process holds, if any. `connect()` is meant to be
+#: called once per program, but automatic capture may need its own connection before
+#: the program makes one -- to declare a gap it found, say -- and the engine only ever
+#: accepts a single stream per run. A second, independent `Session` would open a
+#: socket the engine is not listening for and hang forever on its first reply, so a
+#: process gets exactly one, whoever asks for it first.
+_active_session: Optional["Session"] = None
+
+
 def connect():
-    """Connect to the engine, or return a pass-through session if not recorded."""
+    """Connect to the engine, or return a pass-through session if not recorded.
+
+    Idempotent within a process: a second call returns the session the first one
+    made, rather than opening a socket nothing will ever accept.
+    """
+    global _active_session
     path = os.environ.get("NOIDROID_SOCKET")
     if not path:
         return _PassThrough()
+    if _active_session is not None:
+        return _active_session
     # During a reconstruction nothing should reach the network: everything is served
     # from the recording. Anything that still tries was never recorded, and saying so
     # loudly is the whole point.
     from . import fence
 
     fence.install_for_mode()
-    return Session(path)
+    _active_session = Session(path)
+    return _active_session

--- a/clients/python/noidroid/auto.py
+++ b/clients/python/noidroid/auto.py
@@ -22,6 +22,11 @@ effect produces a trajectory that looks real:
 * async clients and streaming responses
 * anything not going through the OpenAI/Anthropic SDKs
 * time, randomness, and the filesystem
+* subprocesses -- a child does not inherit the bootstrap's patch, so nothing it does
+  is mediated, fenced, or reported. Capturing one properly needs process-tree control
+  this project does not have, so the honest move is not to try: the moment the
+  program imports `subprocess`, that is treated exactly like an unhooked SDK surface
+  and refused by default. See `guard_subprocess`.
 
 `noidroid run --auto` prints what it hooked. If something you rely on is not listed,
 it was not recorded.
@@ -31,11 +36,12 @@ from __future__ import annotations
 
 import importlib
 import os
+import sys
 from typing import Any, Callable, Optional
 
 from . import READ, connect
 
-__all__ = ["install", "hooked"]
+__all__ = ["install", "hooked", "guard_subprocess"]
 
 #: Base clients generated from the same template, so one patch each covers everything.
 PROVIDERS = ("openai", "anthropic")
@@ -66,6 +72,140 @@ def _shared_session():
     if _session is None:
         _session = connect()
     return _session
+
+
+#: Set once the guard has been installed, so a program that imports the client
+#: twice -- same reason every other install in this module is idempotent -- does not
+#: end up double-patching `Popen.__init__`.
+_guarding_subprocess = False
+
+
+def guard_subprocess() -> None:
+    """Treat spawning a child process as the unhooked-surface gap it is.
+
+    A child process does not inherit the bootstrap's patch: its network calls are not
+    fenced, its file writes are not recorded, none of it is mediated. Capturing that
+    properly needs the process-tree control tools like rr and Hermit have, and that is
+    a much bigger piece of work than this module does. What is in scope is not passing
+    silently -- so the moment the program actually spawns one, this treats it exactly
+    like the async SDK client already is: reported, and refused unless the caller says
+    `--allow-gaps`.
+
+    This patches `subprocess.Popen.__init__` rather than watching for the module to be
+    *imported*. An import-time signal was tried first, using `sys.addaudithook` on the
+    `import` event -- CPython's documented mechanism for exactly this, immune to how
+    the import is spelled. It does not work here: `import`'s audit event fires once
+    per module name for the life of the interpreter, and `anthropic` (like most SDKs
+    built on `httpx`) imports `subprocess` itself as a transitive dependency before
+    this module ever gets a chance to install the hook, which spends the one firing on
+    an import that has nothing to do with the program shelling out. Every later
+    `import subprocess` in the program's own code is invisible after that, silently --
+    exactly the failure mode this guard exists to prevent, now baked into detecting
+    it. `Popen.__init__` is not import-order sensitive: every high-level entry point
+    (`subprocess.run`, `.call`, `.check_output`, `os.popen`) constructs a `Popen`
+    internally, so patching the one class method it shares catches all of them, and
+    does so regardless of who imported the module first. `os.system` is the one
+    common way to shell out that bypasses `Popen` entirely and is not covered.
+
+    Patching the constructor alone over-reports, though: `httpx` -- and so `anthropic`
+    and `openai`, both built on it -- shells out to `uname -p` on every real request,
+    to fill in a User-Agent header. That is not the program shelling out; it is the
+    SDK's own plumbing, and flagging it would refuse or declare-opaque every ordinary
+    model call, which is a false alarm louder than the silence this exists to fix. So
+    `guarded_init` looks one frame past `subprocess.py`'s own convenience wrappers
+    (`run`, `call`, `check_call`, `check_output` all construct a `Popen` internally)
+    and reports only when *that* frame -- whoever actually asked for a process to be
+    spawned -- is outside the standard library and outside any installed package.
+    Walking further up would not distinguish anything: every call chain eventually
+    reaches the program's own entry point, library-internal ones included, so asking
+    "is the program's code anywhere on this stack" is true of all of them. Asking who
+    the *immediate* instigator was is what tells `subprocess.run(["git", "diff"])`
+    written in the program apart from `uname -p` three layers inside `httpx`.
+    """
+    global _guarding_subprocess
+    if _guarding_subprocess:
+        return
+    _guarding_subprocess = True
+
+    import subprocess as _subprocess
+    import sysconfig
+
+    library_paths = tuple(
+        os.path.realpath(p)
+        for p in dict.fromkeys(
+            sysconfig.get_path(name)
+            for name in ("stdlib", "platstdlib")
+            if sysconfig.get_path(name)
+        )
+    )
+
+    def is_library_frame(filename: str) -> bool:
+        # site-packages/dist-packages covers every mainstream way a package ends up
+        # installed -- a venv, the system interpreter, a user site -- without having
+        # to enumerate each one's own sysconfig path, which sysconfig only reports for
+        # whichever installation scheme is active right now.
+        if "site-packages" in filename or "dist-packages" in filename:
+            return True
+        return os.path.realpath(filename).startswith(library_paths)
+
+    original_init = _subprocess.Popen.__init__
+    reported = False
+
+    def guarded_init(self, *args, **kwargs):
+        nonlocal reported
+        if not reported:
+            frame = sys._getframe(1)
+            # subprocess.py's own convenience wrappers -- run, call, check_call,
+            # check_output -- all construct a Popen internally; skip past those
+            # specific frames so what gets checked is whoever asked subprocess to do
+            # something, not subprocess's own plumbing for doing it. Anything further
+            # up (uname -p from inside platform.py, called from inside httpx) is a
+            # library frame and is not walked past -- only the immediate instigator
+            # is checked, not the whole chain back to the program's entry point,
+            # which every call has one of and would make this always true.
+            while frame is not None and frame.f_code.co_filename == _subprocess.__file__:
+                frame = frame.f_back
+            from_the_program = frame is not None and not is_library_frame(
+                frame.f_code.co_filename
+            )
+            if from_the_program:
+                reported = True
+                print(
+                    "[noidroid.auto] NOT hooked: subprocess — a child process does "
+                    "not inherit the bootstrap, so nothing it does is mediated, "
+                    "fenced, or reported",
+                    file=sys.stderr,
+                )
+                if os.environ.get("NOIDROID_ALLOW_GAPS") == "1":
+                    # Escapable on purpose. Declare the gap on the recording itself
+                    # so every step from here on says what it is worth, rather than
+                    # the refusal being the only place this was ever written down.
+                    try:
+                        _shared_session().observe(
+                            "subprocess", state=None, restorable=False
+                        )
+                    except Exception:  # noqa: BLE001
+                        # Losing the declaration must not crash the program that
+                        # already decided to accept this gap.
+                        pass
+                else:
+                    print(
+                        "[noidroid.auto] refusing to record: the program is about "
+                        "to spawn a child process, which is not captured, so this "
+                        "recording would be incomplete without saying so.\n"
+                        "  Record it anyway with --allow-gaps if you know the rest "
+                        "of the program does not depend on what the child does.",
+                        file=sys.stderr,
+                    )
+                    # os._exit rather than raising: a raised exception reaches the
+                    # program's own call to Popen(), where a bare `except:` around
+                    # it would swallow the refusal and keep going -- exactly the
+                    # silent gap this exists to close. Dying here is unconditional.
+                    sys.stderr.flush()
+                    os._exit(2)
+        return original_init(self, *args, **kwargs)
+
+    _subprocess.Popen.__init__ = guarded_init
 
 
 # ------------------------------------------------------------------ serialisation
@@ -181,4 +321,7 @@ def install(providers: Optional[tuple] = None) -> list[str]:
         # it is not.
         if getattr(base, "AsyncAPIClient", None) is not None:
             _unhooked.append(f"{provider}._base_client.AsyncAPIClient.request")
+    # Independent of which SDKs are present: a program that shells out is a hole no
+    # matter what else it does or does not call.
+    guard_subprocess()
     return hooked()

--- a/crates/noidroid-core/tests/auto_slice.rs
+++ b/crates/noidroid-core/tests/auto_slice.rs
@@ -21,7 +21,8 @@ use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
 use noidroid_core::engine::{self, Mode, RunSpec};
-use noidroid_core::Repo;
+use noidroid_core::model::Action;
+use noidroid_core::{Grip, Repo};
 
 const FAKE_API: &str = r#"
 import json
@@ -335,6 +336,178 @@ fn a_capture_gap_stops_the_recording_unless_it_is_allowed() {
     )
     .expect("replay should run to completion");
     assert!(report.faithful(), "{:?}", report.divergences);
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// A program that shells out, and nothing else out of the ordinary. No SDK needed:
+/// the hole being tested is the child process, not the model call.
+const SHELLS_OUT: &str = r#"
+import subprocess
+import sys
+
+import noidroid
+
+nd = noidroid.connect()
+nd.call("work.start", lambda: {"ok": True})
+subprocess.run([sys.executable, "-c", "pass"], check=True)
+nd.call("work.end", lambda: {"ok": True})
+nd.finish("success", {})
+"#;
+
+fn shelling_agent(dir: &Path) -> PathBuf {
+    let agent = dir.join("shells.py");
+    fs::write(&agent, SHELLS_OUT).unwrap();
+    agent
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "noidroid-{tag}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+/// A subprocess is outside everything this tool does: it is not mediated, the egress
+/// fence never patched its socket module, and no step records what it touched. The
+/// one thing that must not happen is passing silently.
+///
+/// Unlike the async-client hole, this cannot be caught before the program runs --
+/// nothing is known about it until the moment it happens -- so by the time it is
+/// detected, steps before it may already be recorded. The engine's answer to a child
+/// that dies mid-run is not to erase what already happened: it keeps the steps taken,
+/// marks the run `aborted` with the exit code, and the refusal is what the program's
+/// own last words say. This is the same handling `record` gives any program that dies
+/// unexpectedly, exercised here for a death this project causes on purpose.
+#[test]
+fn a_program_that_shells_out_is_refused_rather_than_half_recorded() {
+    if sdk_available() {
+        // Inverted relative to this file's other gate: `install()` patches every
+        // SDK it finds installed, whether or not the program under test imports it,
+        // so an environment with anthropic present always hits the async-client
+        // hole (#33) before the shelling agent's own `import subprocess` line ever
+        // runs, and refuses for that unrelated reason first. Isolating the claim
+        // this test makes needs an environment with no SDK gap to confound it.
+        eprintln!(
+            "SKIP: needs an environment with no capturable SDK installed, so #33's \
+             async-client refusal does not mask the one under test here"
+        );
+        return;
+    }
+
+    let dir = scratch("spawn-refused");
+    let agent = shelling_agent(&dir);
+    let repo = Repo::open(&dir).unwrap();
+    let pythonpath = format!("{}:{}", bootstrap_path().display(), client_path().display());
+
+    let spec = RunSpec {
+        command: vec!["python3".into(), agent.display().to_string()],
+        launch_dir: dir.clone(),
+        name: Some("blocked".into()),
+        env: vec![("PYTHONPATH".into(), pythonpath)],
+        auto: true,
+        watch: None,
+    };
+
+    let report = engine::run(&repo, &spec, Mode::Record, None)
+        .expect("the engine completes even though the program aborted");
+    let said = report
+        .last_words
+        .as_deref()
+        .expect("a program that died should have last words");
+    assert!(
+        said.contains("subprocess") && said.contains("--allow-gaps"),
+        "the refusal must name the hole and the way past it, got: {said}"
+    );
+    assert_eq!(
+        report.exit_code,
+        Some(2),
+        "the program's own refusal exit code should reach the report"
+    );
+
+    let trajectory = repo
+        .load_trajectory("blocked")
+        .expect("what was recorded before the refusal is still worth keeping");
+    assert_eq!(
+        trajectory.outcome.status, "aborted",
+        "a program that died mid-run is not a program that finished"
+    );
+    let chain = repo.chain(&trajectory).unwrap();
+    assert!(
+        chain
+            .iter()
+            .all(|(_, s)| !matches!(s.action, Action::Finish { .. })),
+        "the recording must stop before the subprocess call, not after a finish that \
+         never happened"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// Allowed, it records — and the recording itself says the program shelled out and
+/// that whatever the child did is outside it. Said in the trajectory, not only in a
+/// log line: `subprocess` is a declared world nobody observed, so every step from
+/// there on is `opaque` and `noidroid log` and `show` print it.
+#[test]
+fn a_program_that_can_shell_out_says_so_in_its_recording() {
+    let dir = scratch("spawn-declared");
+    let agent = shelling_agent(&dir);
+    let repo = Repo::open(&dir).unwrap();
+    let pythonpath = format!("{}:{}", bootstrap_path().display(), client_path().display());
+
+    let spec = RunSpec {
+        command: vec!["python3".into(), agent.display().to_string()],
+        launch_dir: dir.clone(),
+        name: Some("gapped".into()),
+        env: vec![
+            ("PYTHONPATH".into(), pythonpath),
+            ("NOIDROID_ALLOW_GAPS".into(), "1".into()),
+        ],
+        auto: true,
+        watch: None,
+    };
+
+    let report = engine::run(&repo, &spec, Mode::Record, None)
+        .expect("--allow-gaps should record a program that shells out");
+    let recorded = report.trajectory.clone().expect("a recording is produced");
+
+    let declared = recorded
+        .worlds
+        .iter()
+        .find(|w| w.name == "subprocess")
+        .expect("the recording must declare the subprocess it could not capture");
+    assert_eq!(
+        declared.grip,
+        Grip::Opaque,
+        "a child process is not observed and not restorable, so it is opaque"
+    );
+    assert_eq!(
+        report.grip,
+        Grip::Opaque,
+        "the run can claim no more than its weakest part"
+    );
+
+    // The claim is about what the *recording* says, so it has to survive a reload
+    // rather than only live in the report we happen to be holding.
+    let reloaded = repo.load_trajectory("gapped").unwrap();
+    assert!(
+        reloaded.worlds.iter().any(|w| w.name == "subprocess"),
+        "the limitation is part of the trajectory, not of one process's memory"
+    );
+
+    // And the steps after the spawn carry it, so `show` on any of them says opaque
+    // rather than claiming a workspace snapshot is the whole world.
+    let chain = repo.chain(&reloaded).unwrap();
+    assert!(
+        chain.iter().any(|(_, s)| s.grip == Grip::Opaque),
+        "the steps taken after the spawn must say what they are worth"
+    );
 
     let _ = fs::remove_dir_all(&dir);
 }


### PR DESCRIPTION
A child process does not inherit the bootstrap's patch: its network calls are not fenced, its file writes are not recorded, none of it is mediated. Nothing said so. `--auto` now treats it exactly like the async-client hole already is: reported, and refused unless the caller says `--allow-gaps`, in which case the recording declares `subprocess` as an opaque world so every step after it says what it is worth.

## Detection went through two designs before this one

**`sys.addaudithook` on the `import` event** looked right — CPython's documented mechanism for exactly this, immune to how the import is spelled — and doesn't work: `anthropic` (like most SDKs built on `httpx`) imports `subprocess` itself as a transitive dependency before this module ever gets a chance to install the hook. The `import` audit event fires once per module name for the interpreter's life, so that spends the one firing on plumbing that has nothing to do with the program shelling out, and leaves every later `import subprocess` in the program's own code invisible — silently, which is exactly the failure this exists to prevent, now baked into the detector itself.

**Patching `subprocess.Popen.__init__` directly** sidesteps the caching problem but, done naively, over-reports badly: `httpx` shells out to `uname -p` on every real request to build a User-Agent header, so flagging any `Popen` construction refuses (or opaques) every ordinary model call. I found this the hard way — it silently broke an unrelated, previously-passing test (`a_program_with_no_noidroid_code_records_and_replays`) with a `StateMismatch`, because the observation got written into the workspace non-deterministically relative to record vs. replay.

**What ships:** the guard checks the *immediate* caller of `Popen.__init__`, walking past `subprocess.py`'s own convenience wrappers (`run`/`call`/`check_output` all construct a `Popen` internally) but no further, against the standard library and every installed package. `subprocess.run(["git", "diff"])` written in the program has its own frame there; `uname -p` three layers inside `httpx` never does, no matter how deep the library call chain runs. (Walking the *entire* stack doesn't work either — every call chain eventually reaches the program's own entry point, so that's always true and distinguishes nothing.)

## The engine's existing behavior, exercised for a new reason

Detection can only happen once the program is already running — nothing is known about it beforehand, unlike the async-client hole, which `sitecustomize` catches before any of the program's own code executes. So a refusal here may follow steps already recorded. The engine's existing handling for a program that dies mid-run applies unchanged: what happened is kept, marked `aborted`, and the refusal is in the program's last words (`report.last_words`, `noidroid log` calls it `aborted` with the exit code). The test pins this rather than assuming a clean `Err`/no-trajectory outcome, which is what the async-client test gets and what I originally assumed this one would too, incorrectly.

`connect()` in `__init__.py` gained a per-process session cache (`_active_session`): the guard's `--allow-gaps` path calls back into the client to declare the subprocess world, and without this a second, independent `Session` would open a socket the engine isn't listening for and hang. A process gets exactly one connection now, whoever asks for it first.

## Test gating

The refusal-in-isolation test (`a_program_that_shells_out_is_refused_rather_than_half_recorded`) is gated on `!sdk_available()`, inverted from this file's usual convention: `install()` patches every SDK it finds *installed*, regardless of whether the program under test imports it, so any environment with `anthropic` present hits the async-client hole (#33) first and masks the one this test isolates. Verified directly with `PYTHONNOUSERSITE=1` (hides `anthropic` without disabling the `sitecustomize` mechanism the way `python3 -S` would) that the test genuinely runs and passes, not just skips, when that confound is absent.

## Not covered

`os.system()` bypasses `Popen` entirely and isn't caught — noted as a known gap in the README and the docstring, in this project's own idiom of saying what isn't covered rather than rounding up.

Verified: `cargo fmt --all`, `cargo clippy --all-targets -- -D warnings`, `cargo test --all` all clean, rebased onto current `main`. `PYTHONNOUSERSITE=1 cargo test --test auto_slice` run separately to prove the gated test actually exercises its assertions rather than only skipping.

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)