### PR TITLE
feat(client): OpenEnv adapter -- state() becomes a declared world

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ how the package version relates to `STEP_VERSION`, the on-disk object format.
 
 ### Added
 
+- **An OpenEnv adapter — `state()` becomes a declared, witnessed world.** OpenEnv
+  (github.com/meta-pytorch/OpenEnv) standardises RL and agentic environments on three
+  methods: `reset()`, `step(action)`, `state()`. `noidroid.openenv.OpenEnvAdapter`
+  wraps any client shaped that way so `step` is mediated as a `write` — an OpenEnv
+  action mutates state that re-driving the recorded actions into a freshly reset
+  environment rebuilds, the same claim the browser adapter makes about a page — and
+  `state()` is reported after every live step, giving any conformant environment
+  `witnessed` grip with zero per-environment work. It re-drives actions the recording
+  served in its place before the first one it really performs, the same fifteen-line
+  obligation `Shift._catch_up` and `Browser._reconstruct` already carry, so a branch's
+  wrapped environment is genuinely caught up rather than cold when it starts making its
+  own choices — a new test, `the_counterfactual_environment_is_re_driven_rather_than_
+  assumed`, fails without it. `openenv` itself is not a dependency: the adapter is
+  duck-typed against the interface, not the package, and its test drives a hand-written
+  stand-in rather than a real environment — `state()`'s stability across real
+  environments from the ecosystem remains unverified and is the kill criterion this
+  adapter was built to test. (#66)
 - **`noidroid doctor` — what a recording would and would not cover, before one is
   made.** Automatic capture fails open by construction: every patching mechanism can
   miss a surface, and a recording that missed one still looks real. `--auto` already

--- a/README.md
+++ b/README.md
@@ -683,6 +683,23 @@ rows = browser.scrape("tr.flight", ["data-id", "data-price"])["data"]
 pick = browser.decide("pick_flight", options=[r["data-id"] for r in rows], choice=rows[0]["data-id"])
 ```
 
+For OpenEnv-shaped environments, `noidroid.openenv.OpenEnvAdapter` wraps a `step`/`state`
+client so every action is mediated and every episode's state is reported without any
+per-environment work — `state()` is part of the standard's three-method baseline:
+
+```python
+from noidroid.openenv import OpenEnvAdapter
+
+env = OpenEnvAdapter(noidroid.connect(), client, env_id="my-env")
+result = env.step(action)
+```
+
+`step` is declared `write`: like a browser page, re-driving the recorded actions into a
+freshly reset environment rebuilds the state it left behind. See
+[`examples/openenv_agent/`](examples/openenv_agent) — driven against a small stand-in,
+since `openenv` is not installed here; `noidroid.openenv`'s module docstring says exactly
+what that leaves unverified.
+
 ---
 
 ## How it works
@@ -818,10 +835,11 @@ because an object's name *is* the hash of its bytes.
 ```
 crates/noidroid-core/   objects, store, workspace trees, the record/replay/branch engine
 crates/noidroid-cli/    the `noidroid` binary, the palette, the viewer, the Stand
-clients/python/         the client (stdlib only) and the browser adapter
+clients/python/         the client (stdlib only), the browser adapter, and the OpenEnv adapter
 examples/reference/     the reference environment: the whole lifecycle in 100 lines
 examples/flight_agent/  the example above
 examples/browser_agent/ the same idea driving real Chromium
+examples/openenv_agent/ the same idea against an OpenEnv-shaped environment
 docs/                   the environment contract, the technical proposal, the direction
 research/               the scout's knowledge base: discoveries, landscape, recommendations
 manifesto.md            the product vision this is built toward

--- a/clients/python/noidroid/openenv.py
+++ b/clients/python/noidroid/openenv.py
@@ -1,0 +1,110 @@
+"""OpenEnv adapter: `state()` becomes a declared, witnessed world.
+
+OpenEnv (github.com/meta-pytorch/OpenEnv) standardises RL and agentic environments on
+three methods: ``reset()``, ``step(action)``, ``state()``. That third method is a
+declared observation point on *every* conformant environment, so wrapping it gives any
+of them `witnessed` grip (docs/environment-model.md §4.2, §5) for free -- this module
+never has to know what a specific environment does inside `step`.
+
+    from noidroid.openenv import OpenEnvAdapter
+
+    nd = noidroid.connect()
+    client = SomeEnvClient(...)   # reset() already called
+    env = OpenEnvAdapter(nd, client, env_id="my-env")
+    result = env.step(action)
+
+``client`` is duck-typed against OpenEnv's baseline (``step`` and ``state``) rather than
+imported, so this module has no dependency on the ``openenv`` package -- it works
+unmodified against a real ``EnvClient`` or against a test double. Nothing here fails
+until you hand it an object that does not have the two methods it needs.
+
+**Effect kind: `write`.** An OpenEnv action mutates simulator/environment state, and
+that state is reversible under reconstruction the same way a browser page is: re-driving
+the recorded actions into a freshly reset environment rebuilds it. That is exactly the
+claim `write` makes (see CHANGELOG: "a browser navigation is a `write` because
+re-driving rebuilds the page"), and it is not `read` (actions change the world) or
+`irreversible` (nothing in the standard's baseline leaves a mark a simulator cannot
+un-leave). An environment whose actions really are irreversible -- draining a real
+resource through an OpenEnv shim, say -- is a different, per-environment adapter; this
+generic wrapper cannot know that about an arbitrary conformant environment and does not
+guess.
+
+**Re-driving is this adapter's job, not the engine's** (§7.1). During reconstruction the
+engine serves `step` calls from the recording without touching the wrapped client, so
+when a branch crosses the divergence point the client's own accumulated state is still
+sitting wherever it started. Before the first `step` this process really performs, the
+adapter re-performs every action the recording served in place of it, and marks the
+result `Ungrounded` if that does not land where the recording says it should -- about
+fifteen lines, the same shape as `Shift._catch_up` in `examples/reference/agent.py` and
+`Browser._reconstruct`.
+
+**The risk this adapter cannot see past.** OpenEnv's `state()` is specified as "current
+episode state and metadata" with no content or stability contract. An environment that
+folds in a timestamp or a request id makes every reconstruction diverge -- accurate and
+useless, exactly as `Session.observe`'s docstring warns. That is a property of the
+environment being wrapped, and there is no way to detect it generically from here; it
+was checked by hand against the fake client this module ships a test against, not
+against real environments from the ecosystem (`openenv` is not installed in this
+sandbox) -- see the PR for what that leaves open.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from . import WRITE, Session, Ungrounded
+
+__all__ = ["OpenEnvAdapter"]
+
+
+class OpenEnvAdapter:
+    """Wraps an OpenEnv-shaped client so every `step` is mediated and witnessed."""
+
+    def __init__(self, session: Session, client: Any, env_id: str) -> None:
+        if not hasattr(client, "step") or not hasattr(client, "state"):
+            raise TypeError(
+                "client must implement OpenEnv's baseline: step(action) and state()"
+            )
+        self._nd = session
+        self._client = client
+        self._target = f"openenv.{env_id}.step"
+        self._of = f"openenv:{env_id}"
+        # Actions the engine served from the recording instead of letting this process
+        # perform: owed to the client before the next genuinely live step, so its
+        # accumulated state matches what that step assumes.
+        self._owed: list = []
+        self._grounded = True
+
+    def step(self, action: Any) -> Any:
+        """Mediate one `step` and, when it really runs, report the resulting state."""
+        performed = []
+
+        def run():
+            performed.append(True)
+            return self._live(action)
+
+        result = self._nd.call(self._target, run, args={"action": action}, effect=WRITE)
+        if not performed:
+            self._owed.append((action, result))
+        return result
+
+    def _live(self, action: Any) -> Any:
+        self._catch_up()
+        result = self._client.step(action)
+        self._nd.observe(self._of, state=self._client.state(), restorable=False)
+        return result if self._grounded else Ungrounded(result)
+
+    def _catch_up(self) -> None:
+        """Re-perform actions the recording served in this process's place, and check
+        that the client lands where the recording says it should.
+
+        This is the whole of what reconstructing a witnessed OpenEnv world means: the
+        engine rebuilt the *program* by serving it recorded steps; it cannot rebuild the
+        client, because nothing here can put an arbitrary environment back. Only
+        re-performing the actions does that, and only comparing the result with the
+        recorded one shows that it worked. See docs/environment-model.md §7.1.
+        """
+        while self._owed:
+            action, recorded = self._owed.pop(0)
+            if self._client.step(action) != recorded:
+                self._grounded = False

--- a/crates/noidroid-core/tests/openenv_slice.rs
+++ b/crates/noidroid-core/tests/openenv_slice.rs
@@ -1,0 +1,226 @@
+//! The OpenEnv adapter, end to end.
+//!
+//! `environment_slice.rs` proves the environment contract against the reference
+//! reactor. This file proves the same contract against `noidroid.openenv.OpenEnvAdapter`
+//! (clients/python/noidroid/openenv.py) and its example, `examples/openenv_agent`,
+//! because a claim about a generic wrapper is only as good as a real program driven
+//! through it.
+//!
+//! `openenv` itself is not installed in this environment (or assumed to be, in CI): the
+//! example wraps a hand-written stand-in, `examples/openenv_agent/env.py::Counter`, that
+//! implements only OpenEnv's documented three-method baseline. `OpenEnvAdapter` never
+//! imports `openenv` and knows nothing about `Counter` beyond that shape, which is the
+//! whole point of wrapping the interface rather than the package.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use noidroid_core::engine::{self, Mode, Report, RunSpec};
+use noidroid_core::env::{Grip, Situation};
+use noidroid_core::model::{Action, EffectKind, Intervention, Trajectory};
+use noidroid_core::{tree, Repo};
+
+fn examples() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../examples/openenv_agent")
+        .canonicalize()
+        .expect("the openenv example is part of the repository")
+}
+
+struct Fixture {
+    dir: PathBuf,
+    repo: Repo,
+}
+
+impl Fixture {
+    fn new(tag: &str) -> Fixture {
+        let dir = std::env::temp_dir().join(format!(
+            "noidroid-openenv-{tag}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        let repo = Repo::open(&dir).unwrap();
+        Fixture { dir, repo }
+    }
+
+    fn spec(&self, name: Option<&str>) -> RunSpec {
+        let client = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../clients/python")
+            .canonicalize()
+            .expect("the python client is part of the repository");
+        RunSpec {
+            command: vec![
+                "python3".into(),
+                examples().join("agent.py").display().to_string(),
+            ],
+            launch_dir: self.dir.clone(),
+            name: name.map(str::to_string),
+            env: vec![("PYTHONPATH".to_string(), client.display().to_string())],
+            auto: false,
+            watch: None,
+        }
+    }
+
+    fn record(&self, name: &str) -> Trajectory {
+        engine::run(&self.repo, &self.spec(Some(name)), Mode::Record, None)
+            .expect("the openenv example records")
+            .trajectory
+            .expect("a recording produces a trajectory")
+    }
+
+    fn replay(&self, t: &Trajectory) -> Report {
+        engine::run(
+            &self.repo,
+            &self.spec(None),
+            Mode::Replay { live: Vec::new() },
+            Some(t),
+        )
+        .expect("replay runs to completion")
+    }
+
+    fn branch(&self, t: &Trajectory, at: u64, label: &str, choice: &str) -> Trajectory {
+        engine::run(
+            &self.repo,
+            &self.spec(Some(label)),
+            Mode::Branch {
+                at,
+                intervention: Intervention::ReplaceDecision {
+                    name: "move".into(),
+                    value: serde_json::json!(choice),
+                },
+                simulate: Default::default(),
+            },
+            Some(t),
+        )
+        .expect("the checkpoint is reachable")
+        .trajectory
+        .expect("a reachable branch produces a trajectory")
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.dir);
+    }
+}
+
+/// The index of the `move` decision at tick `n` (1-based): genesis, then decide/call
+/// per tick.
+fn decision_at(tick: u64) -> u64 {
+    1 + (tick - 1) * 2
+}
+
+#[test]
+fn a_step_is_mediated_as_write_and_state_becomes_a_witnessed_world() {
+    let f = Fixture::new("witnessed");
+    let t = f.record("counter");
+
+    // The whole claim in one line: wrapping `step` gives the environment `witnessed`
+    // grip with nothing written for this specific environment.
+    assert_eq!(
+        t.worlds
+            .iter()
+            .map(|w| (w.name.as_str(), w.grip))
+            .collect::<Vec<_>>(),
+        vec![("openenv:counter", Grip::Witnessed)],
+    );
+
+    let chain = f.repo.chain(&t).unwrap();
+    let first_call = chain
+        .iter()
+        .find(|(_, s)| matches!(&s.action, Action::Call { target, .. } if target == "openenv.counter.step"))
+        .expect("the agent steps the environment")
+        .1
+        .clone();
+
+    // `step(action)` is declared `write`: re-driving the recorded actions into a fresh
+    // client rebuilds it, the same claim the browser adapter makes about a page.
+    match &first_call.action {
+        Action::Call { effect, .. } => assert_eq!(*effect, EffectKind::Write),
+        other => panic!("expected a Call action, got {other:?}"),
+    }
+    assert_eq!(first_call.grip, Grip::Witnessed);
+
+    // The fingerprint is `state()` as it actually was after this step, not a summary
+    // invented by the adapter.
+    let observed = tree::read(&first_call.state_root, &f.repo.store).unwrap();
+    let worlds = Situation::worlds_in(&observed);
+    assert_eq!(worlds.len(), 1);
+    assert_eq!(worlds[0].0, "openenv:counter");
+    let seen: serde_json::Value = f.repo.store.get_json(&worlds[0].1).unwrap();
+    assert_eq!(seen["count"], 1, "one `inc` after the first tick");
+    assert_eq!(seen["ticks"], 1);
+}
+
+#[test]
+fn a_witnessed_openenv_run_replays_to_the_same_objects_without_touching_the_client() {
+    let f = Fixture::new("replay");
+    let t = f.record("counter");
+    let report = f.replay(&t);
+
+    assert!(
+        report.faithful(),
+        "a witnessed run reconstructs exactly: {:?}",
+        report.divergences
+    );
+    assert_eq!(report.reproduced, report.expected);
+    assert_eq!(
+        report.grip,
+        Grip::Witnessed,
+        "the run reports the weakest grip it had, not the best"
+    );
+    assert_eq!(
+        report.delivery.get("executed"),
+        None,
+        "reconstruction executes nothing; step() is never called on the client, and the \
+         recorded observation is served exactly as any other input is"
+    );
+}
+
+#[test]
+fn the_counterfactual_environment_is_re_driven_rather_than_assumed() {
+    // The claim: when a branch crosses the divergence point, the wrapped client's
+    // accumulated state is genuinely caught up to what the recording implies, not sitting
+    // at its initial reset because the replayed prefix never called `step` on it. If the
+    // catch-up in `OpenEnvAdapter._catch_up` were skipped, this branch would still run to
+    // completion, still hash consistently, and still report a clean outcome -- while
+    // silently describing a counter that never saw its first tick.
+    let f = Fixture::new("redrive");
+    let parent = f.record("counter");
+
+    // Recorded run: policy is "dec once count >= 2, else inc". count: 0->1->2->1->2,
+    // done at the fourth tick.
+    assert_eq!(parent.outcome.result["final"], 2);
+    assert_eq!(parent.outcome.result["result"]["done"], true);
+
+    // Branch at tick 2 and force "dec" instead of the recorded "inc". Tick 1 ("inc") was
+    // served from the recording, so it is owed to the client and must be caught up
+    // before this branch's first genuinely live step:
+    //
+    //   caught up (correct): count 0 --catch-up inc--> 1 --dec--> 0 --inc--> 1 --inc--> 2,
+    //                         four real step() calls, so `ticks` reaches 4 and `done` fires.
+    //   cold (bug):           count 0 --dec--> -1 --inc--> 0 --inc--> 1,
+    //                         only three real step() calls, so `done` never fires.
+    //
+    // The two paths land on different final counts and a different `done` flag, so this
+    // test fails if `_catch_up` is ever skipped or short-circuited.
+    let branch = f.branch(&parent, decision_at(2), "redriven", "dec");
+
+    assert_eq!(
+        branch.outcome.result["final"], 2,
+        "reachable only if tick 1's \"inc\" was really replayed against the client"
+    );
+    assert_eq!(
+        branch.outcome.result["result"]["done"], true,
+        "done requires four real step() calls on the client, including the one \
+         catch-up owed it"
+    );
+
+    // The parent is untouched.
+    let reloaded = f.repo.load_trajectory("counter").unwrap();
+    assert_eq!(reloaded, parent);
+}

--- a/examples/openenv_agent/agent.py
+++ b/examples/openenv_agent/agent.py
@@ -1,0 +1,56 @@
+"""OpenEnv adapter example: a four-tick counter, driven entirely through `nd.call`.
+
+    export PYTHONPATH=$PWD/clients/python
+    noidroid run --name counter -- python examples/openenv_agent/agent.py
+    noidroid show counter@4        # evidence: witnessed -- the fingerprint is state()
+    noidroid branch counter@4 --decide move=dec --label saved
+
+`env.py`'s `Counter` stands in for a real OpenEnv `EnvClient` (see its docstring for
+why). Nothing below imports `openenv`, and nothing below reads `client.count` directly
+for control flow: every decision is based on what `env.step()` mediated back, exactly
+as `examples/reference/agent.py` bases its policy on the mediated reactor reading rather
+than the reactor object -- reading the wrapped client directly is control flow the
+recording would not contain.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import noidroid
+from noidroid.openenv import OpenEnvAdapter
+
+from env import Counter
+
+MOVES = ["inc", "dec"]
+
+
+def policy(observed: int) -> str:
+    return "dec" if observed >= 2 else "inc"
+
+
+def main() -> int:
+    nd = noidroid.connect()
+    client = Counter()
+    client.reset()
+    env = OpenEnvAdapter(nd, client, env_id="counter")
+    try:
+        observed = 0
+        result = None
+        for _ in range(4):
+            move = nd.decide("move", options=MOVES, choice=policy(observed))
+            result = env.step(move)
+            observed = result["observation"]
+            if result["done"]:
+                break
+        nd.finish("success", {"final": observed, "result": result})
+        return 0
+    finally:
+        nd.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/openenv_agent/env.py
+++ b/examples/openenv_agent/env.py
@@ -1,0 +1,44 @@
+"""A minimal stand-in for an OpenEnv `EnvClient`.
+
+Real OpenEnv environments are served over HTTP/WebSocket by the `openenv` package's
+`EnvClient`, which is not installed in this repository's environment. This class mimics
+only the three-method baseline the standard specifies -- `reset()`, `step(action)`,
+`state()` -- well enough to drive `noidroid.openenv.OpenEnvAdapter` without it. It is not
+part of the adapter: `OpenEnvAdapter` knows nothing about this class beyond that shape,
+which is the point of the example.
+
+The counter accumulates, so an action's effect depends on every action before it -- the
+same property that makes a browser page or a reactor need re-driving rather than a cold
+restart, and the reason this example exists rather than a stateless one.
+"""
+
+from __future__ import annotations
+
+
+class Counter:
+    def __init__(self) -> None:
+        self.count = 0
+        self.ticks = 0
+
+    def reset(self) -> dict:
+        self.count = 0
+        self.ticks = 0
+        return {"observation": self.count, "reward": 0.0, "done": False}
+
+    def step(self, action: str) -> dict:
+        if action == "inc":
+            self.count += 1
+        elif action == "dec":
+            self.count -= 1
+        else:
+            raise ValueError(f"unknown action {action!r}")
+        self.ticks += 1
+        return {
+            "observation": self.count,
+            "reward": float(self.count),
+            "done": self.ticks >= 4,
+        }
+
+    def state(self) -> dict:
+        """"Current episode state and metadata" -- OpenEnv's own phrase for it."""
+        return {"count": self.count, "ticks": self.ticks}


