### PR TITLE
docs: state the branch-point boundary for intervention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,11 @@ how the package version relates to `STEP_VERSION`, the on-disk object format.
 
 ### Changed
 
+- **The README and `docs/direction.md` now state the branch-point boundary.**
+  Branching and fault injection answer a `call` or `decide` the program made;
+  `apply_intervention` is reachable only from `on_call`/`on_decide`. An event the
+  program never asked about cannot be injected — that needs preemption, which this
+  project does not have. (#79)
 - **A divergence caused by a clock or a random id now says so.** A timestamp or a UUID
   in a call argument makes every replay diverge, and the report named two long values
   and left the reader to notice that one of them was a clock — then guessed, wrongly,

--- a/README.md
+++ b/README.md
@@ -755,6 +755,11 @@ cannot be vague about its own boundaries.
 - **A branch is not a prediction.** Past the divergence point, `live` calls query a
   world that has moved on. Paranoid Android tells you what happens now from that state — not
   what would have happened then.
+- **Interventions apply only at recorded interaction points.** `--decide`, `--result`,
+  `--fail` and `--inject` all answer a `call` or `decide` the program made. An event it
+  never asked about cannot be injected — that would mean pushing an input into a
+  running program on our schedule instead of its, which needs preemption and this
+  project does not have it.
 - **Browser reconstruction is bounded by the recorded page set.** A branch that
   navigates somewhere the recording never went needs the live network, which is
   refused by default and labelled `live` when allowed. Reaching the site again is not

--- a/docs/direction.md
+++ b/docs/direction.md
@@ -38,6 +38,9 @@ That sounds like a slogan until it starts refusing things. In practice it has me
 - Automatic capture refuses to record around a hole rather than recording through it.
 - A replay that reaches the network is stopped, because a reconstruction that touched
   the world is not a reconstruction.
+- Branching and fault injection apply only at recorded interaction points. An event the
+  program never asked about — something pushed in on our schedule rather than asked for
+  on its — cannot be injected; that needs preemption, and this project does not have it.
 
 The failure mode this project cannot survive is not a crash. It is **a trajectory that
 looks real**. Every silent gap is worse than a loud refusal, and any change that turns


### PR DESCRIPTION
## Summary

- Branching and fault injection (`--decide`, `--result`, `--fail`, `--inject`) apply only at recorded interaction points. `apply_intervention` in `crates/noidroid-core/src/engine.rs` is reachable only from `on_call`/`on_decide` — verified by reading the code, both call sites are the `Phase::Diverging` arms of those two handlers. An event the program never asked about cannot be injected; that needs preemption, which this project does not have.
- One bullet added to README.md's `## Limitations` section (next to the other stated branch/intervention limits) and one to `docs/direction.md`'s "rule that governs everything" list (next to the other examples of not faking a capability we don't have).
- CHANGELOG.md entry under `## [Unreleased]` → `### Changed`.
- No code changes. `cargo fmt --all --check` passes clean, confirming no Rust files were touched.

Antithesis is cited in the issue as evidence the limit is real: they started with a pure input tree, found it insufficient, and added time-indexed injection by interrupt (preemption) to cover what a pure input tree can't express — something this project's architecture cannot do either. Not relitigated here, just named.

## Test plan

- [x] `cargo fmt --all --check` — clean, no Rust files touched
- [x] Read `apply_intervention` and its two call sites in `engine.rs` to confirm the reachability claim
- [ ] Reviewer read of the added prose for tone/placement

Closes #79