### PR TITLE
fix(store): give store's and tree's unit-test tmp() helpers the SEQ counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,16 @@ how the package version relates to `STEP_VERSION`, the on-disk object format.
 
 ### Fixed
 
+- **`Store`'s and `tree`'s own unit-test `tmp()` helpers still named scratch
+  directories from pid and `SystemTime::now()` alone, with no counter.** #44 gave
+  `Store::put`'s scratch name and `watch_slice`'s fixture directory a `SEQ:
+  AtomicU64` counter for exactly this reason: `cargo test` runs a crate's unit tests
+  in parallel threads of one process, and two threads landing on the same clock tick
+  is not exotic. Two neighbours of that fix never got it — `store.rs`'s `tmp()` is
+  untagged and shared by four `#[test]` functions in the same process; `tree.rs`'s
+  three call sites use distinct tags, which happened to keep them apart so far but is
+  the same unguaranteed assumption. Both `tmp()` helpers now carry the same `SEQ`
+  counter `Store::put` already uses. (#80)
 - **The proxy test suite bound fixed ports, so a stale provider could be recorded
   instead of the one under test.** `Provider::start` polled `TcpStream::connect` and
   returned as soon as *something* answered on `8791`-`8794` — never checking that the

--- a/crates/noidroid-core/src/store.rs
+++ b/crates/noidroid-core/src/store.rs
@@ -163,13 +163,15 @@ mod tests {
     use super::*;
 
     fn tmp() -> PathBuf {
+        static SEQ: AtomicU64 = AtomicU64::new(0);
         let p = std::env::temp_dir().join(format!(
-            "noidroid-store-{}-{:?}",
+            "noidroid-store-{}-{:?}-{}",
             std::process::id(),
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap()
-                .as_nanos()
+                .as_nanos(),
+            SEQ.fetch_add(1, Ordering::Relaxed)
         ));
         fs::create_dir_all(&p).unwrap();
         p

--- a/crates/noidroid-core/src/tree.rs
+++ b/crates/noidroid-core/src/tree.rs
@@ -282,15 +282,18 @@ pub fn diff(a: &Tree, b: &Tree) -> Vec<(String, Change)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
 
     fn tmp(tag: &str) -> PathBuf {
+        static SEQ: AtomicU64 = AtomicU64::new(0);
         let p = std::env::temp_dir().join(format!(
-            "noidroid-tree-{tag}-{}-{}",
+            "noidroid-tree-{tag}-{}-{}-{}",
             std::process::id(),
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap()
-                .as_nanos()
+                .as_nanos(),
+            SEQ.fetch_add(1, Ordering::Relaxed)
         ));
         fs::create_dir_all(&p).unwrap();
         p


### PR DESCRIPTION
## Why

#44 gave `Store::put`'s scratch name and `watch_slice`'s fixture directory a
`SEQ: AtomicU64` counter because `cargo test` runs a crate's unit tests in
parallel threads of one process, and two threads landing on the same clock
tick under `SystemTime::now()` is real, not exotic. Two neighbours of that
fix never got it:

- `crates/noidroid-core/src/store.rs`'s test-only `tmp()` is untagged and
  shared by four `#[test]` functions running in the same process.
- `crates/noidroid-core/src/tree.rs`'s test-only `tmp()` uses three distinct
  tags per call site, which has kept it apart so far, but is the same
  unguaranteed assumption — a tag never colliding is not a guarantee.

## What

Both `tmp()` helpers now carry the same `SEQ: AtomicU64` + `fetch_add`
pattern `Store::put` already uses. Mechanical, matches the existing idiom,
no design decision.

## Proof the fix is load-bearing

Before the fix, a standalone reproduction of the old naming scheme (pid +
`SystemTime::now().as_nanos()`, no counter) with 8 threads racing behind a
barrier, run for 2000 rounds, produced a duplicate name in 3/2000 rounds —
confirming the same mechanism #44 fixed elsewhere is real here too, just
rarer because these helpers create a directory rather than write a file
(`fs::create_dir_all` on a colliding name doesn't fail the way `put`'s
rename would, so the collision is silent rather than a hard error — still a
data race between whichever two tests land on the same directory).

## Testing

```
export PATH="$HOME/.cargo/bin:$PATH"
cargo fmt --all
cargo clippy --all-targets -- -D warnings
cargo test --all
```

All green, including the 44 `noidroid-core` lib unit tests (covers both
`store.rs` and `tree.rs` test modules). Chromium isn't present in this
environment; browser tests skip cleanly rather than failing.

Closes #80