### PR DESCRIPTION
## What

`clients/python/noidroid/openenv.py` — `OpenEnvAdapter` wraps an OpenEnv-shaped client
(`step(action)`, `state()`) so every `step` is mediated through `nd.call(...)` with
effect `write`, and `state()` is reported via `nd.observe(f"openenv:{env_id}", ...)`
after every step this process genuinely performs. That gives any conformant OpenEnv
environment `witnessed` grip with no per-environment work, per #66.

## Effect kind: `write`

An OpenEnv action mutates simulator/environment state, and — per the standard's own
baseline — that state is reversible under reconstruction the same way a browser page
is: re-driving the recorded actions into a freshly reset environment rebuilds it. That
is exactly `write`'s claim (CHANGELOG: "a browser navigation is a `write` because
re-driving rebuilds the page"). It is not `read` (an action changes the world) and not
`irreversible` — nothing in OpenEnv's documented baseline leaves a mark a simulator
cannot un-leave; an environment whose actions really are irreversible would need its
own, per-environment adapter, which this generic wrapper deliberately does not attempt.

## Re-driving is included, and it's why the diff is bigger than ~50 lines

`docs/environment-model.md` §7.1 makes re-driving a *witnessed* world the adapter's own
obligation, not the engine's, and names it as the difference between a counterfactual
and "a plausible-looking fiction." Both in-tree precedents (`Browser._reconstruct`,
`Shift._catch_up`) implement it in about fifteen lines each. Skipping it here would mean
a branch of an OpenEnv trajectory starts its wrapped client cold — silently, since the
run still completes and still reports `witnessed` — which is precisely the "trajectory
that looks real" failure the project's direction doc names as the one it cannot
survive. So `OpenEnvAdapter._catch_up` re-performs the actions the recording served in
this process's place before the first one it really executes, and marks the result
`Ungrounded` if the client doesn't land where the recording says it should. The adapter
is ~100 lines including its docstring, ~65 without it.

**Proof the catch-up logic isn't dead code:** I disabled the `self._catch_up()` call
locally and reran the new redrive test — it failed exactly as expected (counter landed
on the "cold" value instead of the "caught up" one). Restored before committing.

## What I verified against a real vs. stand-in OpenEnv client

`openenv` is **not installed** in this sandbox (confirmed: `pip show openenv` /
`python3 -c "import openenv"` both fail), consistent with the issue's expectation. So:

- `noidroid/openenv.py` is duck-typed against the client's *shape* (`step`, `state`)
  rather than importing the `openenv` package — it imports cleanly with or without the
  package present, and never needs it at all, since it never assumes more of the
  environment than the three-method baseline the RFC documents.
- The test (`crates/noidroid-core/tests/openenv_slice.rs`) drives a hand-written
  stand-in, `examples/openenv_agent/env.py::Counter`, through the **real engine over the
  real protocol** (spawns a real `python3` child, real Unix socket, real
  record/replay/branch) — the same style as `browser_slice.rs` and
  `environment_slice.rs`. It proves:
  1. `step` is mediated as `EffectKind::Write`, and the trajectory's `worlds` carries
     exactly `[("openenv:counter", Grip::Witnessed)]`.
  2. The world's stored fingerprint is `state()` as it actually was, not an invented
     summary.
  3. The recording replays faithfully with zero calls executed against the client.
  4. A branch that crosses the divergence point re-drives the owed action against the
     client before continuing live (the catch-up test above).
- **What is not verified**: `state()`'s content/stability contract against any real
  OpenEnv environment from the ecosystem (TRL, verl, TorchForge, SkyRL, `verifiers`).
  That's the issue's own kill criterion, and it stays open — the module docstring says
  this plainly, and it's the natural next step (a follow-up research pass) if this
  adapter gets used for real.

## Scope

No general "any RL environment" abstraction: one adapter class, one example, one test
file. `reset()` is not wrapped — the caller resets its own client before handing it to
the adapter, same as the reference environment's `Reactor`.

## Gate

`cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, and
`cargo test --all` all pass. One unrelated flake on the rebased tree
(`noidroid-cli/tests/cost.rs`'s two streaming tests hit "process did not connect within
30s" under this sandbox's concurrent-worktree CPU contention — several other issues'
worktrees were running `cargo build`/`cargo test` at the same time); reran `cargo test
--test cost -p noidroid-cli` alone and all 4 passed. Not touched by this change.

Closes #66